### PR TITLE
fix(apollo-cache): clear cache after graphql mutations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "avo2-client",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/assignment/services.ts
+++ b/src/assignment/services.ts
@@ -1,8 +1,8 @@
 import { ExecutionResult } from '@apollo/react-common';
 import { cloneDeep, get } from 'lodash-es';
+import { ApolloCacheManager } from '../shared/services/data-service';
 import toastService, { TOAST_TYPE } from '../shared/services/toast-service';
 import { Assignment, AssignmentLayout } from './types';
-import { ApolloCacheManager } from '../shared/services/data-service';
 
 /**
  * Helper functions for inserting, updating, validating and deleting assigment

--- a/src/assignment/services.ts
+++ b/src/assignment/services.ts
@@ -2,6 +2,7 @@ import { ExecutionResult } from '@apollo/react-common';
 import { cloneDeep, get } from 'lodash-es';
 import toastService, { TOAST_TYPE } from '../shared/services/toast-service';
 import { Assignment, AssignmentLayout } from './types';
+import { ApolloCacheManager } from '../shared/services/data-service';
 
 /**
  * Helper functions for inserting, updating, validating and deleting assigment
@@ -47,6 +48,7 @@ export const deleteAssignment = async (triggerAssignmentDelete: any, id: number 
 	try {
 		await triggerAssignmentDelete({
 			variables: { id },
+			update: ApolloCacheManager.clearAssignmentCache,
 		});
 	} catch (err) {
 		console.error(err);
@@ -71,6 +73,7 @@ export const updateAssignment = async (
 				id: assignment.id,
 				assignment: assignmentToSave,
 			},
+			update: ApolloCacheManager.clearAssignmentCache,
 		});
 
 		if (!response || !response.data) {
@@ -101,6 +104,7 @@ export const insertAssignment = async (
 			variables: {
 				assignment: assignmentToSave,
 			},
+			update: ApolloCacheManager.clearAssignmentCache,
 		});
 
 		const id = get(response, 'data.insert_app_assignments.returning[0].id');

--- a/src/assignment/views/AssignmentDetail.tsx
+++ b/src/assignment/views/AssignmentDetail.tsx
@@ -39,7 +39,7 @@ import { renderAvatar } from '../../collection/helpers';
 import { RouteParts } from '../../constants';
 import ItemVideoDescription from '../../item/components/ItemVideoDescription';
 import LoadingErrorLoadedComponent from '../../shared/components/DataComponent/LoadingErrorLoadedComponent';
-import { dataService } from '../../shared/services/data-service';
+import { ApolloCacheManager, dataService } from '../../shared/services/data-service';
 import toastService, { TOAST_TYPE } from '../../shared/services/toast-service';
 import { IconName } from '../../shared/types/types';
 import {
@@ -132,6 +132,7 @@ const AssignmentDetail: FunctionComponent<AssignmentProps> = ({ match, loginStat
 						variables: {
 							assignmentResponses: [assignmentResponse],
 						},
+						update: ApolloCacheManager.clearAssignmentCache,
 					});
 					const assignmentResponseId = get(
 						reply,
@@ -261,6 +262,7 @@ const AssignmentDetail: FunctionComponent<AssignmentProps> = ({ match, loginStat
 						id: assignmentResponse.id,
 						assignmentResponse: updatedAssignmentResponse,
 					},
+					update: ApolloCacheManager.clearAssignmentCache,
 				})
 					.then(() => {
 						toastService(

--- a/src/collection/components/modals/ShareCollectionModal.tsx
+++ b/src/collection/components/modals/ShareCollectionModal.tsx
@@ -16,10 +16,10 @@ import {
 } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
+import { ApolloCacheManager } from '../../../shared/services/data-service';
 import toastService, { TOAST_TYPE } from '../../../shared/services/toast-service';
 import { UPDATE_COLLECTION } from '../../graphql';
 import { getValidationErrorsForPublish } from '../../helpers/validation';
-import { ApolloCacheManager } from '../../../shared/services/data-service';
 
 interface ShareCollectionModalProps {
 	isOpen: boolean;

--- a/src/collection/components/modals/ShareCollectionModal.tsx
+++ b/src/collection/components/modals/ShareCollectionModal.tsx
@@ -19,6 +19,7 @@ import { Avo } from '@viaa/avo2-types';
 import toastService, { TOAST_TYPE } from '../../../shared/services/toast-service';
 import { UPDATE_COLLECTION } from '../../graphql';
 import { getValidationErrorsForPublish } from '../../helpers/validation';
+import { ApolloCacheManager } from '../../../shared/services/data-service';
 
 interface ShareCollectionModalProps {
 	isOpen: boolean;
@@ -76,6 +77,7 @@ const ShareCollectionModal: FunctionComponent<ShareCollectionModalProps> = ({
 					id: collection.id,
 					collection: newCollection,
 				},
+				update: ApolloCacheManager.clearCollectionCache,
 			});
 			setValidationError(undefined);
 			toastService(

--- a/src/collection/views/CollectionDetail.tsx
+++ b/src/collection/views/CollectionDetail.tsx
@@ -38,15 +38,15 @@ import {
 	generateContentLinkString,
 	generateSearchLinks,
 } from '../../shared/helpers/generateLink';
+import { ApolloCacheManager } from '../../shared/services/data-service';
 import toastService, { TOAST_TYPE } from '../../shared/services/toast-service';
 import { IconName } from '../../shared/types/types';
 import FragmentDetail from '../components/FragmentDetail';
 import { DELETE_COLLECTION, GET_COLLECTION_BY_ID } from '../graphql';
+import { renderAvatar } from '../helpers';
 import { ContentTypeString } from '../types';
 
 import './CollectionDetail.scss';
-import { renderAvatar } from '../helpers';
-import { ApolloCacheManager } from '../../shared/services/data-service';
 
 interface CollectionDetailProps extends RouteComponentProps {}
 

--- a/src/collection/views/CollectionDetail.tsx
+++ b/src/collection/views/CollectionDetail.tsx
@@ -46,6 +46,7 @@ import { ContentTypeString } from '../types';
 
 import './CollectionDetail.scss';
 import { renderAvatar } from '../helpers';
+import { ApolloCacheManager } from '../../shared/services/data-service';
 
 interface CollectionDetailProps extends RouteComponentProps {}
 
@@ -67,6 +68,7 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({ match, his
 				variables: {
 					id: idToDelete,
 				},
+				update: ApolloCacheManager.clearCollectionCache,
 			});
 			setIdToDelete(null);
 			toastService('Het verwijderen van de collectie is gelukt', TOAST_TYPE.SUCCESS);

--- a/src/collection/views/CollectionEdit.tsx
+++ b/src/collection/views/CollectionEdit.tsx
@@ -29,6 +29,7 @@ import ControlledDropdown from '../../shared/components/ControlledDropdown/Contr
 import { DataQueryComponent } from '../../shared/components/DataComponent/DataQueryComponent';
 import DeleteObjectModal from '../../shared/components/modals/DeleteObjectModal';
 import InputModal from '../../shared/components/modals/InputModal';
+import { ApolloCacheManager } from '../../shared/services/data-service';
 import { getThumbnailForCollection } from '../../shared/services/stills-service';
 import toastService, { TOAST_TYPE } from '../../shared/services/toast-service';
 import { IconName } from '../../shared/types/types';
@@ -136,6 +137,7 @@ const CollectionEdit: FunctionComponent<CollectionEditProps> = props => {
 				variables: {
 					id: currentCollection.id,
 				},
+				update: ApolloCacheManager.clearCollectionCache,
 			});
 
 			// TODO: Refresh data on Collections page.
@@ -198,6 +200,7 @@ const CollectionEdit: FunctionComponent<CollectionEditProps> = props => {
 					id: cleanedCollection.id,
 					collection: cleanedCollection,
 				},
+				update: ApolloCacheManager.clearCollectionCache,
 			});
 		} catch (err) {
 			console.error(err);
@@ -284,6 +287,7 @@ const CollectionEdit: FunctionComponent<CollectionEditProps> = props => {
 				id: currentCollection.id,
 				fragment: fragmentToAdd,
 			},
+			update: ApolloCacheManager.clearCollectionCache,
 		});
 
 		const newFragment = get(response, 'data.insert_app_collection_fragments.returning[0]');
@@ -402,7 +406,12 @@ const CollectionEdit: FunctionComponent<CollectionEditProps> = props => {
 			const deletePromises: Promise<any>[] = [];
 
 			deleteFragmentIds.forEach((id: number) => {
-				deletePromises.push(triggerCollectionFragmentDelete({ variables: { id } }));
+				deletePromises.push(
+					triggerCollectionFragmentDelete({
+						variables: { id },
+						update: ApolloCacheManager.clearCollectionCache,
+					})
+				);
 			});
 
 			// Update fragments
@@ -431,6 +440,7 @@ const CollectionEdit: FunctionComponent<CollectionEditProps> = props => {
 							id,
 							fragment: fragmentToUpdate,
 						},
+						update: ApolloCacheManager.clearCollectionCache,
 					})
 				);
 			});
@@ -471,6 +481,7 @@ const CollectionEdit: FunctionComponent<CollectionEditProps> = props => {
 					id: cleanedCollection.id,
 					collection: cleanedCollection,
 				},
+				update: ApolloCacheManager.clearCollectionCache,
 			});
 			setCurrentCollection(newCollection);
 			setInitialCollection(cloneDeep(newCollection));

--- a/src/collection/views/CollectionOverview.tsx
+++ b/src/collection/views/CollectionOverview.tsx
@@ -23,13 +23,13 @@ import { ITEMS_PER_PAGE } from '../../my-workspace/constants';
 import { DataQueryComponent } from '../../shared/components/DataComponent/DataQueryComponent';
 import DeleteObjectModal from '../../shared/components/modals/DeleteObjectModal';
 import { formatDate, formatTimestamp, fromNow } from '../../shared/helpers/formatters/date';
+import { ApolloCacheManager } from '../../shared/services/data-service';
 import toastService, { TOAST_TYPE } from '../../shared/services/toast-service';
 import { IconName } from '../../shared/types/types';
 import { DELETE_COLLECTION, GET_COLLECTIONS_BY_OWNER } from '../graphql';
 import { getFullName, getInitials } from '../helpers';
 
 import './CollectionOverview.scss';
-import { ApolloCacheManager } from '../../shared/services/data-service';
 
 interface CollectionsProps extends RouteComponentProps {
 	numberOfCollections: number;

--- a/src/collection/views/CollectionOverview.tsx
+++ b/src/collection/views/CollectionOverview.tsx
@@ -29,6 +29,7 @@ import { DELETE_COLLECTION, GET_COLLECTIONS_BY_OWNER } from '../graphql';
 import { getFullName, getInitials } from '../helpers';
 
 import './CollectionOverview.scss';
+import { ApolloCacheManager } from '../../shared/services/data-service';
 
 interface CollectionsProps extends RouteComponentProps {
 	numberOfCollections: number;
@@ -53,6 +54,7 @@ const Collections: FunctionComponent<CollectionsProps> = ({ numberOfCollections,
 				variables: {
 					id: idToDelete,
 				},
+				update: ApolloCacheManager.clearCollectionCache,
 			});
 			toastService('Collectie is verwijderd', TOAST_TYPE.SUCCESS);
 			refetchCollections();

--- a/src/item/components/modals/FragmentAddToCollection.tsx
+++ b/src/item/components/modals/FragmentAddToCollection.tsx
@@ -35,7 +35,7 @@ import { DataQueryComponent } from '../../../shared/components/DataComponent/Dat
 import { FlowPlayer } from '../../../shared/components/FlowPlayer/FlowPlayer';
 import { formatDurationHoursMinutesSeconds } from '../../../shared/helpers/formatters/duration';
 import { toSeconds } from '../../../shared/helpers/parsers/duration';
-import { dataService } from '../../../shared/services/data-service';
+import { ApolloCacheManager, dataService } from '../../../shared/services/data-service';
 import { trackEvents } from '../../../shared/services/event-logging-service';
 import { fetchPlayerTicket } from '../../../shared/services/player-ticket-service';
 import toastService, { TOAST_TYPE } from '../../../shared/services/toast-service';
@@ -106,6 +106,7 @@ export const FragmentAddToCollection: FunctionComponent<FragmentAddToCollectionP
 						collection_id: collection.id,
 					},
 				},
+				update: ApolloCacheManager.clearCollectionCache,
 			});
 			if (!response || response.errors) {
 				console.error(get(response, 'errors'));
@@ -136,6 +137,7 @@ export const FragmentAddToCollection: FunctionComponent<FragmentAddToCollectionP
 				variables: {
 					collection: newCollection,
 				},
+				update: ApolloCacheManager.clearCollectionCache,
 			});
 			const insertedCollection: Partial<Avo.Collection.Collection> = get(
 				response,

--- a/src/shared/services/data-service.ts
+++ b/src/shared/services/data-service.ts
@@ -13,7 +13,7 @@ export class ApolloCacheManager {
 	 * @param cache
 	 */
 	public static clearCollectionCache(cache: { [key: string]: any }) {
-		ApolloCacheManager.deleteCacheFromCache(cache, 'app_collection');
+		ApolloCacheManager.deleteFromCache(cache, 'app_collection');
 	}
 
 	/**
@@ -22,9 +22,9 @@ export class ApolloCacheManager {
 	 * @param cache
 	 */
 	public static clearAssignmentCache = (cache: { [key: string]: any }) =>
