### PR TITLE
fix(content-edit): check if path isn't current content page path

### DIFF
--- a/src/admin/content/views/ContentEdit.tsx
+++ b/src/admin/content/views/ContentEdit.tsx
@@ -217,7 +217,7 @@ const ContentEdit: FunctionComponent<ContentEditProps> = ({ history, match, user
 				variables: { path: contentForm.path },
 			});
 			const page: Avo.Content.Content | undefined = get(response, 'data.app_content[0]');
-			if (page) {
+			if (page && String(page.id) !== id) {
 				errors.path = t('Dit path is reeds gebruikt door pagina: {{pageTitle}}', {
 					pageTitle: page.title,
 				});

--- a/src/content-page/views/ContentPage.tsx
+++ b/src/content-page/views/ContentPage.tsx
@@ -9,6 +9,7 @@ import { Avo } from '@viaa/avo2-types';
 import { ContentBlockPreview } from '../../admin/content-block/components';
 import { ContentBlockConfig } from '../../admin/content-block/content-block.types';
 import { parseContentBlocks } from '../../admin/content-block/helpers';
+import { SpecialPermissionGroups } from '../../admin/menu/views/MenuEdit';
 import { DefaultSecureRouteProps } from '../../authentication/components/SecuredRoute';
 import { ErrorActionButton } from '../../error/views/ErrorView';
 import { DataQueryComponent } from '../../shared/components';
@@ -43,7 +44,10 @@ const ContentPage: FunctionComponent<ContentPageDetailProps> = ({ match, user })
 
 	const renderContentPage = (contentPage: Avo.Content.Content) => {
 		const pageUserGroups: number[] = (contentPage as any).user_group_ids || []; // TODO remove cast to any when typings v2.10.0 is released
-		const userUserGroups: number[] = [...get(user, 'profile.userGroupIds', []), user ? -2 : -1]; // Ingelogde gebruiker en niet ingelogde gebruiker
+		const userUserGroups: number[] = [
+			...get(user, 'profile.userGroupIds', []),
+			user ? SpecialPermissionGroups.loggedInUsers : SpecialPermissionGroups.loggedOutUsers,
+		];
 		if (!intersection(pageUserGroups, userUserGroups).length) {
 			// User isn't allowed to see this page (this will in the future also be checked by the graphql instance
 			setErrorInfo({


### PR DESCRIPTION
When adding a path to a content page, we check if the path is unique by doing a query if the path already exists in the database

We should check if it already exists and if this existing content page isn't equal to the content page that is currently being edited