### PR TITLE
fix: fragments with external_id === -1 are text blocks

### DIFF
--- a/src/collection/components/CollectionFragment.tsx
+++ b/src/collection/components/CollectionFragment.tsx
@@ -29,6 +29,7 @@ import ControlledDropdown from '../../shared/components/ControlledDropdown/Contr
 import { DataQueryComponent } from '../../shared/components/DataComponent/DataQueryComponent';
 import toastService, { TOAST_TYPE } from '../../shared/services/toast-service';
 import { GET_ITEM_META_BY_EXTERNAL_ID } from '../graphql';
+import { isVideoFragment } from '../helpers';
 import AddFragment from './AddFragment';
 
 interface CollectionFragmentProps extends RouteComponentProps {
@@ -257,7 +258,7 @@ const CollectionFragment: FunctionComponent<CollectionFragmentProps> = ({
 						</Toolbar>
 					</div>
 					<div className="c-card__body">
-						{!!fragment.external_id ? (
+						{isVideoFragment(fragment) ? (
 							<Grid>
 								<Column size="3-6">
 									<Thumbnail category="collection" label="collectie" />
@@ -279,7 +280,7 @@ const CollectionFragment: FunctionComponent<CollectionFragmentProps> = ({
 		);
 	};
 
-	return fragment.external_id ? (
+	return isVideoFragment(fragment) ? (
 		// TODO: Change when relationship between item_meta and collection exists
 		<DataQueryComponent
 			query={GET_ITEM_META_BY_EXTERNAL_ID}

--- a/src/collection/helpers.ts
+++ b/src/collection/helpers.ts
@@ -1,0 +1,3 @@
+export function isVideoFragment(fragmentInfo: { external_id: string | undefined }) {
+	return fragmentInfo.external_id && fragmentInfo.external_id !== '-1';
+}

--- a/src/collection/views/Collection.tsx
+++ b/src/collection/views/Collection.tsx
@@ -50,6 +50,7 @@ import { generateContentLinkString } from '../../shared/helpers/generateLink';
 import toastService, { TOAST_TYPE } from '../../shared/services/toast-service';
 import { DeleteCollectionModal } from '../components';
 import { DELETE_COLLECTION, GET_COLLECTION_BY_ID } from '../graphql';
+import { isVideoFragment } from '../helpers';
 import { ContentBlockInfo, ContentBlockType, ContentTypeString } from '../types';
 
 interface CollectionProps extends RouteComponentProps {}
@@ -134,7 +135,7 @@ const Collection: FunctionComponent<CollectionProps> = ({ match, history }) => {
 
 			fragments.forEach((collectionFragment: Avo.Collection.Fragment) => {
 				contentBlockInfos.push({
-					blockType: collectionFragment.external_id
+					blockType: isVideoFragment(collectionFragment)
 						? ContentBlockType.VideoTitleTextButton
 						: ContentBlockType.RichText,
 					content: {

--- a/src/collection/views/EditCollectionMetadata.tsx
+++ b/src/collection/views/EditCollectionMetadata.tsx
@@ -28,6 +28,7 @@ import { TagInfo } from '@viaa/avo2-components/dist/components/TagsInput/TagsInp
 import { DataQueryComponent } from '../../shared/components/DataComponent/DataQueryComponent';
 import toastService, { TOAST_TYPE } from '../../shared/services/toast-service';
 import { GET_CLASSIFICATIONS_AND_SUBJECTS } from '../graphql';
+import { isVideoFragment } from '../helpers';
 import { getVideoStills, VideoStill } from '../service';
 import { getValidationFeedbackForShortDescription } from './EditCollection';
 
@@ -55,7 +56,11 @@ const EditCollectionMetadata: FunctionComponent<EditCollectionMetadataProps> = (
 	const fetchThumbnailImages = async () => {
 		// Only update thumbnails when modal is opened, not when closed
 		try {
-			const externalIds = compact(collection.collection_fragments.map(cf => cf.external_id));
+			const externalIds = compact(
+				collection.collection_fragments.map(fragment =>
+					isVideoFragment(fragment) ? fragment.external_id : undefined
+				)
+			);
 			const videoStills: VideoStill[] = await getVideoStills(externalIds, 20);
 			setVideoStills(
 				uniq([


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1710840/65144032-b27a3580-da16-11e9-9e6c-3efc56dbd507.png)
