### PR TITLE
fix(collection-edit, assignment-edit): re-add second save button

### DIFF
--- a/src/assignment/views/AssignmentEdit.tsx
+++ b/src/assignment/views/AssignmentEdit.tsx
@@ -920,6 +920,24 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps> = ({
 						</Form>
 					</Container>
 				</Container>
+				<Container background="alt" mode="vertical">
+					<Container mode="horizontal">
+						<Toolbar autoHeight>
+							<ToolbarRight>
+								<ToolbarItem>
+									<ButtonToolbar>
+										<Button
+											type="primary"
+											label="Opslaan"
+											onClick={() => saveAssignment(currentAssignment)}
+											disabled={isSaving}
+										/>
+									</ButtonToolbar>
+								</ToolbarItem>
+							</ToolbarRight>
+						</Toolbar>
+					</Container>
+				</Container>
 
 				<DeleteObjectModal
 					title={`Ben je zeker dat de opdracht "${currentAssignment.title}" wil verwijderen?`}

--- a/src/collection/views/CollectionEdit.tsx
+++ b/src/collection/views/CollectionEdit.tsx
@@ -457,6 +457,24 @@ const CollectionEdit: FunctionComponent<CollectionEditProps> = props => {
 						updateCollectionProperty={updateCollectionProperty}
 					/>
 				)}
+				<Container background="alt" mode="vertical">
+					<Container mode="horizontal">
+						<Toolbar autoHeight>
+							<ToolbarRight>
+								<ToolbarItem>
+									<ButtonToolbar>
+										<Button
+											type="primary"
+											label="Opslaan"
+											onClick={() => onSaveCollection(refetchCollection)}
+											disabled={isSavingCollection}
+										/>
+									</ButtonToolbar>
+								</ToolbarItem>
+							</ToolbarRight>
+						</Toolbar>
+					</Container>
+				</Container>
 				{/* <ReorderCollectionModal
 					isOpen={isReorderModalOpen}
 					onClose={() => setIsReorderModalOpen(false)}


### PR DESCRIPTION
this was probably lost in a previous commit

Collection edit page:
![image](https://user-images.githubusercontent.com/1710840/68411577-f96ce780-018a-11ea-943a-e6f6d14f594b.png)

Assignment edit page:
![image](https://user-images.githubusercontent.com/1710840/68411598-02f64f80-018b-11ea-8e43-871821d4a395.png)
