### PR TITLE
fix(cut-fragment): not update start/end when no cut.

### DIFF
--- a/src/collection/components/FragmentEdit.tsx
+++ b/src/collection/components/FragmentEdit.tsx
@@ -285,11 +285,10 @@ const FragmentEdit: FunctionComponent<FragmentEditProps> = ({
 									poster={itemMetaData.thumbnail_path}
 									title={itemMetaData.title}
 									onInit={initFlowPlayer}
-									start={cuePoints.start}
-									end={cuePoints.end}
 									subtitles={['30-12-2011', 'VRT']}
 									token={getEnv('FLOW_PLAYER_TOKEN')}
 									dataPlayerId={getEnv('FLOW_PLAYER_ID')}
+									{...cuePoints}
 								/>
 							</Column>
 							<Column size="3-6">{renderForm(fragment, itemMetaData, index)}</Column>

--- a/src/item/components/modals/FragmentAddToCollection.tsx
+++ b/src/item/components/modals/FragmentAddToCollection.tsx
@@ -127,6 +127,10 @@ const FragmentAddToCollection: FunctionComponent<FragmentAddToCollectionProps> =
 		setIsProcessing(true);
 
 		try {
+			const hasCut = !(
+				fragmentEndTime === toSeconds(itemMetaData.duration) && fragmentStartTime === 0
+			);
+
 			const response: void | ExecutionResult<
 				Avo.Collection.Fragment
 			> = await triggerCollectionFragmentInsert({
@@ -134,10 +138,10 @@ const FragmentAddToCollection: FunctionComponent<FragmentAddToCollectionProps> =
 					id: collection.id,
 					fragment: {
 						use_custom_fields: false,
-						start_oc: fragmentStartTime,
+						start_oc: hasCut ? fragmentStartTime : null,
 						position: (collection.collection_fragments || []).length,
 						external_id: externalId,
-						end_oc: fragmentEndTime,
+						end_oc: hasCut ? fragmentEndTime : null,
 						custom_title: null,
 						custom_description: null,
 						collection_id: collection.id,

--- a/src/item/components/modals/FragmentAddToCollection.tsx
+++ b/src/item/components/modals/FragmentAddToCollection.tsx
@@ -127,9 +127,8 @@ const FragmentAddToCollection: FunctionComponent<FragmentAddToCollectionProps> =
 		setIsProcessing(true);
 
 		try {
-			const hasCut = !(
-				fragmentEndTime === toSeconds(itemMetaData.duration) && fragmentStartTime === 0
-			);
+			const hasCut =
+				fragmentEndTime !== toSeconds(itemMetaData.duration) || fragmentStartTime !== 0;
 
 			const response: void | ExecutionResult<
 				Avo.Collection.Fragment


### PR DESCRIPTION
If we always apply the start/end time, we will never know whether a fragment was cut. Hence don't always apply the start/end. Only if cut.