### PR TITLE
fix(collections-overview): fix collection paging offset

### DIFF
--- a/src/collection/views/CollectionOverview.tsx
+++ b/src/collection/views/CollectionOverview.tsx
@@ -263,7 +263,7 @@ const Collections: FunctionComponent<CollectionsProps> = ({ numberOfCollections,
 			query={GET_COLLECTIONS_BY_OWNER}
 			variables={{
 				owner_profile_id: getProfileId(),
-				offset: page,
+				offset: page * ITEMS_PER_PAGE,
 				order: { [sortColumn]: sortOrder },
 			}}
 			resultPath="app_collections"


### PR DESCRIPTION
This is by item instead of by page, so for page 2 we need to pass 20 instead of 1

![image](https://user-images.githubusercontent.com/1710840/68412696-fa067d80-018c-11ea-92bd-67334c7d17f8.png)
