### PR TITLE
feat(flowplayer): add seektime support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avo2-client",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "scripts": {
     "prestart": "npm run env",

--- a/src/item/components/ItemVideoDescription.tsx
+++ b/src/item/components/ItemVideoDescription.tsx
@@ -1,4 +1,5 @@
 import { debounce } from 'lodash-es';
+import * as queryString from 'querystring';
 import React, {
 	createRef,
 	FunctionComponent,
@@ -10,7 +11,7 @@ import React, {
 import { RouteComponentProps, withRouter } from 'react-router';
 import { Scrollbar } from 'react-scrollbars-custom';
 
-import { Column, convertToHtml, ExpandableContainer, Grid } from '@viaa/avo2-components';
+import { Button, Column, convertToHtml, ExpandableContainer, Grid } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
 import { FlowPlayer } from '../../shared/components/FlowPlayer/FlowPlayer';
@@ -28,7 +29,10 @@ interface ItemVideoDescriptionProps extends RouteComponentProps {
 
 const DEFAULT_VIDEO_HEIGHT = 421;
 
-const ItemVideoDescription: FunctionComponent<ItemVideoDescriptionProps> = ({ itemMetaData }) => {
+const ItemVideoDescription: FunctionComponent<ItemVideoDescriptionProps> = ({
+	itemMetaData,
+	location,
+}) => {
 	const videoRef: RefObject<HTMLVideoElement> = createRef();
 
 	const [playerTicket, setPlayerTicket] = useState<string>();
@@ -36,6 +40,8 @@ const ItemVideoDescription: FunctionComponent<ItemVideoDescriptionProps> = ({ it
 	const [videoHeight, setVideoHeight] = useState<number>(DEFAULT_VIDEO_HEIGHT); // correct height for desktop screens
 
 	useEffect(() => {
+		getSeekerTimeFromQueryParams();
+
 		// Register window listener when the component mounts
 		const onResizeHandler = debounce(
 			() => {
@@ -61,11 +67,10 @@ const ItemVideoDescription: FunctionComponent<ItemVideoDescriptionProps> = ({ it
 	 * Set video current time from the query params once the video has loaded its meta data
 	 * If this happens sooner, the time will be ignored by the video player
 	 */
-	// TODO trigger this function when flowplayer is loaded
-	// const getSeekerTimeFromQueryParams = () => {
-	// 	const queryParams = queryString.parse(location.search);
-	// 	setTime(parseInt((queryParams.time as string) || '0', 10));
-	// };
+	const getSeekerTimeFromQueryParams = () => {
+		const queryParams = queryString.parse(location.search);
+		setTime(parseInt((queryParams.time as string) || '0', 10));
+	};
 
 	const handleTimeLinkClicked = async (timestamp: string) => {
 		const seconds = parseDuration(timestamp);
@@ -85,13 +90,14 @@ const ItemVideoDescription: FunctionComponent<ItemVideoDescriptionProps> = ({ it
 
 			if (timestampRegex.test(part)) {
 				return (
-					<a
+					<Button
+						type="link"
 						key={`description-link-${index}`}
 						className="u-clickable"
 						onClick={() => handleTimeLinkClicked(part)}
 					>
 						{part}
-					</a>
+					</Button>
 				);
 			}
 
@@ -115,6 +121,7 @@ const ItemVideoDescription: FunctionComponent<ItemVideoDescriptionProps> = ({ it
 					{itemMetaData.thumbnail_path && ( // TODO: Replace publisher, published_at by real publisher
 						<FlowPlayer
 							src={playerTicket ? playerTicket.toString() : null}
+							seekTime={time}
 							poster={itemMetaData.thumbnail_path}
 							title={itemMetaData.title}
 							onInit={initFlowPlayer}

--- a/src/shared/components/FlowPlayer/FlowPlayer.tsx
+++ b/src/shared/components/FlowPlayer/FlowPlayer.tsx
@@ -39,7 +39,6 @@ export const FlowPlayer: FunctionComponent<FlowPlayerProps> = ({
 			setLastSeekTime(seekTime);
 			// seekTime should be updated
 			if (videoPlayerRef.current) {
-				console.log('seekTime updated', seekTime);
 				videoPlayerRef.current.currentTime = seekTime;
 			}
 		}

--- a/src/shared/components/FlowPlayer/FlowPlayer.tsx
+++ b/src/shared/components/FlowPlayer/FlowPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, MutableRefObject, useEffect, useRef } from 'react';
+import React, { FunctionComponent, MutableRefObject, useEffect, useRef, useState } from 'react';
 
 import { Icon } from '@viaa/avo2-components';
 
@@ -16,6 +16,7 @@ interface FlowPlayerProps {
 	subtitles: string[];
 	start?: number | null;
 	end?: number | null;
+	seekTime?: number;
 	onInit?: () => void;
 }
 
@@ -26,10 +27,23 @@ export const FlowPlayer: FunctionComponent<FlowPlayerProps> = ({
 	onInit,
 	start = 0,
 	end = undefined,
+	seekTime,
 	subtitles,
 }) => {
 	const videoContainerRef = useRef(null);
 	const videoPlayerRef: MutableRefObject<any | undefined> = useRef<any>();
+	const [lastSeekTime, setLastSeekTime] = useState<number | undefined>(undefined);
+
+	useEffect(() => {
+		if (typeof seekTime !== 'undefined' && seekTime !== lastSeekTime && seekTime !== 0) {
+			setLastSeekTime(seekTime);
+			// seekTime should be updated
+			if (videoPlayerRef.current) {
+				console.log('seekTime updated', seekTime);
+				videoPlayerRef.current.currentTime = seekTime;
+			}
+		}
+	}, [seekTime]);
 
 	const createTitleOverlay = () => {
 		const titleOverlay = document.createElement('div');


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1710840/66732761-6c6d9180-ee5d-11e9-812c-74e8bfcac4c7.png)

Allows the user to jump to a video timestamp by clicking the timestamp in the video description after the video is initialized.

Good test url with timestamps: http://localhost:8080/item/8911n96442