### PR TITLE
fix(item-video-description): hide scrollbar when desc. is collasped

### DIFF
--- a/src/item/components/ItemVideoDescription.tsx
+++ b/src/item/components/ItemVideoDescription.tsx
@@ -185,8 +185,8 @@ const ItemVideoDescription: FunctionComponent<ItemVideoDescriptionProps> = ({
 					</Trans>
 				</BlockHeading>
 			)}
-			{/* TODO: Fix label height - "Beschrijving" label height (22) + padding (15 * 2) + read more button (36) - additional margin (8) */}
-			<ExpandableContainer collapsedHeight={videoHeight - 22 - 15 * 2 - 36 - 8}>
+			{/* TODO: Fix label height - "Beschrijving" label height (22) + padding (15 * 2) + read more button (36) - additional margin (18) */}
+			<ExpandableContainer collapsedHeight={videoHeight - 22 - 15 * 2 - 36 - 18}>
 				<p>{formatTimestamps(convertToHtml(description))}</p>
 			</ExpandableContainer>
 		</Scrollbar>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1710840/73444049-1fec8a00-4358-11ea-9c50-49b1f4dc8fa4.png)
