### PR TITLE
Bugfix/content blocks perf

### DIFF
--- a/src/admin/content-block/components/ContentBlockFieldEditor/ContentBlockFieldEditor.tsx
+++ b/src/admin/content-block/components/ContentBlockFieldEditor/ContentBlockFieldEditor.tsx
@@ -1,4 +1,4 @@
-import { get, isArray, isNil } from 'lodash-es';
+import { debounce, get, isArray, isNil } from 'lodash-es';
 import React, { FunctionComponent } from 'react';
 
 import { SelectOption } from '@viaa/avo2-components';
@@ -110,6 +110,17 @@ const ContentBlockFieldEditor: FunctionComponent<ContentBlockFieldProps> = ({
 			editorProps = {
 				onChange: (value: any) => handleChange(type, fieldKey, value, stateIndex),
 				checked: (state as any)[fieldKey],
+			};
+			break;
+		case ContentBlockEditor.TextArea:
+		case ContentBlockEditor.TextInput:
+			editorProps = {
+				onChange: debounce(
+					(value: any) => handleChange(type, fieldKey, value, stateIndex),
+					150,
+					{ leading: true }
+				),
+				value: (state as any)[fieldKey],
 			};
 			break;
 		default:

--- a/src/admin/content-block/components/ContentBlockFieldEditor/ContentBlockFieldEditor.tsx
+++ b/src/admin/content-block/components/ContentBlockFieldEditor/ContentBlockFieldEditor.tsx
@@ -32,7 +32,7 @@ interface ContentBlockFieldProps {
 	) => void;
 }
 
-export const ContentBlockFieldEditor: FunctionComponent<ContentBlockFieldProps> = ({
+const ContentBlockFieldEditor: FunctionComponent<ContentBlockFieldProps> = ({
 	block,
 	fieldKey,
 	formGroupIndex,
@@ -124,3 +124,5 @@ export const ContentBlockFieldEditor: FunctionComponent<ContentBlockFieldProps> 
 
 	return <EditorComponent {...defaultProps} {...editorProps} />;
 };
+
+export default React.memo(ContentBlockFieldEditor);

--- a/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
+++ b/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
@@ -268,7 +268,8 @@ const ContentBlockForm: FunctionComponent<ContentBlockFormProps> = ({
 
 export default React.memo(ContentBlockForm, (prevProps, nextProps) => {
 	let areEqual = false;
-
+	// We don't need to check the other props because they are functions
+	// which will never change
 	if (
 		isEqual(prevProps.config, nextProps.config) &&
 		prevProps.isAccordionOpen === nextProps.isAccordionOpen &&
@@ -277,6 +278,6 @@ export default React.memo(ContentBlockForm, (prevProps, nextProps) => {
 	) {
 		areEqual = true;
 	}
-
+	// The component will rerender when false is returned
 	return areEqual;
 });

--- a/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
+++ b/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
@@ -267,17 +267,12 @@ const ContentBlockForm: FunctionComponent<ContentBlockFormProps> = ({
 };
 
 export default React.memo(ContentBlockForm, (prevProps, nextProps) => {
-	let areEqual = false;
-	// We don't need to check the other props because they are functions
-	// which will never change
-	if (
+	// We don't need to check the other props because they are functions which will never change
+	// The component will rerender when false is returned
+	return (
 		isEqual(prevProps.config, nextProps.config) &&
 		prevProps.isAccordionOpen === nextProps.isAccordionOpen &&
 		prevProps.blockIndex === nextProps.blockIndex &&
 		prevProps.length === nextProps.length
-	) {
-		areEqual = true;
-	}
-	// The component will rerender when false is returned
-	return areEqual;
+	);
 });

--- a/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
+++ b/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.tsx
@@ -1,4 +1,4 @@
-import { get, isNil, isNumber } from 'lodash-es';
+import { get, isEqual, isNil, isNumber } from 'lodash-es';
 import React, { FunctionComponent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -29,7 +29,7 @@ import {
 	ContentBlockStateType,
 } from '../../../shared/types';
 
-import { ContentBlockFormGroup } from '../ContentBlockFormGroup/ContentBlockFormGroup';
+import ContentBlockFormGroup from '../ContentBlockFormGroup/ContentBlockFormGroup';
 import { REPEATABLE_CONTENT_BLOCKS } from '../ContentBlockPreview/ContentBlockPreview.const';
 
 import './ContentBlockForm.scss';
@@ -266,4 +266,17 @@ const ContentBlockForm: FunctionComponent<ContentBlockFormProps> = ({
 	return <Form className="c-content-block-form">{renderBlockForm(config)}</Form>;
 };
 
-export default ContentBlockForm;
+export default React.memo(ContentBlockForm, (prevProps, nextProps) => {
+	let areEqual = false;
+
+	if (
+		isEqual(prevProps.config, nextProps.config) &&
+		prevProps.isAccordionOpen === nextProps.isAccordionOpen &&
+		prevProps.blockIndex === nextProps.blockIndex &&
+		prevProps.length === nextProps.length
+	) {
+		areEqual = true;
+	}
+
+	return areEqual;
+});

--- a/src/admin/content-block/components/ContentBlockFormGroup/ContentBlockFormGroup.tsx
+++ b/src/admin/content-block/components/ContentBlockFormGroup/ContentBlockFormGroup.tsx
@@ -14,7 +14,7 @@ import {
 	ContentBlockStateType,
 } from '../../../shared/types';
 
-import { ContentBlockFieldEditor } from '../ContentBlockFieldEditor/ContentBlockFieldEditor';
+import ContentBlockFieldEditor from '../ContentBlockFieldEditor/ContentBlockFieldEditor';
 
 interface ContentBlockFormGroupProps {
 	config: ContentBlockConfig;
@@ -32,7 +32,7 @@ interface ContentBlockFormGroupProps {
 	formErrors: ContentBlockFormError;
 }
 
-export const ContentBlockFormGroup: FunctionComponent<ContentBlockFormGroupProps> = ({
+const ContentBlockFormGroup: FunctionComponent<ContentBlockFormGroupProps> = ({
 	config,
 	blockIndex,
 	formGroup,
@@ -77,3 +77,5 @@ export const ContentBlockFormGroup: FunctionComponent<ContentBlockFormGroupProps
 		})}
 	</div>
 );
+
+export default React.memo(ContentBlockFormGroup);


### PR DESCRIPTION
**Problem**: When adding many content-blocks on the edit page, editing in the input, textarea and wysiwig field-editors was practically unusable (slow performance).

**Cause**: Each content-block form gets re-rendered when a single one gets updated. This was really visible when typing in one of the editors mentioned above.

**Solution**: 
* Add `React.memo` to the smallest parts (form-group and field-editor components) in the chain
* Add `React.memo` and custom compare function for the form component. This is where we got the biggest performance gain.
* Debounce TextInput and Textarea editors onChange handlers to trigger less dispatches