### PR TITLE
fix(content-block-form): improve location of delete button

### DIFF
--- a/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
+++ b/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
@@ -115,6 +115,7 @@ const ContentBlockForm: FunctionComponent<ContentBlockFormProps> = ({
 						icon="delete"
 						type="danger"
 						onClick={() => removeComponentFromState(stateIndex)}
+						size="small"
 					/>
 				</FlexItem>
 			)
@@ -139,9 +140,9 @@ const ContentBlockForm: FunctionComponent<ContentBlockFormProps> = ({
 			<Spacer margin="top-small">
 				{isArray(formGroup.state) ? (
 					formGroup.state.map((formGroupState, stateIndex) => (
-						<Spacer key={stateIndex} margin="bottom-small">
-							<BlockHeading type="h4" className="u-m-t-0">
-								<Toolbar>
+						<Spacer key={stateIndex} margin="bottom">
+							<BlockHeading type="h4" className="u-m-t-0 u-spacer-bottom-s">
+								<Toolbar autoHeight>
 									<ToolbarLeft>{`${get(config, 'components.name')} ${stateIndex + 1}`}</ToolbarLeft>
 									<ToolbarRight>{renderRemoveButton(stateIndex)}</ToolbarRight>
 								</Toolbar>

--- a/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
+++ b/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
@@ -14,6 +14,9 @@ import {
 	FlexItem,
 	Form,
 	Spacer,
+	Toolbar,
+	ToolbarLeft,
+	ToolbarRight,
 } from '@viaa/avo2-components';
 
 import {
@@ -138,7 +141,10 @@ const ContentBlockForm: FunctionComponent<ContentBlockFormProps> = ({
 					formGroup.state.map((formGroupState, stateIndex) => (
 						<Spacer key={stateIndex} margin="bottom-small">
 							<BlockHeading type="h4" className="u-m-t-0">
-								{`${get(config, 'components.name')} ${stateIndex + 1}`}
+								<Toolbar>
+									<ToolbarLeft>{`${get(config, 'components.name')} ${stateIndex + 1}`}</ToolbarLeft>
+									<ToolbarRight>{renderRemoveButton(stateIndex)}</ToolbarRight>
+								</Toolbar>
 							</BlockHeading>
 							<Flex spaced="regular" wrap>
 								<FlexItem>
@@ -149,7 +155,6 @@ const ContentBlockForm: FunctionComponent<ContentBlockFormProps> = ({
 										stateIndex={stateIndex}
 									/>
 								</FlexItem>
-								{renderRemoveButton(stateIndex)}
 							</Flex>
 						</Spacer>
 					))

--- a/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
+++ b/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
@@ -222,7 +222,7 @@ const ContentBlockForm: FunctionComponent<ContentBlockFormProps> = ({
 							title={t(
 								'admin/content-block/components/content-block-form/content-block-form___verwijder-content-block'
 							)}
-							type="tertiary"
+							type="danger"
 						/>
 					</ButtonToolbar>
 				</AccordionActions>

--- a/src/admin/content-block/components/ContentBlockFormGroup/ContentBlockFormGroup.tsx
+++ b/src/admin/content-block/components/ContentBlockFormGroup/ContentBlockFormGroup.tsx
@@ -42,31 +42,24 @@ export const ContentBlockFormGroup: FunctionComponent<ContentBlockFormGroupProps
 	formErrors,
 }) => (
 	<div className="c-content-block-form-group">
-		{Object.keys(formGroup.fields).map((key: string, formGroupIndex: number) => {
-			const formGroupOptions = {
-				key: createKey('form-group', blockIndex, formGroupIndex, stateIndex),
-				label: formGroup.fields[key].label,
-			};
-
-			return (
-				<Spacer margin="bottom">
-					<FormGroup
-						{...formGroupOptions}
-						error={formErrors[key as keyof ContentBlockComponentState | keyof ContentBlockState]}
-					>
-						<ContentBlockFieldEditor
-							block={{ config, index: blockIndex }}
-							fieldKey={key as keyof ContentBlockComponentState | keyof ContentBlockState}
-							field={formGroup.fields[key]}
-							state={formGroupState}
-							type={formGroupType}
-							formGroupIndex={formGroupIndex}
-							stateIndex={stateIndex}
-							handleChange={handleChange}
-						/>
-					</FormGroup>
-				</Spacer>
-			);
-		})}
+		{Object.keys(formGroup.fields).map((key: string, formGroupIndex: number) => (
+			<Spacer key={createKey('form-group', blockIndex, formGroupIndex, stateIndex)} margin="bottom">
+				<FormGroup
+					label={formGroup.fields[key].label}
+					error={formErrors[key as keyof ContentBlockComponentState | keyof ContentBlockState]}
+				>
+					<ContentBlockFieldEditor
+						block={{ config, index: blockIndex }}
+						fieldKey={key as keyof ContentBlockComponentState | keyof ContentBlockState}
+						field={formGroup.fields[key]}
+						state={formGroupState}
+						type={formGroupType}
+						formGroupIndex={formGroupIndex}
+						stateIndex={stateIndex}
+						handleChange={handleChange}
+					/>
+				</FormGroup>
+			</Spacer>
+		))}
 	</div>
 );


### PR DESCRIPTION
## make delete button red for content blocks

![image](https://user-images.githubusercontent.com/1710840/73940932-9f480380-48ec-11ea-85fe-9dc855947e7d.png)




## change location of delete button inside content block to be next to the title of the block

before:
![image](https://user-images.githubusercontent.com/1710840/73940699-32346e00-48ec-11ea-8e64-bdd2ab4cc901.png)


after:
![image](https://user-images.githubusercontent.com/1710840/73940660-2052cb00-48ec-11ea-98d4-098360e5b9ae.png)
