### PR TITLE
fix: show item deleted instead of not found if item was soft deleted

### DIFF
--- a/src/404/views/NotFound.tsx
+++ b/src/404/views/NotFound.tsx
@@ -3,15 +3,17 @@ import React, { FunctionComponent } from 'react';
 
 interface NotFoundProps {
 	message?: string;
+	icon?: string;
 }
 
 export const NotFound: FunctionComponent<NotFoundProps> = ({
 	message = 'De pagina werd niet gevonden',
+	icon = 'search',
 }) => {
 	return (
 		<Container mode="vertical" background="alt" className="o-container-vertical-title">
 			<Container size="medium" mode="horizontal">
-				<Blankslate body="" icon="search" title={message} />
+				<Blankslate body="" icon={icon} title={message} />
 			</Container>
 		</Container>
 	);

--- a/src/item/views/Item.tsx
+++ b/src/item/views/Item.tsx
@@ -48,6 +48,7 @@ import { parseDuration } from '../../shared/helpers/parsers/duration';
 import './Item.scss';
 import { AddFragmentToCollection } from './modals/AddFragmentToCollection';
 
+import NotFound from '../../404/views/NotFound';
 import { GET_ITEM_BY_ID } from '../item.gql';
 
 interface ItemProps extends RouteComponentProps {}

--- a/src/shared/components/DataComponent/DataQueryComponent.tsx
+++ b/src/shared/components/DataComponent/DataQueryComponent.tsx
@@ -34,7 +34,18 @@ export const DataQueryComponent: FunctionComponent<DataQueryComponentProps> = ({
 				}
 
 				if (result.error) {
-					return <span>Error: {result.error.message}</span>;
+					const firstGraphQlError = get(result, 'error.graphQLErrors[0].message');
+					if (firstGraphQlError === 'DELETED') {
+						// TODO show different message if a list of items was returned but only some were deleted
+						return <NotFound message="Dit item is verwijderd" icon="delete" />;
+					}
+					if (firstGraphQlError === 'ORPHANED') {
+						return <NotFound message="Dit item is een wees" icon="user-x" />; // TODO improve error message
+					}
+					console.error(result.error);
+					return (
+						<NotFound message={'Er ging iets mis tijdens het ophalen'} icon="alert-triangle" />
+					);
 				}
 
 				const data = get(result, resultPath ? `data.${resultPath}` : 'data');


### PR DESCRIPTION
closes: https://district01.atlassian.net/browse/AVO2-93

Should be merged after: https://github.com/viaacode/avo2-proxy/pull/25

![image](https://user-images.githubusercontent.com/1710840/64162000-db0f0680-ce3e-11e9-8854-2a013c980a46.png)

Je kan dit testen door in de server de response aan te passen naar lege array, of de proxy af te zetten voor een error of door altijd DELETED terug te geven
https://github.com/viaacode/avo2-proxy/pull/25/files#diff-b73a9dfcd930b3525610630d3926caebR20
