### PR TITLE
fix(cut-fragment-modal): start_oc never gets saved

### DIFF
--- a/src/collection/components/FragmentEdit.tsx
+++ b/src/collection/components/FragmentEdit.tsx
@@ -31,13 +31,13 @@ import toastService, { TOAST_TYPE } from '../../shared/services/toast-service';
 import { IconName } from '../../shared/types/types';
 import { isMediaFragment } from '../helpers';
 import FragmentAdd from './FragmentAdd';
-import CutFragmentModal from './modals/CutFragmentModal';
+import CutFragmentModal, { FragmentPropertyUpdateInfo } from './modals/CutFragmentModal';
 
 interface FragmentEditProps extends RouteComponentProps {
 	index: number;
 	collection: Avo.Collection.Collection;
 	swapFragments: (currentId: number, direction: 'up' | 'down') => void;
-	updateFragmentProperty: (value: any, fieldName: string, fragmentId: number) => void;
+	updateFragmentProperties: (updateInfos: FragmentPropertyUpdateInfo[]) => void;
 	openOptionsId: number | null;
 	setOpenOptionsId: React.Dispatch<React.SetStateAction<number | null>>;
 	fragment: Avo.Collection.Fragment;
@@ -49,7 +49,7 @@ const FragmentEdit: FunctionComponent<FragmentEditProps> = ({
 	index,
 	collection,
 	swapFragments,
-	updateFragmentProperty,
+	updateFragmentProperties,
 	openOptionsId,
 	setOpenOptionsId,
 	fragment,
@@ -70,13 +70,21 @@ const FragmentEdit: FunctionComponent<FragmentEditProps> = ({
 
 	// Change listener for custom fields toggle
 	const onChangeToggle = () => {
-		updateFragmentProperty(!useCustomFields, 'use_custom_fields', fragment.id);
+		updateFragmentProperties([
+			{ value: !useCustomFields, fieldName: 'use_custom_fields' as const, fragmentId: fragment.id },
+		]);
 		setUseCustomFields(!useCustomFields);
 	};
 
 	// Change listener for custom fields text
-	const onChangeText = (field: string, value: string) =>
-		updateFragmentProperty(value, `custom_${field}`, fragment.id);
+	const onChangeText = (field: 'title' | 'description', value: string) =>
+		updateFragmentProperties([
+			{
+				value,
+				fieldName: `custom_${field}` as 'custom_title' | 'custom_description',
+				fragmentId: fragment.id,
+			},
+		]);
 
 	// Get correct fragment property according to fragment type
 	const getFragmentProperty = (
@@ -302,7 +310,7 @@ const FragmentEdit: FunctionComponent<FragmentEditProps> = ({
 					isOpen={isCutModalOpen}
 					onClose={() => setIsCutModalOpen(false)}
 					itemMetaData={itemMetaData}
-					updateFragmentProperty={updateFragmentProperty}
+					updateFragmentProperties={updateFragmentProperties}
 					fragment={fragment}
 					updateCuePoints={setCuePoints}
 				/>

--- a/src/collection/components/modals/CutFragmentModal.tsx
+++ b/src/collection/components/modals/CutFragmentModal.tsx
@@ -22,11 +22,17 @@ import { fetchPlayerTicket } from '../../../shared/services/player-ticket-servic
 import toastService, { TOAST_TYPE } from '../../../shared/services/toast-service';
 import { getValidationErrorsForStartAndEndTime } from '../../helpers/validation';
 
+export interface FragmentPropertyUpdateInfo {
+	value: string | number | boolean | null;
+	fieldName: keyof Avo.Collection.Fragment;
+	fragmentId: number;
+}
+
 interface CutFragmentModalProps {
 	isOpen: boolean;
 	onClose: () => void;
 	itemMetaData: Avo.Item.Item;
-	updateFragmentProperty: (value: any, fieldName: string, fragmentId: number) => void;
+	updateFragmentProperties: (updateInfos: FragmentPropertyUpdateInfo[]) => void;
 	updateCuePoints: (cuepoints: any) => void;
 	fragment: Avo.Collection.Fragment;
 }
@@ -35,7 +41,7 @@ const CutFragmentModal: FunctionComponent<CutFragmentModalProps> = ({
 	onClose,
 	isOpen,
 	itemMetaData,
-	updateFragmentProperty,
+	updateFragmentProperties,
 	fragment,
 	updateCuePoints,
 }) => {
@@ -89,8 +95,10 @@ const CutFragmentModal: FunctionComponent<CutFragmentModalProps> = ({
 		const start = toSeconds(fragmentStartTimeString, true);
 		const end = toSeconds(fragmentEndTimeString, true);
 
-		updateFragmentProperty(start, 'start_oc', fragment.id);
-		updateFragmentProperty(end, 'end_oc', fragment.id);
+		updateFragmentProperties([
+			{ value: start, fieldName: 'start_oc' as const, fragmentId: fragment.id },
+			{ value: end, fieldName: 'end_oc' as const, fragmentId: fragment.id },
+		]);
 		updateCuePoints({
 			start,
 			end,

--- a/src/collection/helpers/validation.ts
+++ b/src/collection/helpers/validation.ts
@@ -187,7 +187,6 @@ export function getValidationErrorForSave(collection: Avo.Collection.Collection)
 function getError<T>(rule: ValidationRule<T>, object: T) {
 	if (typeof rule.error === 'string') {
 		return rule.error;
-	} else {
-		return rule.error(object);
 	}
+	return rule.error(object);
 }

--- a/src/collection/views/CollectionEdit.tsx
+++ b/src/collection/views/CollectionEdit.tsx
@@ -38,6 +38,7 @@ import { getThumbnailForCollection } from '../../shared/services/stills-service'
 import toastService, { TOAST_TYPE } from '../../shared/services/toast-service';
 import { IconName } from '../../shared/types/types';
 import { ReorderCollectionModal, ShareCollectionModal } from '../components';
+import { FragmentPropertyUpdateInfo } from '../components/modals/CutFragmentModal';
 import {
 	DELETE_COLLECTION,
 	DELETE_COLLECTION_FRAGMENT,
@@ -163,7 +164,7 @@ const CollectionEdit: FunctionComponent<CollectionEditProps> = props => {
 	};
 
 	// Update individual property of fragment
-	const updateFragmentProperty = (value: any, propertyName: string, fragmentId: number) => {
+	const updateFragmentProperties = (updateInfos: FragmentPropertyUpdateInfo[]) => {
 		const tempCollection: Avo.Collection.Collection | undefined = cloneDeep(currentCollection);
 
 		if (!tempCollection) {
@@ -174,11 +175,13 @@ const CollectionEdit: FunctionComponent<CollectionEditProps> = props => {
 			return;
 		}
 
-		const fragmentToUpdate = tempCollection.collection_fragments.find(
-			(item: Avo.Collection.Fragment) => item.id === fragmentId
-		);
+		updateInfos.forEach((updateInfo: FragmentPropertyUpdateInfo) => {
+			const fragmentToUpdate = tempCollection.collection_fragments.find(
+				(item: Avo.Collection.Fragment) => item.id === updateInfo.fragmentId
+			);
 
-		(fragmentToUpdate as any)[propertyName] = value;
+			(fragmentToUpdate as any)[updateInfo.fieldName] = updateInfo.value;
+		});
 
 		setCurrentCollection(tempCollection);
 	};
@@ -673,7 +676,7 @@ const CollectionEdit: FunctionComponent<CollectionEditProps> = props => {
 						collection={currentCollection}
 						swapFragments={swapFragments}
 						updateCollection={setCurrentCollection}
-						updateFragmentProperty={updateFragmentProperty}
+						updateFragmentProperties={updateFragmentProperties}
 					/>
 				)}
 				{currentTab === 'metadata' && (

--- a/src/collection/views/CollectionEditContent.tsx
+++ b/src/collection/views/CollectionEditContent.tsx
@@ -5,19 +5,20 @@ import { Container } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
 import { FragmentAdd, FragmentEdit } from '../components';
+import { FragmentPropertyUpdateInfo } from '../components/modals/CutFragmentModal';
 
 interface CollectionEditContentProps {
 	collection: Avo.Collection.Collection;
 	swapFragments: (currentId: number, direction: 'up' | 'down') => void;
 	updateCollection: (collection: Avo.Collection.Collection) => void;
-	updateFragmentProperty: (value: string, fieldName: string, fragmentId: number) => void;
+	updateFragmentProperties: (updateInfo: FragmentPropertyUpdateInfo[]) => void;
 }
 
 const CollectionEditContent: FunctionComponent<CollectionEditContentProps> = ({
 	collection,
 	swapFragments,
 	updateCollection,
-	updateFragmentProperty,
+	updateFragmentProperties,
 }) => {
 	const [openOptionsId, setOpenOptionsId] = useState<number | null>(null);
 
@@ -38,7 +39,7 @@ const CollectionEditContent: FunctionComponent<CollectionEditContentProps> = ({
 							index={index}
 							collection={collection}
 							swapFragments={swapFragments}
-							updateFragmentProperty={updateFragmentProperty}
+							updateFragmentProperties={updateFragmentProperties}
 							openOptionsId={openOptionsId}
 							setOpenOptionsId={setOpenOptionsId}
 							fragment={fragment}


### PR DESCRIPTION
### Steps to reproduce the bug before this PR
* go to a collection
* edit a fragment start time
* save the collection
* reload the page
* open the cut fragment modal

### Expected result:
the previously set start_oc cut time should be shown

### Current result:
the start_oc _cut time is set to 0

### Cause
This is caused by the asynchronous nature of setState functions. So try to avoid this pattern in the future:
Calling 2 functions that set the state, right after eachother, where the functions internally take a copy of the current state, and then set that state at the end of the function.
https://github.com/viaacode/avo2-client/blob/3c96c4a7dcc0098d6e6e78188620852429858379/src/collection/components/modals/CutFragmentModal.tsx#L47-L48

What happened was:
* update start_oc function is called
* it clones the currentCollection, modifies it and calls setState with the copy
* update start_end function is called
* it clones the currentCollection, modifies it and calls setState with the copy
* the first setState completes and sets the state with the modified start_oc
* the second setState completes and sets the state with the modified end_oc (start_oc is overridden here)