### PR TITLE
fix: fix @viaa/types .git folder error by updating to @viaa/types@1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3267,9 +3267,9 @@
       }
     },
     "@viaa/avo2-types": {
-      "version": "1.4.0",
-      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-types/-/avo2-types-1.4.0.tgz",
-      "integrity": "sha512-qREECdjsuZ5rTg0vXL1kkk2w/e34QH4OnheNJdqPZM+GgVw9mmBeZtnIrl9AdmeY413v6CPwIEy4y4aQUrG4ZA=="
+      "version": "1.4.2",
+      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-types/-/avo2-types-1.4.2.tgz",
+      "integrity": "sha512-yVCKWg768eRGQ6CanUQbrI8oVZD/A0j0XFCJxbaJhj9/xYYomI+0KAMi5pwmvrx3U1iaez8jL2nQhSU41cLQug=="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "preinstall": "rm -rf node_modules/@viaa/avo2-types/.git",
     "test": "jest --verbose",
     "lint": "tslint -p .",
     "format": "npm run lint -- --fix"
@@ -13,7 +12,7 @@
   "dependencies": {
     "@types/react-redux": "^6.0.14",
     "@viaa/avo2-components": "^1.6.0",
-    "@viaa/avo2-types": "^1.4.0",
+    "@viaa/avo2-types": "^1.4.2",
     "classnames": "^2.2.6",
     "lodash-es": "^4.17.11",
     "marked": "^0.6.3",


### PR DESCRIPTION
This should allow you to do npm i without the need to delete the old typings first