### PR TITLE
fix(navigation): fix active navigation item color

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,7 @@ const App: FunctionComponent<AppProps & RouteComponentProps> = ({ history, login
 					{ label: 'Ontdek', location: `/${RouteParts.Discover}` },
 					{
 						label: 'Mijn Werkruimte',
-						location: `/${RouteParts.MyWorkspace}/${RouteParts.Collections}`,
+						location: `/${RouteParts.MyWorkspace}`,
 						icon: 'briefcase',
 					},
 					{ label: 'Projecten', location: `/${RouteParts.Projects}` },

--- a/src/my-workspace/routes.tsx
+++ b/src/my-workspace/routes.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import SecuredRoute from '../authentication/components/SecuredRoute';
 import { RouteParts } from '../constants';
 import MyWorkspace from './views/MyWorkspace';
 
 export const renderMyWorkspaceRoutes = () => (
-	<SecuredRoute component={MyWorkspace} path={`/${RouteParts.MyWorkspace}/:tabId`} exact={true} />
+	<Fragment>
+		<SecuredRoute component={MyWorkspace} path={`/${RouteParts.MyWorkspace}`} exact={true} />
+		<SecuredRoute component={MyWorkspace} path={`/${RouteParts.MyWorkspace}/:tabId`} exact={true} />
+	</Fragment>
 );

--- a/src/shared/components/Navigation/Navigation.scss
+++ b/src/shared/components/Navigation/Navigation.scss
@@ -1,0 +1,61 @@
+.c-nav ul {
+	margin: 0;
+	padding: 0;
+}
+
+.c-nav li {
+	display: inline-block;
+	margin-right: 0.4rem;
+}
+
+.c-nav__item {
+	display: block;
+	padding: 0.8rem 1.6rem;
+	color: #385265;
+	text-decoration: none;
+	border-radius: 0.3rem;
+}
+
+.c-nav__item:hover, .c-nav__item:focus {
+	background: #EDEFF2;
+	color: #2B414F;
+}
+
+.c-nav__item--i {
+	color: #FFF;
+}
+
+.c-nav__item--i:hover, .c-nav__item--i:focus {
+	background: #436580;
+	color: #FFF;
+}
+
+.c-nav__item--active {
+	background: #EDEFF2;
+	color: #2B414F;
+}
+
+.c-nav__item--active:hover, .c-nav__item--active:focus {
+	background: #D6DEE3;
+}
+
+.c-nav__item--i.c-nav__item--active {
+	background: #283d4e;
+	color: #FFF;
+}
+
+.c-nav__item--i.c-nav__item--active:hover, .c-nav__item--i.c-nav__item--active:focus {
+	background: #05080b;
+}
+
+.c-nav.c-nav .o-svg-icon {
+	width: 1.8rem;
+	height: 1.8rem;
+	position: relative;
+	bottom: 0.2rem;
+	margin-right: 0.75rem;
+}
+
+.c-nav.c-nav .o-svg-icon * {
+	fill: #557891;
+}

--- a/src/shared/components/Navigation/Navigation.tsx
+++ b/src/shared/components/Navigation/Navigation.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 
 import {
 	Button,
@@ -11,6 +11,8 @@ import {
 	ToolbarLeft,
 	ToolbarRight,
 } from '@viaa/avo2-components';
+
+import './Navigation.scss';
 
 type NavigationItem = {
 	label: string;
@@ -44,7 +46,7 @@ export const Navigation: FunctionComponent<NavigationProps> = ({
 											<img
 												className="c-brand__image"
 												src="/images/avo-logo-i.svg"
-												alt="Archief voor Onderwijs"
+												alt="Archief voor Onderwijs logo"
 											/>
 										</Link>
 									</h1>
@@ -53,14 +55,17 @@ export const Navigation: FunctionComponent<NavigationProps> = ({
 									<div className="u-mq-switch-main-nav-has-space">
 										<ul className="c-nav">
 											{primaryItems.map(item => (
-												<li
-													className="c-nav__item c-nav__item--i"
-													key={`${item.location}-${item.label}`}
-												>
-													<Link to={item.location}>
+												<li>
+													<NavLink
+														to={item.location}
+														className="c-nav__item c-nav__item--i"
+														activeClassName="c-nav__item--active"
+														key={`${item.location}-${item.label}`}
+														exact={item.location === '/'}
+													>
 														{item.icon && <Icon name={item.icon} />}
 														{item.label}
-													</Link>
+													</NavLink>
 												</li>
 											))}
 										</ul>
@@ -74,11 +79,16 @@ export const Navigation: FunctionComponent<NavigationProps> = ({
 									<div className="u-mq-switch-main-nav-authentication">
 										<ul className="c-nav">
 											{secondaryItems.map(item => (
-												<li
-													className="c-nav__item c-nav__item--i"
-													key={`${item.location}-${item.label}`}
-												>
-													<Link to={item.location}>{item.label}</Link>
+												<li>
+													<NavLink
+														to={item.location}
+														className="c-nav__item c-nav__item--i"
+														activeClassName="c-nav__item--active"
+														key={`${item.location}-${item.label}`}
+														exact={false}
+													>
+														{item.label}
+													</NavLink>
 												</li>
 											))}
 										</ul>
@@ -104,19 +114,31 @@ export const Navigation: FunctionComponent<NavigationProps> = ({
 					<Container mode="vertical">
 						<ul className="c-nav-mobile">
 							{primaryItems.map(item => (
-								<li className="c-nav-mobile__item" key={`${item.location}-${item.label}`}>
-									<Link to={item.location}>
+								<li>
+									<NavLink
+										to={item.location}
+										className="c-nav-mobile__item"
+										activeClassName="c-nav__item--active"
+										key={`${item.location}-${item.label}`}
+										exact={false}
+									>
 										{item.label}
 										{item.icon && <Icon name={item.icon} />}
-									</Link>
+									</NavLink>
 								</li>
 							))}
 						</ul>
 						<ul className="c-nav-mobile">
 							{secondaryItems.map(item => (
-								<li className="c-nav-mobile__item" key={`${item.location}-${item.label}`}>
-									<Link to={item.location}>{item.label}</Link>
-								</li>
+								<NavLink
+									to={item.location}
+									className="c-nav-mobile__item"
+									activeClassName="c-nav__item--active"
+									key={`${item.location}-${item.label}`}
+									exact={false}
+								>
+									{item.label}
+								</NavLink>
 							))}
 						</ul>
 					</Container>
@@ -129,14 +151,16 @@ export const Navigation: FunctionComponent<NavigationProps> = ({
 								<div className="c-toolbar__item">
 									<ul className="c-nav">
 										{primaryItems.map(item => (
-											<li
-												className="c-nav__item c-nav__item--i"
-												key={`${item.location}-${item.label}`}
-											>
-												<Link to={item.location}>
+											<li>
+												<NavLink
+													to={item.location}
+													activeClassName="c-nav__item--active"
+													className="c-nav__item c-nav__item--i"
+													key={`${item.location}-${item.label}`}
+												>
 													{item.icon && <Icon name={item.icon} />}
 													{item.label}
-												</Link>
+												</NavLink>
 											</li>
 										))}
 									</ul>


### PR DESCRIPTION
current situation:
wrong color for active state:
![image](https://user-images.githubusercontent.com/1710840/65951606-acd21600-e440-11e9-8884-26edc5fb9f13.png)

when going to assignments, the workspace navigation item isn't active:
![image](https://user-images.githubusercontent.com/1710840/65951636-c1161300-e440-11e9-931c-e6e9f37210bb.png)


After this PR both issues are resolved:
![image](https://user-images.githubusercontent.com/1710840/65951654-ca9f7b00-e440-11e9-89b2-da5ea004c9a2.png)

closes: https://district01.atlassian.net/browse/AVO2-635
