### PR TITLE
fix(smartschool-auth): implement logout routes for multiple idps

### DIFF
--- a/src/authentication/helpers/get-profile-info.ts
+++ b/src/authentication/helpers/get-profile-info.ts
@@ -8,6 +8,11 @@ function getUserInfo() {
 	return get(state, 'loginState.data.userInfo');
 }
 
+export function getLogoutPath(): string | undefined {
+	const state: any = store.getState();
+	return get(state, 'loginState.data.logoutPath');
+}
+
 export function getProfileId(): string {
 	const userInfo = getUserInfo();
 	const profileId = get(userInfo, 'profile.id');

--- a/src/authentication/helpers/redirect-to-idp.ts
+++ b/src/authentication/helpers/redirect-to-idp.ts
@@ -1,5 +1,8 @@
 import queryString from 'query-string';
+
 import { getEnv } from '../../shared/helpers/env';
+import toastService, { TOAST_TYPE } from '../../shared/services/toast-service';
+import { getLogoutPath } from './get-profile-info';
 
 export function redirectToLoginPage(returnToUrl: string) {
 	// Not logged in, we need to redirect the user to the SAML identity server login page
@@ -13,7 +16,12 @@ export function redirectToPage(returnToUrl: string) {
 }
 
 export function redirectToLogoutPage(returnToUrl: string) {
-	window.location.href = `${getEnv('PROXY_URL')}/auth/logout?${queryString.stringify({
+	const logoutPath = getLogoutPath();
+	if (!logoutPath) {
+		toastService('Het uitloggen is mislukt', TOAST_TYPE.DANGER);
+		return;
+	}
+	window.location.href = `${getEnv('PROXY_URL')}/${logoutPath}?${queryString.stringify({
 		returnToUrl,
 	})}`;
 }


### PR DESCRIPTION
This PR requires a PR on the backend to work: https://github.com/viaacode/avo2-proxy/pull/53

You can test this by logging in with any idp and the trying to click the logout button