### PR TITLE
feat(fragment-detail): make fragment detail title clickable

### DIFF
--- a/src/assignment/views/AssignmentDetail.tsx
+++ b/src/assignment/views/AssignmentDetail.tsx
@@ -341,6 +341,7 @@ const AssignmentDetail: FunctionComponent<AssignmentProps> = ({ match, user, ...
 							(assignmentContent as Avo.Collection.Collection).collection_fragments
 						}
 						showDescription={assignment.content_layout === AssignmentLayout.PlayerAndText}
+						linkToItems={false}
 						match={match}
 						user={user}
 						{...rest}

--- a/src/collection/components/fragment/FragmentDetail.tsx
+++ b/src/collection/components/fragment/FragmentDetail.tsx
@@ -4,12 +4,16 @@ import { BlockIntro } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
+import { redirectToClientPage } from '../../../authentication/helpers/redirects';
+import { APP_PATH } from '../../../constants';
 import { ItemVideoDescription } from '../../../item/components';
+import { buildLink } from '../../../shared/helpers';
 import { getFragmentProperty } from '../../helpers';
 
 interface FragmentDetailProps extends DefaultSecureRouteProps {
 	collectionFragment: Avo.Collection.Fragment;
 	showDescription: boolean;
+	linkToItems: boolean;
 }
 
 /**
@@ -17,15 +21,35 @@ interface FragmentDetailProps extends DefaultSecureRouteProps {
  * The bottom meta data is not included in the component
  * @param collectionFragment
  * @param showDescriptionNextToVideo
- * @param props FragmentDetailProps
  * @constructor
  */
 // TODO: Split up in FragmentDetailList and FragmentDetail component.
 const FragmentDetail: FunctionComponent<FragmentDetailProps> = ({
 	collectionFragment,
 	showDescription,
+	linkToItems,
+	history,
 	...rest
 }) => {
+	const getTitleClickedHandler = () => {
+		if (
+			linkToItems &&
+			collectionFragment.item_meta &&
+			(collectionFragment.item_meta.type.label === 'video' ||
+				collectionFragment.item_meta.type.label === 'audio')
+		) {
+			return () => {
+				if (collectionFragment.item_meta) {
+					redirectToClientPage(
+						buildLink(APP_PATH.ITEM, { id: collectionFragment.item_meta.external_id }),
+						history
+					);
+				}
+			};
+		}
+		return undefined;
+	};
+
 	return collectionFragment.item_meta ? (
 		<ItemVideoDescription
 			showDescription={showDescription}
@@ -44,6 +68,8 @@ const FragmentDetail: FunctionComponent<FragmentDetailProps> = ({
 				collectionFragment.use_custom_fields,
 				'description'
 			)}
+			onTitleClicked={getTitleClickedHandler()}
+			history={history}
 			{...rest}
 		/>
 	) : (

--- a/src/collection/components/fragment/FragmentListDetail.tsx
+++ b/src/collection/components/fragment/FragmentListDetail.tsx
@@ -10,6 +10,7 @@ import FragmentDetail from './FragmentDetail';
 interface FragmentDetailProps extends DefaultSecureRouteProps {
 	collectionFragments: Avo.Collection.Fragment[];
 	showDescription: boolean;
+	linkToItems: boolean;
 }
 
 /**
@@ -17,12 +18,12 @@ interface FragmentDetailProps extends DefaultSecureRouteProps {
  * The bottom meta data is not included in the component
  * @param collectionFragments
  * @param showDescriptionNextToVideo
- * @param props FragmentDetailProps
  * @constructor
  */
 const FragmentListDetail: FunctionComponent<FragmentDetailProps> = ({
 	collectionFragments,
 	showDescription,
+	linkToItems,
 	...rest
 }) => {
 	const renderCollectionFragments = () =>
@@ -35,6 +36,7 @@ const FragmentListDetail: FunctionComponent<FragmentDetailProps> = ({
 					<FragmentDetail
 						collectionFragment={collectionFragment}
 						showDescription={showDescription}
+						linkToItems={linkToItems}
 						{...rest}
 					/>
 				</li>

--- a/src/collection/views/CollectionDetail.tsx
+++ b/src/collection/views/CollectionDetail.tsx
@@ -93,6 +93,7 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 			canEditCollections: boolean;
 			canDeleteCollections: boolean;
 			canCreateCollections: boolean;
+			canViewItems: boolean;
 		}>
 	>({});
 	const [loadingInfo, setLoadingInfo] = useState<LoadingInfo>({ state: 'loading' });
@@ -149,6 +150,7 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 				user
 			),
 			PermissionService.hasPermissions([{ name: PermissionNames.CREATE_COLLECTIONS }], user),
+			PermissionService.hasPermissions([{ name: PermissionNames.VIEW_ITEMS }], user),
 		])
 			.then(permissions => {
 				setPermissions({
@@ -156,6 +158,7 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 					canEditCollections: permissions[1],
 					canDeleteCollections: permissions[2],
 					canCreateCollections: permissions[3],
+					canViewItems: permissions[4],
 				});
 			})
 			.catch(err => {
@@ -356,6 +359,7 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 						<FragmentListDetail
 							collectionFragments={collection_fragments}
 							showDescription
+							linkToItems={permissions.canViewItems || false}
 							history={history}
 							match={match}
 							user={user}

--- a/src/item/components/ItemVideoDescription.tsx
+++ b/src/item/components/ItemVideoDescription.tsx
@@ -38,6 +38,7 @@ interface ItemVideoDescriptionProps extends DefaultSecureRouteProps {
 	showTitle?: boolean;
 	title?: string;
 	description?: string;
+	onTitleClicked?: () => void;
 }
 
 const DEFAULT_VIDEO_HEIGHT = 421;
@@ -49,6 +50,7 @@ const ItemVideoDescription: FunctionComponent<ItemVideoDescriptionProps> = ({
 	showDescription = true,
 	title = itemMetaData.title,
 	description = itemMetaData.description,
+	onTitleClicked,
 	user,
 }) => {
 	const videoRef: RefObject<HTMLVideoElement> = createRef();
@@ -166,7 +168,13 @@ const ItemVideoDescription: FunctionComponent<ItemVideoDescriptionProps> = ({
 			}}
 		>
 			{showTitle ? (
-				<Heading type="h3">{title}</Heading>
+				<Heading
+					type="h3"
+					className={onTitleClicked ? 'u-clickable' : ''}
+					onClick={onTitleClicked || (() => {})}
+				>
+					{title}
+				</Heading>
 			) : (
 				<Heading type="h4">
 					<Trans i18nKey="item/components/item-video-description___beschrijving">


### PR DESCRIPTION
closes: https://district01.atlassian.net/browse/AVO2-931

items should only be clickable in collection detail for teachers (not for pupils)
![image](https://user-images.githubusercontent.com/1710840/72052065-b6331000-32c4-11ea-96eb-ef81bdb5c9da.png)


items should not be clickable inside the preview of an assignment (view as pupil)
![image](https://user-images.githubusercontent.com/1710840/72052165-e5e21800-32c4-11ea-8cfd-04bb43fcb966.png)