-		ApolloCacheManager.deleteCacheFromCache(cache, 'app_assignment');
+		ApolloCacheManager.deleteFromCache(cache, 'app_assignment');
 
-	private static deleteCacheFromCache(cache: { [key: string]: any }, keyPrefix: string) {
+	private static deleteFromCache(cache: { [key: string]: any }, keyPrefix: string) {
 		Object.keys(cache.data.data).forEach(
 			(key: string) => key.match(new RegExp(`^${keyPrefix}`)) && cache.data.delete(key)
 		);

--- a/src/shared/services/data-service.ts
+++ b/src/shared/services/data-service.ts
@@ -5,3 +5,28 @@ export const dataService = new ApolloClient({
 	uri: `${getEnv('PROXY_URL')}/data`,
 	credentials: 'include',
 });
+
+export class ApolloCacheManager {
+	/**
+	 * Clear all collection related data from the cache
+	 * eg: app_collections, app_collection_fragments
+	 * @param cache
+	 */
+	public static clearCollectionCache(cache: { [key: string]: any }) {
+		ApolloCacheManager.deleteCacheFromCache(cache, 'app_collection');
+	}
+
+	/**
+	 * Clears all assignment related items from the cache
+	 * eg: app_assignment
+	 * @param cache
+	 */
+	public static clearAssignmentCache = (cache: { [key: string]: any }) =>
+		ApolloCacheManager.deleteCacheFromCache(cache, 'app_assignment');
+
+	private static deleteCacheFromCache(cache: { [key: string]: any }, keyPrefix: string) {
+		Object.keys(cache.data.data).forEach(
+			(key: string) => key.match(new RegExp(`^${keyPrefix}`)) && cache.data.delete(key)
+		);
+	}
+}

--- a/src/shared/services/event-logging-service.ts
+++ b/src/shared/services/event-logging-service.ts
@@ -74,7 +74,7 @@ export function trackEvents(events: Event[] | Event) {
 			variables: { eventLogEntries },
 		})
 		.then(() => {})
-		.catch(err => {
+		.catch((err: any) => {
 			console.error('Failed to log events to database', { eventLogEntries, innerException: err });
 		});
 }


### PR DESCRIPTION
This solves the issue where you see old data in the client after you did a mutation

Steps to see the issue in the old version:
* search for a video
* click: add to collection
* create a new collection
* add
* search for another video
* add to collection

current result: dropdown list does not contain previously created collection
expected result: dropdown list contains all collections, even the one that was created just before this action