### PR TITLE
Bugfix/content blocks updates

### DIFF
--- a/src/admin/content-block/components/ContentBlockFieldEditor/ContentBlockFieldEditor.tsx
+++ b/src/admin/content-block/components/ContentBlockFieldEditor/ContentBlockFieldEditor.tsx
@@ -42,7 +42,7 @@ export const ContentBlockFieldEditor: FunctionComponent<ContentBlockFieldProps> 
 }) => {
 	const { index, config } = block;
 	const EditorComponent = EDITOR_TYPES_MAP[field.editorType];
-	const editorId = createKey('e', index, formGroupIndex, stateIndex);
+	const editorId = createKey('editor', index, formGroupIndex, stateIndex);
 	const defaultProps = {
 		...field.editorProps,
 		editorId,

--- a/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
+++ b/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
@@ -181,24 +181,22 @@ const ContentBlockForm: FunctionComponent<ContentBlockFormProps> = ({
 				<AccordionTitle>{accordionTitle}</AccordionTitle>
 				<AccordionActions>
 					<ButtonToolbar>
-						{blockIndex > 0 && (
-							<Button
-								icon="chevron-up"
-								onClick={() => onReorder(blockIndex, -1)}
-								size="small"
-								title="Verplaats naar boven"
-								type="tertiary"
-							/>
-						)}
-						{blockIndex + 1 < length && (
-							<Button
-								icon="chevron-down"
-								onClick={() => onReorder(blockIndex, 1)}
-								size="small"
-								title="Verplaats naar onder"
-								type="tertiary"
-							/>
-						)}
+						<Button
+							disabled={blockIndex === 0}
+							icon="chevron-up"
+							onClick={() => onReorder(blockIndex, -1)}
+							size="small"
+							title="Verplaats naar boven"
+							type="tertiary"
+						/>
+						<Button
+							disabled={blockIndex + 1 === length}
+							icon="chevron-down"
+							onClick={() => onReorder(blockIndex, 1)}
+							size="small"
+							title="Verplaats naar onder"
+							type="tertiary"
+						/>
 						<Button
 							icon="edit"
 							onClick={setIsAccordionOpen}

--- a/src/admin/content-block/components/ContentBlockFormGroup/ContentBlockFormGroup.tsx
+++ b/src/admin/content-block/components/ContentBlockFormGroup/ContentBlockFormGroup.tsx
@@ -43,7 +43,7 @@ export const ContentBlockFormGroup: FunctionComponent<ContentBlockFormGroupProps
 	handleChange,
 	formErrors,
 }) => (
-	<>
+	<div className="c-content-block-form-group">
 		{Object.keys(formGroup.fields).map((key: string, formGroupIndex: number) => {
 			const formGroupOptions = {
 				key: createKey('form-group', blockIndex, formGroupIndex, stateIndex),
@@ -72,5 +72,5 @@ export const ContentBlockFormGroup: FunctionComponent<ContentBlockFormGroupProps
 				</FormGroup>
 			);
 		})}
-	</>
+	</div>
 );

--- a/src/admin/content-block/components/ContentBlockFormGroup/ContentBlockFormGroup.tsx
+++ b/src/admin/content-block/components/ContentBlockFormGroup/ContentBlockFormGroup.tsx
@@ -46,7 +46,7 @@ export const ContentBlockFormGroup: FunctionComponent<ContentBlockFormGroupProps
 	<>
 		{Object.keys(formGroup.fields).map((key: string, formGroupIndex: number) => {
 			const formGroupOptions = {
-				key: createKey('e', blockIndex, formGroupIndex, stateIndex),
+				key: createKey('form-group', blockIndex, formGroupIndex, stateIndex),
 				label: createFieldEditorLabel(
 					get(config, 'components.name'),
 					formGroup.fields[key].label,

--- a/src/admin/content/helpers/reducers/content-edit.ts
+++ b/src/admin/content/helpers/reducers/content-edit.ts
@@ -40,12 +40,11 @@ const reorderConfigs = (
 	{ configIndex, indexUpdate }: { configIndex: number; indexUpdate: number }
 ): ContentBlockConfig[] => {
 	const newIndex = configIndex + indexUpdate;
-
 	// Get updated item and remove it from copy
 	const updatedConfig = configs.splice(configIndex, 1)[0];
 	// Add item back at new index
 	configs.splice(newIndex, 0, updatedConfig);
-	// Update position properties with new index
+
 	return repositionConfigs(configs);
 };
 
@@ -146,45 +145,21 @@ export const contentEditReducer = (
 
 	switch (type) {
 		case ContentEditActionType.ADD_CONTENT_BLOCK_CONFIG:
-			return {
-				...state,
-				contentBlockConfigs: [...contentBlockConfigs, payload],
-			};
+			return { contentBlockConfigs: [...contentBlockConfigs, payload] };
 		case ContentEditActionType.REMOVE_CONTENT_BLOCK_CONFIG:
-			return {
-				...state,
-				contentBlockConfigs: removeConfig([...contentBlockConfigs], payload),
-			};
+			return { contentBlockConfigs: removeConfig([...contentBlockConfigs], payload) };
 		case ContentEditActionType.REORDER_CONTENT_BLOCK_CONFIG:
-			return {
-				...state,
-				contentBlockConfigs: reorderConfigs([...contentBlockConfigs], payload),
-			};
+			return { contentBlockConfigs: reorderConfigs([...contentBlockConfigs], payload) };
 		case ContentEditActionType.SET_CONTENT_BLOCK_CONFIGS:
-			return {
-				...state,
-				contentBlockConfigs: payload,
-			};
+			return { contentBlockConfigs: payload };
 		case ContentEditActionType.ADD_COMPONENTS_STATE:
-			return {
-				...state,
-				contentBlockConfigs: addComponentState([...contentBlockConfigs], payload),
-			};
+			return { contentBlockConfigs: addComponentState([...contentBlockConfigs], payload) };
 		case ContentEditActionType.REMOVE_COMPONENTS_STATE:
-			return {
-				...state,
-				contentBlockConfigs: removeComponentState([...contentBlockConfigs], payload),
-			};
+			return { contentBlockConfigs: removeComponentState([...contentBlockConfigs], payload) };
 		case ContentEditActionType.SET_COMPONENTS_STATE:
-			return {
-				...state,
-				contentBlockConfigs: setComponentState([...contentBlockConfigs], payload),
-			};
+			return { contentBlockConfigs: setComponentState([...contentBlockConfigs], payload) };
 		case ContentEditActionType.SET_BLOCK_STATE:
-			return {
-				...state,
-				contentBlockConfigs: setBlockState([...contentBlockConfigs], payload),
-			};
+			return { contentBlockConfigs: setBlockState([...contentBlockConfigs], payload) };
 
 		default:
 			return state;

--- a/src/admin/content/helpers/reducers/content-edit.ts
+++ b/src/admin/content/helpers/reducers/content-edit.ts
@@ -1,5 +1,7 @@
-import { createReducer } from '../../../../shared/helpers';
-import { ContentBlockConfig } from '../../../content-block/content-block.types';
+import {
+	ContentBlockComponentState,
+	ContentBlockConfig,
+} from '../../../content-block/content-block.types';
 
 import { ContentEditAction, ContentEditActionType, ContentEditState } from '../../content.types';
 
@@ -9,7 +11,8 @@ export const CONTENT_EDIT_INITIAL_STATE = (
 	contentBlockConfigs,
 });
 
-const repositionContentBlockConfigs = (updatedConfigs: ContentBlockConfig[]) => {
+// Helpers
+const repositionConfigs = (updatedConfigs: ContentBlockConfig[]) => {
 	return updatedConfigs.map((config, position) => ({
 		...config,
 		block: {
@@ -22,149 +25,168 @@ const repositionContentBlockConfigs = (updatedConfigs: ContentBlockConfig[]) => 
 	}));
 };
 
-export const contentEditReducer = (initialState: ContentEditState) =>
-	createReducer<ContentEditState>(initialState, {
-		[ContentEditActionType.ADD_CONTENT_BLOCK_CONFIG]: (state, action: ContentEditAction) => ({
-			...state,
-			contentBlockConfigs: [...state.contentBlockConfigs, action.payload],
-		}),
-		[ContentEditActionType.REMOVE_CONTENT_BLOCK_CONFIG]: (state, action: ContentEditAction) => {
-			// Clone config
-			const clonedConfigs = [...state.contentBlockConfigs];
-			// Remove item from array
-			clonedConfigs.splice(action.payload, 1);
-			// Update position properties with new index
-			const repositionedConfigs = repositionContentBlockConfigs(clonedConfigs);
+const removeConfig = (
+	configs: ContentBlockConfig[],
+	indexToRemove: number
+): ContentBlockConfig[] => {
+	// Remove item from array
+	configs.splice(indexToRemove, 1);
+	// Update position properties with new index
+	return repositionConfigs(configs);
+};
 
-			return {
-				...state,
-				contentBlockConfigs: repositionedConfigs,
-			};
+const reorderConfigs = (
+	configs: ContentBlockConfig[],
+	{ configIndex, indexUpdate }: { configIndex: number; indexUpdate: number }
+): ContentBlockConfig[] => {
+	const newIndex = configIndex + indexUpdate;
+
+	// Get updated item and remove it from copy
+	const updatedConfig = configs.splice(configIndex, 1)[0];
+	// Add item back at new index
+	configs.splice(newIndex, 0, updatedConfig);
+	// Update position properties with new index
+	return repositionConfigs(configs);
+};
+
+const addComponentState = (
+	configs: ContentBlockConfig[],
+	{ index, formGroupState }: { index: number; formGroupState: ContentBlockComponentState[] }
+): ContentBlockConfig[] => {
+	// Convert update object to array if necessary
+	const componentState = [...configs[index].components.state, ...formGroupState];
+	// Update single content block config
+	const updatedConfig = {
+		...configs[index],
+		components: {
+			...configs[index].components,
+			state: componentState,
 		},
-		[ContentEditActionType.REORDER_CONTENT_BLOCK_CONFIG]: (state, action: ContentEditAction) => {
-			const { configIndex, indexUpdate } = action.payload;
-			const newIndex = configIndex + indexUpdate;
+	};
+	// Apply update object to config
+	configs.splice(index, 1, updatedConfig);
 
-			// Clone config
-			const clonedConfigs = [...state.contentBlockConfigs];
-			// Get updated item and remove it from copy
-			const updatedConfig = clonedConfigs.splice(configIndex, 1)[0];
-			// Add item back at new index
-			clonedConfigs.splice(newIndex, 0, updatedConfig);
-			// Update position properties with new index
-			const repositionedConfigs = repositionContentBlockConfigs(clonedConfigs);
+	return configs;
+};
 
-			return {
-				...state,
-				contentBlockConfigs: repositionedConfigs,
-			};
-		},
-		[ContentEditActionType.SET_CONTENT_BLOCK_CONFIGS]: (state, action: ContentEditAction) => ({
-			...state,
-			contentBlockConfigs: action.payload,
-		}),
-		[ContentEditActionType.ADD_COMPONENTS_STATE]: (state, action: ContentEditAction) => {
-			const { index, formGroupState } = action.payload;
+const removeComponentState = (
+	configs: ContentBlockConfig[],
+	{ index, stateIndex }: { index: number; stateIndex: number }
+): ContentBlockConfig[] => {
+	(configs[index].components.state as ContentBlockComponentState[]).splice(stateIndex, 1);
 
-			// Clone config
-			const contentBlocks = [...state.contentBlockConfigs];
+	return configs;
+};
 
-			// Convert update object to array if necessary
-			const componentState = [...contentBlocks[index].components.state, ...formGroupState];
+const setComponentState = (
+	configs: ContentBlockConfig[],
+	payload: { index: number; formGroupState: ContentBlockComponentState; stateIndex: number }
+): ContentBlockConfig[] => {
+	const { index, formGroupState, stateIndex } = payload;
 
-			// Update single content block config
-			const updatedConfig = {
-				...contentBlocks[index],
-				components: {
-					...contentBlocks[index].components,
-					state: componentState,
-				},
-			};
-
-			// Apply update object to config
-			contentBlocks.splice(index, 1, updatedConfig);
-
-			return {
-				...state,
-				contentBlockConfigs: contentBlocks,
-			};
-		},
-		[ContentEditActionType.REMOVE_COMPONENTS_STATE]: (state, action: ContentEditAction) => {
-			const { index, stateIndex } = action.payload;
-
-			const contentBlocks = [...state.contentBlockConfigs];
-
-			(contentBlocks[index].components.state as any).splice(stateIndex, 1);
-
-			return {
-				state,
-				contentBlockConfigs: contentBlocks,
-			};
-		},
-		[ContentEditActionType.SET_COMPONENTS_STATE]: (state, action: ContentEditAction) => {
-			const { index, formGroupState, stateIndex } = action.payload;
-
-			// Clone config
-			const contentBlocks = [...state.contentBlockConfigs];
-
-			if (stateIndex || stateIndex === 0) {
-				(contentBlocks[index].components.state as any)[stateIndex] = {
-					...(contentBlocks[index].components.state as any)[stateIndex],
+	if (stateIndex || stateIndex === 0) {
+		(configs[index].components.state as ContentBlockComponentState[])[stateIndex] = {
+			...(configs[index].components.state as ContentBlockComponentState[])[stateIndex],
+			...formGroupState,
+		};
+	} else {
+		// Convert update object to array if necessary
+		const componentState = Array.isArray(configs[index].components.state)
+			? [...configs[index].components.state, formGroupState]
+			: {
+					...configs[index].components.state,
 					...formGroupState,
-				};
-			} else {
-				// Convert update object to array if necessary
-				const componentState = Array.isArray(contentBlocks[index].components.state)
-					? [...contentBlocks[index].components.state, formGroupState]
-					: {
-							...contentBlocks[index].components.state,
-							...formGroupState,
-					  };
+			  };
 
-				// Update single content block config
-				const updatedConfig = {
-					...contentBlocks[index],
-					components: {
-						...contentBlocks[index].components,
-						state: componentState,
-						fields: contentBlocks[index].components.fields,
-					},
-				};
+		// Update single content block config
+		const updatedConfig: ContentBlockConfig = {
+			...configs[index],
+			components: {
+				...configs[index].components,
+				state: componentState,
+				fields: configs[index].components.fields,
+			},
+		};
 
-				// Apply update object to config
-				contentBlocks.splice(index, 1, updatedConfig);
-			}
+		// Apply update object to config
+		configs.splice(index, 1, updatedConfig);
+	}
 
+	return configs;
+};
+
+const setBlockState = (
+	configs: ContentBlockConfig[],
+	{ index, formGroupState }: { index: number; formGroupState: ContentBlockComponentState[] }
+): ContentBlockConfig[] => {
+	// Update single content block config
+	const updatedConfig = {
+		...configs[index],
+		block: {
+			...configs[index].block,
+			state: {
+				...configs[index].block.state,
+				...formGroupState,
+			},
+			fields: configs[index].block.fields,
+		},
+	};
+	// Apply update object to config
+	configs.splice(index, 1, updatedConfig);
+
+	return configs;
+};
+
+// Reducer
+export const contentEditReducer = (
+	state: ContentEditState,
+	{ payload, type }: ContentEditAction
+) => {
+	const { contentBlockConfigs } = state;
+
+	switch (type) {
+		case ContentEditActionType.ADD_CONTENT_BLOCK_CONFIG:
 			return {
 				...state,
-				contentBlockConfigs: contentBlocks,
+				contentBlockConfigs: [...contentBlockConfigs, payload],
 			};
-		},
-		[ContentEditActionType.SET_BLOCK_STATE]: (state, action: ContentEditAction) => {
-			const { index, formGroupState } = action.payload;
-
-			// Clone config
-			const contentBlocks = [...state.contentBlockConfigs];
-
-			// Update single content block config
-			const updatedConfig = {
-				...contentBlocks[index],
-				block: {
-					...contentBlocks[index].block,
-					state: {
-						...contentBlocks[index].block.state,
-						...formGroupState,
-					},
-					fields: contentBlocks[index].block.fields,
-				},
-			};
-
-			// Apply update object to config
-			contentBlocks.splice(index, 1, updatedConfig);
-
+		case ContentEditActionType.REMOVE_CONTENT_BLOCK_CONFIG:
 			return {
 				...state,
-				contentBlockConfigs: contentBlocks,
+				contentBlockConfigs: removeConfig([...contentBlockConfigs], payload),
 			};
-		},
-	});
+		case ContentEditActionType.REORDER_CONTENT_BLOCK_CONFIG:
+			return {
+				...state,
+				contentBlockConfigs: reorderConfigs([...contentBlockConfigs], payload),
+			};
+		case ContentEditActionType.SET_CONTENT_BLOCK_CONFIGS:
+			return {
+				...state,
+				contentBlockConfigs: payload,
+			};
+		case ContentEditActionType.ADD_COMPONENTS_STATE:
+			return {
+				...state,
+				contentBlockConfigs: addComponentState([...contentBlockConfigs], payload),
+			};
+		case ContentEditActionType.REMOVE_COMPONENTS_STATE:
+			return {
+				...state,
+				contentBlockConfigs: removeComponentState([...contentBlockConfigs], payload),
+			};
+		case ContentEditActionType.SET_COMPONENTS_STATE:
+			return {
+				...state,
+				contentBlockConfigs: setComponentState([...contentBlockConfigs], payload),
+			};
+		case ContentEditActionType.SET_BLOCK_STATE:
+			return {
+				...state,
+				contentBlockConfigs: setBlockState([...contentBlockConfigs], payload),
+			};
+
+		default:
+			return state;
+	}
+};

--- a/src/admin/content/views/ContentEdit.tsx
+++ b/src/admin/content/views/ContentEdit.tsx
@@ -54,12 +54,11 @@ interface ContentEditProps extends DefaultSecureRouteProps<{ id?: string }> {}
 
 const ContentEdit: FunctionComponent<ContentEditProps> = ({ history, match, user }) => {
 	const { id } = match.params;
-	const initialState = CONTENT_EDIT_INITIAL_STATE();
 
 	// Hooks
 	const [{ contentBlockConfigs }, dispatch] = useReducer<
 		Reducer<ContentEditState, ContentEditAction>
-	>(contentEditReducer(initialState), initialState);
+	>(contentEditReducer, CONTENT_EDIT_INITIAL_STATE());
 
 	const [formErrors, setFormErrors] = useState<ContentEditFormErrors>({});
 	const [configToDelete, setConfigToDelete] = useState<number>();

--- a/src/admin/content/views/ContentEditContentBlocks.tsx
+++ b/src/admin/content/views/ContentEditContentBlocks.tsx
@@ -78,7 +78,7 @@ const ContentEditContentBlocks: FunctionComponent<ContentEditContentBlocksProps>
 
 			return (
 				<ContentBlockForm
-					key={createKey('e', index)}
+					key={createKey('form', index)}
 					config={contentBlockConfig}
 					blockIndex={index}
 					isAccordionOpen={accordionsOpenState[contentBlockFormKey] || false}
@@ -110,7 +110,7 @@ const ContentEditContentBlocks: FunctionComponent<ContentEditContentBlocksProps>
 
 			return (
 				<ContentBlockPreview
-					key={createKey('p', blockIndex)}
+					key={createKey('preview', blockIndex)}
 					componentState={components.state}
 					contentWidth={contentWidth}
 					blockState={block.state}


### PR DESCRIPTION
* Fixes content-edit reducer being run twice
* Disable cb reorder buttons i/o hinding them
* Tried some other different things to prevent crash when reordering/deleting cb configs