### PR TITLE
fix(admin-content): prevent sidebar being pushed by long content

### DIFF
--- a/src/admin/content-block/components/ContentBlockPreview/ContentBlockPreview.tsx
+++ b/src/admin/content-block/components/ContentBlockPreview/ContentBlockPreview.tsx
@@ -121,9 +121,16 @@ const ContentBlockPreview: FunctionComponent<ContentBlockPreviewProps> = ({
 		// TODO: Extend spacer with paddings in components lib
 		// This way we can easily set paddings from a content-blocks blockState
 		<div
-			className={classnames(`u-bg-${blockState.backgroundColor} u-padding`, {
-				'u-color-white': DARK_BACKGROUND_COLOR_OPTIONS.includes(blockState.backgroundColor),
-			})}
+			className={classnames(
+				'c-content-block-preview',
+				`u-bg-${blockState.backgroundColor}`,
+				'u-padding',
+				{
+					'u-color-white': DARK_BACKGROUND_COLOR_OPTIONS.includes(
+						blockState.backgroundColor
+					),
+				}
+			)}
 		>
 			<Container
 				mode="horizontal"

--- a/src/admin/content-block/content-block.const.ts
+++ b/src/admin/content-block/content-block.const.ts
@@ -1,6 +1,8 @@
 import {
 	ButtonType,
 	Checkbox,
+	ContentItemStyle,
+	ContentTabStyle,
 	MultiRange,
 	Select,
 	SelectOption,
@@ -8,11 +10,6 @@ import {
 	TextInput,
 	WYSIWYG,
 } from '@viaa/avo2-components';
-import {
-	// TODO: Export from comp lib.
-	ContentItemStyle,
-	ContentTabStyle,
-} from '@viaa/avo2-components/dist/content-blocks/BlockPageOverview/BlockPageOverview';
 
 import { FileUpload } from '../../shared/components';
 import i18n from '../../shared/translations/i18n';

--- a/src/admin/content-block/helpers/generators/image-grid.ts
+++ b/src/admin/content-block/helpers/generators/image-grid.ts
@@ -1,5 +1,5 @@
+import { GridItem } from '@viaa/avo2-components';
 import { MultiRangeProps } from '@viaa/avo2-components/dist/components/MultiRange/MultiRange';
-import { GridItem } from '@viaa/avo2-components/dist/content-blocks/BlockGrid/BlockGrid';
 
 import { FileUploadProps } from '../../../../shared/components/FileUpload/FileUpload';
 import i18n from '../../../../shared/translations/i18n';

--- a/src/admin/content/views/ContentEdit.scss
+++ b/src/admin/content/views/ContentEdit.scss
@@ -4,6 +4,14 @@
 	flex: 1 1 auto;
 }
 
+.c-content-edit-view__preview {
+	overflow-x: hidden;
+
+	.o-container {
+		overflow-x: hidden;
+	}
+}
+
 .c-content-edit-view__sidebar {
 	max-width: 45%;
 	height: auto;

--- a/src/admin/content/views/ContentEdit.scss
+++ b/src/admin/content/views/ContentEdit.scss
@@ -7,12 +7,9 @@
 .c-content-edit-view__preview {
 	overflow-x: hidden;
 
-	.o-container {
-		overflow-x: hidden;
-	}
-
-	.c-content > p {
+	.c-content-block-preview > .o-container {
 		overflow-wrap: break-word;
+		overflow-x: hidden;
 	}
 }
 

--- a/src/admin/content/views/ContentEdit.scss
+++ b/src/admin/content/views/ContentEdit.scss
@@ -10,6 +10,10 @@
 	.o-container {
 		overflow-x: hidden;
 	}
+
+	.c-content > p {
+		overflow-wrap: break-word;
+	}
 }
 
 .c-content-edit-view__sidebar {

--- a/src/admin/content/views/ContentEditContentBlocks.tsx
+++ b/src/admin/content/views/ContentEditContentBlocks.tsx
@@ -125,7 +125,7 @@ const ContentEditContentBlocks: FunctionComponent<ContentEditContentBlocksProps>
 
 	return (
 		<Flex className="c-content-edit-view__content">
-			<FlexItem>{renderBlockPreviews()}</FlexItem>
+			<FlexItem className="c-content-edit-view__preview">{renderBlockPreviews()}</FlexItem>
 			<Sidebar className="c-content-edit-view__sidebar" light>
 				{renderContentBlockForms()}
 				<Form>

--- a/src/admin/shared/types/content-block.ts
+++ b/src/admin/shared/types/content-block.ts
@@ -3,9 +3,9 @@ import {
 	ButtonType,
 	ContentItemStyle,
 	ContentTabStyle,
+	GridItem,
 	IconName,
 } from '@viaa/avo2-components';
-import { GridItem } from '@viaa/avo2-components/dist/content-blocks/BlockGrid/BlockGrid'; // TODO: import from components library when exported.
 import { Avo } from '@viaa/avo2-types';
 
 import { ContentPageType } from '../../content/content.types';

--- a/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.tsx
+++ b/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent, useState } from 'react';
 
-import { FlowPlayer } from '@viaa/avo2-components';
-import { FlowPlayerProps } from '@viaa/avo2-components/dist/components/FlowPlayer/FlowPlayer';
+import { FlowPlayer, FlowPlayerProps } from '@viaa/avo2-components';
 
 import { CustomError } from '../../helpers';
 import { BookmarksViewsPlaysService } from '../../services/bookmarks-views-plays-service';


### PR DESCRIPTION
Heb dit al even staan, zorgt ervoor dat de sidebar niet meer opzij wordt geduwd bij lange woorden in previews (niet dat dit veel gaat voorkomen normaal gezien)