### PR TITLE
fix(edit-collection): AVO2-738 show spinner during save instead of 404

### DIFF
--- a/src/collection/views/CollectionEdit.tsx
+++ b/src/collection/views/CollectionEdit.tsx
@@ -423,7 +423,6 @@ const CollectionEdit: FunctionComponent<CollectionEditProps> = props => {
 				deletePromises.push(
 					triggerCollectionFragmentDelete({
 						variables: { id },
-						update: ApolloCacheManager.clearCollectionCache,
 					})
 				);
 			});
@@ -454,7 +453,6 @@ const CollectionEdit: FunctionComponent<CollectionEditProps> = props => {
 							id,
 							fragment: fragmentToUpdate,
 						},
-						update: ApolloCacheManager.clearCollectionCache,
 					})
 				);
 			});

--- a/src/shared/components/DataComponent/DataQueryComponent.tsx
+++ b/src/shared/components/DataComponent/DataQueryComponent.tsx
@@ -1,5 +1,5 @@
 import { DocumentNode } from 'graphql';
-import { get } from 'lodash-es';
+import { get, isEmpty } from 'lodash-es';
 import React, { FunctionComponent, ReactNode } from 'react';
 import { Query, QueryResult } from 'react-apollo';
 
@@ -47,6 +47,15 @@ export const DataQueryComponent: FunctionComponent<DataQueryComponentProps> = ({
 					return (
 						<NotFound message={'Er ging iets mis tijdens het ophalen'} icon="alert-triangle" />
 					);
+				}
+
+				if (isEmpty(get(result, 'data'))) {
+					// Temp empty because of cache clean
+					return showSpinner ? (
+						<Flex orientation="horizontal" center>
+							<Spinner size="large" />
+						</Flex>
+					) : null;
 				}
 
 				const data = get(result, resultPath ? `data.${resultPath}` : 'data');


### PR DESCRIPTION
also avoid clearing the cache for every fragment that is updated, only clear it once when the collection object is saved

fixed this issue: https://district01.atlassian.net/browse/AVO2-738