### PR TITLE
fix(coll-fragment): ensure range selector value is never > duration

### DIFF
--- a/src/collection/components/modals/CutFragmentModal.tsx
+++ b/src/collection/components/modals/CutFragmentModal.tsx
@@ -168,6 +168,7 @@ const CutFragmentModal: FunctionComponent<CutFragmentModalProps> = ({
 		fetchPlayerTicket(itemMetaData.external_id).then(data => setPlayerTicket(data));
 
 	// TODO: Replace publisher, published_at by real publisher
+	const fragmentDuration: number = toSeconds(itemMetaData.duration, true) || 0;
 	return (
 		<Modal
 			isOpen={isOpen}
@@ -196,10 +197,10 @@ const CutFragmentModal: FunctionComponent<CutFragmentModalProps> = ({
 					/>
 					<div className="m-multi-range-wrapper">
 						<MultiRange
-							values={[fragmentStart, fragmentEnd]}
+							values={[fragmentStart, Math.min(fragmentEnd, fragmentDuration)]}
 							onChange={onUpdateMultiRangeValues}
 							min={0}
-							max={toSeconds(itemMetaData.duration, true) || 0}
+							max={fragmentDuration}
 							step={1}
 						/>
 					</div>

--- a/src/item/components/modals/AddToCollectionModal.tsx
+++ b/src/item/components/modals/AddToCollectionModal.tsx
@@ -285,6 +285,7 @@ const AddToCollectionModal: FunctionComponent<AddToCollectionModalProps> = ({
 	const renderAddToCollectionModal = () => {
 		const initFlowPlayer = () =>
 			!playerTicket && fetchPlayerTicket(externalId).then(data => setPlayerTicket(data));
+		const fragmentDuration = toSeconds(itemMetaData.duration) || 0;
 
 		return (
 			<Modal
@@ -319,10 +320,10 @@ const AddToCollectionModal: FunctionComponent<AddToCollectionModalProps> = ({
 											/>
 											<div className="m-multi-range-wrapper">
 												<MultiRange
-													values={[fragmentStartTime, fragmentEndTime]}
+													values={[fragmentStartTime, Math.min(fragmentEndTime, fragmentDuration)]}
 													onChange={onUpdateMultiRangeValues}
 													min={0}
-													max={toSeconds(itemMetaData.duration) || 0}
+													max={fragmentDuration}
 													step={1}
 												/>
 											</div>


### PR DESCRIPTION
closes: https://district01.atlassian.net/browse/AVO2-929

a video can have a duration of: "00:02:01" => 121 seconds
and the fragment can have an end set to 122 seconds

The range selector component will throw an error if you try to set the value to a value larger than the max value.

Fixed by limiting the fragmentEnd to the duration of the video