### PR TITLE
fix: fix null date crash, fix useEffect warnings in search and item page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3218,9 +3218,9 @@
       }
     },
     "@viaa/avo2-components": {
-      "version": "1.3.0",
-      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-components/-/avo2-components-1.3.0.tgz",
-      "integrity": "sha512-bmFtVJUDvTsX6kD6PpW3kDyET8NvTiDzXkxbU/I3rahIQWZyRTQvxA5oYZ3GhDHeJB5/zqI9CRRQiK76IL0jcQ==",
+      "version": "1.4.0",
+      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-components/-/avo2-components-1.4.0.tgz",
+      "integrity": "sha512-N11MOwZpR/bjECEyNYKfoowJS/N0modcUaQ595v3NyMIRoMYzwVAp93lcqD8IzVoA3H/1TGvIjkBNKZxRUdX+A==",
       "requires": {
         "@types/classnames": "^2.2.7",
         "@types/marked": "^0.6.5",

--- a/src/item/views/Item.tsx
+++ b/src/item/views/Item.tsx
@@ -75,7 +75,7 @@ const Item: FunctionComponent<ItemProps> = ({
 	 */
 	useEffect(() => {
 		getItem(id);
-	}, [id]);
+	}, [id, getItem]);
 
 	/**
 	 * Update video and query param time when time changes in the state

--- a/src/search/views/Search.tsx
+++ b/src/search/views/Search.tsx
@@ -140,7 +140,7 @@ const Search: FunctionComponent<SearchProps> = ({
 			filterOptions,
 			{}
 		);
-	}, [formState, sortOrder, currentPage, history]);
+	}, [search, formState, sortOrder, currentPage, history]);
 
 	/**
 	 * display the search results on the page and in the url when the results change
@@ -172,7 +172,7 @@ const Search: FunctionComponent<SearchProps> = ({
 			//  Scroll to the first search result
 			window.scrollTo(0, 0);
 		}
-	}, [searchResults]);
+	}, [searchResults, currentPage, formState, history, sortOrder]);
 
 	const getFiltersFromQueryParams = () => {
 		// Check if current url already has a query param set

--- a/src/shared/components/CheckboxDropdown/CheckboxDropdownModal.tsx
+++ b/src/shared/components/CheckboxDropdown/CheckboxDropdownModal.tsx
@@ -124,6 +124,7 @@ export const CheckboxDropdownModal: FunctionComponent<CheckboxDropdownModalProps
 	};
 
 	const renderButton = () => {
+		const selectedTags = getSelectedTags();
 		return (
 			<button
 				className="c-button c-button--secondary"
@@ -131,14 +132,16 @@ export const CheckboxDropdownModal: FunctionComponent<CheckboxDropdownModalProps
 			>
 				<div className="c-button__content">
 					<div className="c-button__label">{label}</div>
-					<div style={{ marginLeft: '6px' }}>
-						<TagList
-							tags={getSelectedTags()}
-							swatches={false}
-							closable={true}
-							onTagClosed={removeFilter}
-						/>
-					</div>
+					{!!selectedTags.length && (
+						<div style={{ marginLeft: '6px' }}>
+							<TagList
+								tags={selectedTags}
+								swatches={false}
+								closable={true}
+								onTagClosed={removeFilter}
+							/>
+						</div>
+					)}
 					<Icon name={isOpen ? 'caret-up' : 'caret-down'} size="small" type="arrows" />
 				</div>
 			</button>

--- a/src/shared/helpers/formatters/date.ts
+++ b/src/shared/helpers/formatters/date.ts
@@ -1,8 +1,8 @@
 /**
  * Converts a date from format 2000-12-31 to 31/12/2000
  */
-export function formatDate(dateString: string = '', separator: string = '/'): string {
-	return dateString
+export function formatDate(dateString: string | null, separator: string = '/'): string {
+	return (dateString || '')
 		.split('-')
 		.reverse()
 		.join(separator);


### PR DESCRIPTION
* client would crash when date is null for a search result.
    * steps to reproduce: search for "archief"
* fix warnings with useEffects not having all of their dependencies defined
* fix filters inside filter button when no filters are selected. empty div causes a little extra width, causes the filter buttons to wrap to 2 lines on desktop

![image](https://user-images.githubusercontent.com/1710840/60893003-606fa380-a260-11e9-8d20-551d48bb0122.png)
