### PR TITLE
fix(flowplayer): only set cuepoints if fragment end time is passed

### DIFF
--- a/src/shared/components/FlowPlayer/FlowPlayer.tsx
+++ b/src/shared/components/FlowPlayer/FlowPlayer.tsx
@@ -24,8 +24,8 @@ export const FlowPlayer: FunctionComponent<FlowPlayerProps> = ({
 	poster,
 	title,
 	onInit,
-	start,
-	end,
+	start = 0,
+	end = undefined,
 	subtitles,
 }) => {
 	const videoContainerRef = useRef(null);
@@ -76,7 +76,7 @@ export const FlowPlayer: FunctionComponent<FlowPlayerProps> = ({
 				plugins: ['subtitles', 'chromecast', 'cuepoints'],
 
 				// CUEPOINTS
-				cuepoints: [{ start, end }],
+				...(end ? { cuepoints: [{ start, end }] } : {}), // Only set cuepoints if end is passed
 				draw_cuepoints: true,
 			});
 


### PR DESCRIPTION
fixes issue where cuepoints would throw an error when no start, end times are passed.