### PR TITLE
fix(collection-edit-meta): show one audio thumbnail for select cover

### DIFF
--- a/src/collection/components/FragmentDetail.tsx
+++ b/src/collection/components/FragmentDetail.tsx
@@ -30,7 +30,7 @@ import { orderBy } from 'lodash-es';
 import { generateContentLinkString } from '../../shared/helpers/generateLink';
 import { fetchPlayerTicket } from '../../shared/services/player-ticket-service';
 import toastService, { TOAST_TYPE } from '../../shared/services/toast-service';
-import { isVideoFragment } from '../helpers';
+import { isMediaFragment } from '../helpers';
 import { ContentBlockInfo, ContentBlockType, ContentTypeString } from '../types';
 
 interface FragmentDetailProps {
@@ -63,7 +63,7 @@ const FragmentDetail: FunctionComponent<FragmentDetailProps> = ({ collectionFrag
 					.then(data => setPlayerTicket(data))
 					.catch(() => toastService('Play ticket kon niet opgehaald worden.', TOAST_TYPE.DANGER));
 
-			if (isVideoFragment(fragment)) {
+			if (isMediaFragment(fragment)) {
 				initFlowPlayer();
 			}
 
@@ -91,7 +91,7 @@ const FragmentDetail: FunctionComponent<FragmentDetailProps> = ({ collectionFrag
 				},
 			};
 
-			const currentContentBlock = isVideoFragment(fragment)
+			const currentContentBlock = isMediaFragment(fragment)
 				? contentBlocks.videoTitleText
 				: contentBlocks.titleText;
 

--- a/src/collection/components/FragmentEdit.tsx
+++ b/src/collection/components/FragmentEdit.tsx
@@ -28,7 +28,7 @@ import { FlowPlayer } from '../../shared/components/FlowPlayer/FlowPlayer';
 import { fetchPlayerTicket } from '../../shared/services/player-ticket-service';
 import toastService, { TOAST_TYPE } from '../../shared/services/toast-service';
 import { IconName } from '../../shared/types/types';
-import { isVideoFragment } from '../helpers';
+import { isMediaFragment } from '../helpers';
 import FragmentAdd from './FragmentAdd';
 import CutFragmentModal from './modals/CutFragmentModal';
 
@@ -86,7 +86,7 @@ const FragmentEdit: FunctionComponent<FragmentEditProps> = ({
 		itemMetaData: Avo.Item.Item,
 		index: number
 	) => {
-		const disableVideoFields: boolean = !useCustomFields && !!isVideoFragment(fragment);
+		const disableVideoFields: boolean = !useCustomFields && !!isMediaFragment(fragment);
 
 		const onChangeTitle = (value: string) =>
 			updateFragmentProperty(value, 'custom_title', fragment.id);
@@ -268,7 +268,7 @@ const FragmentEdit: FunctionComponent<FragmentEditProps> = ({
 					</Toolbar>
 				</div>
 				<div className="c-panel__body">
-					{isVideoFragment(fragment) ? ( // TODO: Replace publisher, published_at by real publisher
+					{isMediaFragment(fragment) ? ( // TODO: Replace publisher, published_at by real publisher
 						<Grid>
 							<Column size="3-6">
 								<FlowPlayer

--- a/src/collection/graphql.ts
+++ b/src/collection/graphql.ts
@@ -21,6 +21,10 @@ export const GET_COLLECTION_BY_ID = gql`
 					title
 					description
 					thumbnail_path
+					type {
+						id
+						label
+					}
 				}
 				end_oc
 				custom_title

--- a/src/collection/helpers.ts
+++ b/src/collection/helpers.ts
@@ -1,4 +1,4 @@
-export const isVideoFragment = (fragmentInfo: { external_id: string | undefined }) => {
+export const isMediaFragment = (fragmentInfo: { external_id: string | undefined }) => {
 	return fragmentInfo.external_id && fragmentInfo.external_id !== '-1';
 };
 


### PR DESCRIPTION
closes: https://district01.atlassian.net/browse/AVO2-663

You can use this collection to test: http://localhost:8080/collectie/29/bewerk

![image](https://user-images.githubusercontent.com/1710840/66579101-916fb500-eb7c-11e9-98a4-1e871f0a9f07.png)
