### PR TITLE
feat(cb-heading): add ‘h1’ option

### DIFF
--- a/src/admin/content-block/content-block.const.ts
+++ b/src/admin/content-block/content-block.const.ts
@@ -95,6 +95,7 @@ export const CONTENT_BLOCK_INITIAL_STATE_MAP = {
 
 // Options
 export const HEADING_LEVEL_OPTIONS: SelectOption<HeadingLevelOptions>[] = [
+	{ label: i18n.t('H1'), value: 'h1' },
 	{ label: i18n.t('H2'), value: 'h2' },
 	{ label: i18n.t('H3'), value: 'h3' },
 	{ label: i18n.t('H4'), value: 'h4' },

--- a/src/admin/content-block/content-block.types.ts
+++ b/src/admin/content-block/content-block.types.ts
@@ -11,7 +11,7 @@ export type ContentBlockStateOptions =
 
 export type AlignOptions = 'left' | 'right' | 'center';
 
-export type HeadingLevelOptions = 'h2' | 'h3' | 'h4';
+export type HeadingLevelOptions = 'h1' | 'h2' | 'h3' | 'h4';
 
 export type ButtonTypeOptions = 'primary' | 'secondary';
 

--- a/src/admin/content-block/helpers/generators/ctas.ts
+++ b/src/admin/content-block/helpers/generators/ctas.ts
@@ -13,7 +13,7 @@ import {
 import { CONTENT_BLOCK_FIELD_DEFAULTS, FORM_STATE_DEFAULTS, TEXT_FIELD } from './defaults';
 
 const EMPTY_CTA: CTAsBlockComponentState = {
-	headingType: 'h2',
+	headingType: 'h1',
 	heading: '',
 	content: '',
 	buttonType: 'secondary',

--- a/src/admin/content-block/helpers/generators/heading.ts
+++ b/src/admin/content-block/helpers/generators/heading.ts
@@ -18,7 +18,7 @@ import {
 
 export const INITIAL_HEADING_BLOCK_COMPONENT_STATE = (): HeadingBlockComponentState => ({
 	children: '',
-	type: 'h2',
+	type: 'h1',
 	align: 'left',
 });
 


### PR DESCRIPTION
Na deze optie 3 weken geleden te moeten wegnemen, moet deze er weer bij. 😅 

- Selecteren van H1 voor Titel en CTA bok.