### PR TITLE
feat(permission-group-overview): use filter table for permission groups

### DIFF
--- a/src/admin/permission-groups/permission-group.const.ts
+++ b/src/admin/permission-groups/permission-group.const.ts
@@ -2,6 +2,7 @@ import { TableColumn } from '@viaa/avo2-components';
 
 import { ROUTE_PARTS } from '../../shared/constants';
 import i18n from '../../shared/translations/i18n';
+import { FilterableColumn } from '../shared/components/FilterTable/FilterTable';
 
 export const PERMISSION_GROUP_PATH = {
 	PERMISSION_GROUP_OVERVIEW: `/${ROUTE_PARTS.admin}/${ROUTE_PARTS.permissionGroups}`,
@@ -12,7 +13,7 @@ export const PERMISSION_GROUP_PATH = {
 
 export const ITEMS_PER_PAGE = 10;
 
-export const PERMISSION_GROUP_OVERVIEW_TABLE_COLS: TableColumn[] = [
+export const PERMISSION_GROUP_OVERVIEW_TABLE_COLS: FilterableColumn[] = [
 	{
 		id: 'label',
 		label: i18n.t('admin/permission-groups/permission-group___naam'),
@@ -27,11 +28,13 @@ export const PERMISSION_GROUP_OVERVIEW_TABLE_COLS: TableColumn[] = [
 		id: 'created_at',
 		label: i18n.t('admin/permission-groups/permission-group___gemaakt-op'),
 		sortable: true,
+		filterType: 'DateRangeDropdown',
 	},
 	{
 		id: 'updated_at',
 		label: i18n.t('admin/permission-groups/permission-group___aangepast-op'),
 		sortable: true,
+		filterType: 'DateRangeDropdown',
 	},
 	{ id: 'actions', label: '' },
 ];

--- a/src/admin/permission-groups/permission-group.gql.ts
+++ b/src/admin/permission-groups/permission-group.gql.ts
@@ -2,30 +2,19 @@ import { gql } from 'apollo-boost';
 
 export const GET_PERMISSION_GROUPS = gql`
 	query getAllPermissionGroups(
+		$where: users_permission_groups_bool_exp!
 		$offset: Int!
 		$limit: Int!
 		$orderBy: [users_permission_groups_order_by!]!
-		$queryText: String!
 	) {
-		users_permission_groups(
-			offset: $offset
-			limit: $limit
-			order_by: $orderBy
-			where: {
-				_or: [{ label: { _ilike: $queryText } }, { description: { _ilike: $queryText } }]
-			}
-		) {
+		users_permission_groups(offset: $offset, limit: $limit, order_by: $orderBy, where: $where) {
 			label
 			description
 			created_at
 			updated_at
 			id
 		}
-		users_permission_groups_aggregate(
-			where: {
-				_or: [{ label: { _ilike: $queryText } }, { description: { _ilike: $queryText } }]
-			}
-		) {
+		users_permission_groups_aggregate(where: $where) {
 			aggregate {
 				count
 			}

--- a/src/admin/permission-groups/permission-group.service.ts
+++ b/src/admin/permission-groups/permission-group.service.ts
@@ -28,15 +28,15 @@ export class PermissionGroupService {
 		page: number,
 		sortColumn: PermissionGroupOverviewTableCols,
 		sortOrder: Avo.Search.OrderDirection,
-		queryText: string
+		where: any
 	): Promise<[PermissionGroup[], number]> {
 		let variables: any;
 		try {
 			variables = {
+				where,
 				offset: ITEMS_PER_PAGE * page,
 				limit: ITEMS_PER_PAGE,
 				orderBy: [{ [sortColumn]: sortOrder }],
-				queryText: `%${queryText}%`,
 			};
 			const response = await dataService.query({
 				variables,

--- a/src/admin/permission-groups/permission-group.types.ts
+++ b/src/admin/permission-groups/permission-group.types.ts
@@ -1,3 +1,5 @@
+import { FilterableTableState } from '../shared/components/FilterTable/FilterTable';
+
 export type PermissionGroupOverviewTableCols =
 	| 'label'
 	| 'description'
@@ -27,4 +29,11 @@ export interface Permission {
 export interface PermissionGroupEditFormErrorState {
 	label?: string;
 	description?: string;
+}
+
+export interface PermissionGroupTableState extends FilterableTableState {
+	label: string;
+	description: string | null;
+	created_at: string;
+	updated_at: string;
 }

--- a/src/admin/permission-groups/views/PermissionGroupOverview.tsx
+++ b/src/admin/permission-groups/views/PermissionGroupOverview.tsx
@@ -1,27 +1,8 @@
 import { isNil } from 'lodash-es';
-import React, {
-	FunctionComponent,
-	KeyboardEvent,
-	ReactElement,
-	useCallback,
-	useEffect,
-	useState,
-} from 'react';
+import React, { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import {
-	Button,
-	ButtonToolbar,
-	Container,
-	Form,
-	FormGroup,
-	Pagination,
-	Spacer,
-	Table,
-	TextInput,
-	Toolbar,
-	ToolbarRight,
-} from '@viaa/avo2-components';
+import { Button, ButtonToolbar, Container } from '@viaa/avo2-components';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
 import { ErrorView } from '../../../error/views';
@@ -31,9 +12,10 @@ import {
 	LoadingInfo,
 } from '../../../shared/components';
 import { formatDate, navigate } from '../../../shared/helpers';
-import { useTableSort } from '../../../shared/hooks';
 import { ToastService } from '../../../shared/services';
-import { KeyCode } from '../../../shared/types';
+import { ItemsTableState } from '../../items/items.types';
+import FilterTable, { getFilters } from '../../shared/components/FilterTable/FilterTable';
+import { getDateRangeFilters, getQueryFilter } from '../../shared/helpers/filters';
 import { AdminLayout, AdminLayoutActions, AdminLayoutBody } from '../../shared/layouts';
 
 import {
@@ -42,7 +24,11 @@ import {
 	PERMISSION_GROUP_PATH,
 } from '../permission-group.const';
 import { PermissionGroupService } from '../permission-group.service';
-import { PermissionGroup, PermissionGroupOverviewTableCols } from '../permission-group.types';
+import {
+	PermissionGroup,
+	PermissionGroupOverviewTableCols,
+	PermissionGroupTableState,
+} from '../permission-group.types';
 import './PermissionGroupOverview.scss';
 
 interface PermissionGroupOverviewProps extends DefaultSecureRouteProps {}
@@ -53,27 +39,33 @@ const PermissionGroupOverview: FunctionComponent<PermissionGroupOverviewProps> =
 	const [permissionGroupCount, setPermissionGroupCount] = useState<number>(0);
 	const [permissionGroupIdToDelete, setPermissionGroupIdToDelete] = useState<number | null>(null);
 	const [isConfirmModalOpen, setIsConfirmModalOpen] = useState<boolean>(false);
-	const [queryText, setQueryText] = useState<string>('');
-	const [searchTerm, setSearchTerm] = useState<string>('');
-	const [page, setPage] = useState<number>(0);
 	const [loadingInfo, setLoadingInfo] = useState<LoadingInfo>({ state: 'loading' });
-
-	const [sortColumn, sortOrder, handleSortClick] = useTableSort<PermissionGroupOverviewTableCols>(
-		'updated_at'
-	);
+	const [tableState, setTableState] = useState<Partial<PermissionGroupTableState>>({});
 
 	const [t] = useTranslation();
 
 	const fetchPermissionGroups = useCallback(async () => {
+		const generateWhereObject = (filters: Partial<ItemsTableState>) => {
+			const andFilters: any[] = [];
+			andFilters.push(
+				...getQueryFilter(filters.query, (queryWordWildcard: string) => [
+					{ title: { _ilike: queryWordWildcard } },
+					{ description: { _ilike: queryWordWildcard } },
+				])
+			);
+			andFilters.push(...getDateRangeFilters(filters, ['created_at', 'updated_at']));
+			return { _and: andFilters };
+		};
+
 		try {
 			const [
 				permissionGroupTemp,
 				permissionGroupCountTemp,
 			] = await PermissionGroupService.fetchPermissionGroups(
-				page,
-				sortColumn,
-				sortOrder,
-				queryText
+				tableState.page || 0,
+				(tableState.sort_column || 'updated_at') as PermissionGroupOverviewTableCols,
+				tableState.sort_order || 'desc',
+				generateWhereObject(getFilters(tableState))
 			);
 
 			setPermissionGroups(permissionGroupTemp);
@@ -86,7 +78,7 @@ const PermissionGroupOverview: FunctionComponent<PermissionGroupOverviewProps> =
 				),
 			});
 		}
-	}, [setPermissionGroups, setLoadingInfo, t, page, queryText, sortColumn, sortOrder]);
+	}, [setPermissionGroups, setLoadingInfo, t, tableState]);
 
 	useEffect(() => {
 		fetchPermissionGroups();
@@ -113,12 +105,6 @@ const PermissionGroupOverview: FunctionComponent<PermissionGroupOverviewProps> =
 	const openModal = (permissionGroup: PermissionGroup): void => {
 		setIsConfirmModalOpen(true);
 		setPermissionGroupIdToDelete(permissionGroup.id);
-	};
-
-	const handleKeyUp = (e: KeyboardEvent<HTMLInputElement>) => {
-		if (e.keyCode === KeyCode.Enter) {
-			setQueryText(searchTerm);
-		}
 	};
 
 	// Render
@@ -186,11 +172,8 @@ const PermissionGroupOverview: FunctionComponent<PermissionGroupOverviewProps> =
 		}
 	};
 
-	const renderPermissionGroupTable = () => {
-		if (!permissionGroups) {
-			return;
-		}
-		return !permissionGroups.length ? (
+	const renderNoResults = () => {
+		return (
 			<ErrorView
 				message={t(
 					'admin/permission-groups/views/permission-group-overview___er-zijn-nog-geen-permissie-groepen-aangemaakt'
@@ -202,80 +185,32 @@ const PermissionGroupOverview: FunctionComponent<PermissionGroupOverviewProps> =
 					</Trans>
 				</p>
 			</ErrorView>
-		) : (
+		);
+	};
+
+	const renderPermissionGroupTable = () => {
+		return (
 			<>
-				<Table
+				<FilterTable
 					columns={PERMISSION_GROUP_OVERVIEW_TABLE_COLS}
-					data={permissionGroups}
-					emptyStateMessage={
-						queryText
-							? t(
-									'admin/permission-groups/views/permission-group-overview___er-zijn-geen-permissie-groepen-gevonden-die-voldoen-aan-je-zoekterm'
-							  )
-							: t(
-									'admin/permission-groups/views/permission-group-overview___er-zijn-nog-geen-permissie-groepen-aangemaakt'
-							  )
-					}
-					onColumnClick={columId => {
-						setPage(0);
-						handleSortClick(columId as PermissionGroupOverviewTableCols);
-					}}
+					data={permissionGroups || []}
+					dataCount={permissionGroupCount}
 					renderCell={(rowData: PermissionGroup, columnId: string) =>
 						renderTableCell(rowData, columnId as PermissionGroupOverviewTableCols)
 					}
-					rowKey="id"
-					variant="bordered"
-					sortColumn={sortColumn}
-					sortOrder={sortOrder}
+					searchTextPlaceholder={t('Zoek op titel, beschrijving')}
+					renderNoResults={renderNoResults}
+					noContentMatchingFiltersMessage={t(
+						'admin/permission-groups/views/permission-group-overview___er-zijn-geen-permissie-groepen-gevonden-die-voldoen-aan-je-zoekterm'
+					)}
+					itemsPerPage={ITEMS_PER_PAGE}
+					onTableStateChanged={setTableState}
 				/>
-				<Spacer margin="top-small">
-					<Pagination
-						pageCount={Math.ceil(permissionGroupCount / ITEMS_PER_PAGE)}
-						onPageChange={setPage}
-						currentPage={page}
-					/>
-				</Spacer>
 				<DeleteObjectModal
 					deleteObjectCallback={() => handleDelete()}
 					isOpen={isConfirmModalOpen}
 					onClose={() => setIsConfirmModalOpen(false)}
 				/>
-			</>
-		);
-	};
-
-	const renderPermissionGroupFiltersAndBody = (): ReactElement => {
-		return (
-			<>
-				<Spacer margin="bottom-small">
-					<Toolbar>
-						<ToolbarRight>
-							<Form type="inline">
-								<FormGroup className="c-permission-group__search" inlineMode="grow">
-									<TextInput
-										placeholder={t(
-											'admin/permission-groups/views/permission-group-overview___zoek-op-naam-beschrijving'
-										)}
-										icon="search"
-										onChange={setSearchTerm}
-										onKeyUp={handleKeyUp}
-										value={searchTerm}
-									/>
-								</FormGroup>
-								<FormGroup inlineMode="shrink">
-									<Button
-										label={t(
-											'admin/permission-groups/views/permission-group-overview___zoeken'
-										)}
-										type="primary"
-										onClick={() => setQueryText(searchTerm)}
-									/>
-								</FormGroup>
-							</Form>
-						</ToolbarRight>
-					</Toolbar>
-				</Spacer>
-				{renderPermissionGroupTable()}
 			</>
 		);
 	};
@@ -292,7 +227,7 @@ const PermissionGroupOverview: FunctionComponent<PermissionGroupOverviewProps> =
 						<LoadingErrorLoadedComponent
 							loadingInfo={loadingInfo}
 							dataObject={permissionGroups}
-							render={renderPermissionGroupFiltersAndBody}
+							render={renderPermissionGroupTable}
 						/>
 					</Container>
 				</Container>

--- a/src/admin/permission-groups/views/PermissionGroupOverview.tsx
+++ b/src/admin/permission-groups/views/PermissionGroupOverview.tsx
@@ -198,7 +198,7 @@ const PermissionGroupOverview: FunctionComponent<PermissionGroupOverviewProps> =
 					renderCell={(rowData: PermissionGroup, columnId: string) =>
 						renderTableCell(rowData, columnId as PermissionGroupOverviewTableCols)
 					}
-					searchTextPlaceholder={t('Zoek op titel, beschrijving')}
+					searchTextPlaceholder={t('Zoek op naam, beschrijving')}
 					renderNoResults={renderNoResults}
 					noContentMatchingFiltersMessage={t(
 						'admin/permission-groups/views/permission-group-overview___er-zijn-geen-permissie-groepen-gevonden-die-voldoen-aan-je-zoekterm'

--- a/src/admin/user-groups/user-group.gql.ts
+++ b/src/admin/user-groups/user-group.gql.ts
@@ -26,27 +26,16 @@ export const GET_USER_GROUPS = gql`
 		$limit: Int!
 		$offset: Int!
 		$orderBy: [users_groups_order_by!]!
-		$queryText: String!
+		$where: users_groups_bool_exp!
 	) {
-		users_groups(
-			limit: $limit
-			offset: $offset
-			order_by: $orderBy
-			where: {
-				_or: [{ label: { _ilike: $queryText } }, { description: { _ilike: $queryText } }]
-			}
-		) {
+		users_groups(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
 			label
 			id
 			created_at
 			description
 			updated_at
 		}
-		users_groups_aggregate(
-			where: {
-				_or: [{ label: { _ilike: $queryText } }, { description: { _ilike: $queryText } }]
-			}
-		) {
+		users_groups_aggregate(where: $where) {
 			aggregate {
 				count
 			}

--- a/src/admin/user-groups/user-group.service.ts
+++ b/src/admin/user-groups/user-group.service.ts
@@ -21,15 +21,15 @@ export class UserGroupService {
 		page: number,
 		sortColumn: string,
 		sortOrder: Avo.Search.OrderDirection,
-		query: string
+		where: any
 	): Promise<[UserGroup[], number]> {
 		let variables: any;
 		try {
 			variables = {
+				where,
 				offset: ITEMS_PER_PAGE * page,
 				limit: ITEMS_PER_PAGE,
 				orderBy: [{ [sortColumn]: sortOrder }],
-				queryText: `%${query}%`,
 			};
 			const response = await dataService.query({
 				variables,


### PR DESCRIPTION
permission groups was build before we had the filter table, so we can unify this, resulting in less lines of code, more uniform code and better filter/sort capability

before:
![image](https://user-images.githubusercontent.com/1710840/76849748-4aca6900-6846-11ea-8543-627a479d0280.png)

after:
![image](https://user-images.githubusercontent.com/1710840/76849753-4c942c80-6846-11ea-816e-843ef9e7c8b1.png)
