### PR TITLE
feat(auth): add accept conditions page for new users

### DIFF
--- a/src/authentication/authentication.routes.tsx
+++ b/src/authentication/authentication.routes.tsx
@@ -6,6 +6,7 @@ import { APP_PATH } from '../constants';
 import { Login, Logout, RegisterOrLogin, RegisterStamboek } from './views';
 import StudentTeacher from './views/registration-flow/r10-student-teacher';
 import ManualRegistration from './views/registration-flow/r4-manual-registration';
+import AcceptConditions from './views/registration-flow/l8-accept-conditions';
 
 export const renderAuthenticationRoutes = (): ReactNode[] => [
 	<Route component={Login} exact path={APP_PATH.LOGIN.route} key={APP_PATH.LOGIN.route} />,
@@ -33,5 +34,11 @@ export const renderAuthenticationRoutes = (): ReactNode[] => [
 		exact
 		path={APP_PATH.REGISTER_OR_LOGIN.route}
 		key={APP_PATH.REGISTER_OR_LOGIN.route}
+	/>,
+	<Route
+		component={AcceptConditions}
+		exact
+		path={APP_PATH.ACCEPT_CONDITIONS.route}
+		key={APP_PATH.ACCEPT_CONDITIONS.route}
 	/>,
 ];

--- a/src/authentication/components/SecuredRoute.tsx
+++ b/src/authentication/components/SecuredRoute.tsx
@@ -103,20 +103,32 @@ const SecuredRoute: FunctionComponent<SecuredRouteProps> = ({
 							/>
 						);
 					}
-					if (isProfileComplete(user)) {
-						const Component = component;
-						return <Component {...props} user={user} />;
+					// TODO remove cast once update to typings 2.14.0
+					if (!(loginState as any).acceptedConditions) {
+						// Redirect to the accept user and privacy declaration
+						return (
+							<Redirect
+								to={{
+									pathname: APP_PATH.ACCEPT_CONDITIONS.route,
+									state: { from: props.location },
+								}}
+							/>
+						);
 					}
-					// Redirect to the complete profile route
-					// So we can redirect to the originally requested route once the user completes their profile info
-					return (
-						<Redirect
-							to={{
-								pathname: APP_PATH.COMPLETE_PROFILE.route,
-								state: { from: props.location },
-							}}
-						/>
-					);
+					if (!isProfileComplete(user)) {
+						// Redirect to the complete profile route
+						// So we can redirect to the originally requested route once the user completes their profile info
+						return (
+							<Redirect
+								to={{
+									pathname: APP_PATH.COMPLETE_PROFILE.route,
+									state: { from: props.location },
+								}}
+							/>
+						);
+					}
+					const Component = component;
+					return <Component {...props} user={user} />;
 				}
 
 				// On errors or not logged in => redirect to login or register page

--- a/src/authentication/store/selectors.ts
+++ b/src/authentication/store/selectors.ts
@@ -19,5 +19,9 @@ export const selectUser = ({ loginState }: AppState) => {
 };
 
 export const selectLoginMessage = ({ loginState }: AppState) => {
-	return get(loginState, ['data', 'loginMessage']);
+	return get(loginState, ['data', 'message']);
+};
+
+export const selectAcceptedConditions = ({ loginState }: AppState) => {
+	return get(loginState, ['data', 'acceptedConditions']);
 };

--- a/src/authentication/views/registration-flow/l8-accept-conditions.tsx
+++ b/src/authentication/views/registration-flow/l8-accept-conditions.tsx
@@ -1,0 +1,153 @@
+import { get } from 'lodash-es';
+import React, { FunctionComponent, useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import { Dispatch } from 'redux';
+
+import { Button, Spacer, Toolbar, ToolbarCenter } from '@viaa/avo2-components';
+import { Avo } from '@viaa/avo2-types';
+
+import { ContentPage } from '../../../content-page/views';
+import { LoadingErrorLoadedComponent, LoadingInfo } from '../../../shared/components';
+import { CustomError } from '../../../shared/helpers';
+import { ToastService } from '../../../shared/services';
+import { ContentPageService } from '../../../shared/services/content-page-service';
+import { NotificationService } from '../../../shared/services/notification-service';
+import { AppState } from '../../../store';
+import { DefaultSecureRouteProps } from '../../components/SecuredRoute';
+import { redirectToClientPage } from '../../helpers/redirects';
+import { getLoginStateAction } from '../../store/actions';
+import { selectLogin, selectUser } from '../../store/selectors';
+
+export const ACCEPTED_TERMS_OF_USE_AND_PRIVACY_CONDITIONS =
+	'ACCEPTED_TERMS_OF_USE_AND_PRIVACY_CONDITIONS';
+
+export interface AcceptConditionsProps extends DefaultSecureRouteProps {
+	getLoginState: () => Dispatch;
+	loginState: Avo.Auth.LoginResponse | null;
+}
+
+const AcceptConditions: FunctionComponent<AcceptConditionsProps> = ({
+	history,
+	location,
+	user,
+	getLoginState,
+	loginState,
+}) => {
+	const [t] = useTranslation();
+
+	// The term of use and the privacy conditions
+	const [pages, setPages] = useState<(Avo.Content.Content | null)[]>([]);
+	const [loadingInfo, setLoadingInfo] = useState<LoadingInfo>({ state: 'loading' });
+
+	const fetchContentPage = useCallback(async () => {
+		try {
+			setPages(
+				await Promise.all([
+					ContentPageService.getContentPageByPath('/gebruikersvoorwaarden'),
+					ContentPageService.getContentPageByPath('/privacy-voorwaarden'),
+				])
+			);
+		} catch (err) {
+			setLoadingInfo({
+				state: 'error',
+				message: t('Het ophalen van de gebruikers- en privacy voorwaarden is mislukt'),
+			});
+		}
+	}, [setLoadingInfo, setPages, t]);
+
+	useEffect(() => {
+		fetchContentPage();
+	}, [fetchContentPage]);
+
+	useEffect(() => {
+		if (pages && pages.length === 2) {
+			if (pages[0] && pages[1]) {
+				setLoadingInfo({ state: 'loaded' });
+			} else {
+				setLoadingInfo({
+					state: 'error',
+					message: t('Het ophalen van de gebruikers- en privacy voorwaarden is mislukt'),
+				});
+			}
+		}
+	}, [pages, t]);
+
+	useEffect(() => {
+		if (get(loginState, 'acceptConditions')) {
+			const fromRoute = get(location, 'state.from.pathname');
+			if (!fromRoute) {
+				throw new CustomError(
+					'Failed to navigate to previously requested route because location.state.from is not set',
+					null,
+					{ location }
+				);
+			}
+			redirectToClientPage(fromRoute, history);
+		}
+	}, [loginState, location, history]);
+
+	const handleAcceptConditions = async () => {
+		try {
+			await NotificationService.setNotification(
+				ACCEPTED_TERMS_OF_USE_AND_PRIVACY_CONDITIONS,
+				get(user, 'profile.id'),
+				true,
+				true
+			);
+
+			getLoginState();
+		} catch (err) {
+			console.error(
+				new CustomError('Failed to set accept conditions notification in the database')
+			);
+			ToastService.danger(t('Het opslaan van de accepteer condities is mislukt'));
+		}
+	};
+
+	const renderAcceptConditionsPage = () => {
+		return (
+			<>
+				<Spacer margin="bottom-large">
+					{/* terms of use */}
+					<ContentPage contentPage={pages[0] as Avo.Content.Content} />
+					{/* privacy conditions */}
+					<ContentPage contentPage={pages[1] as Avo.Content.Content} />
+				</Spacer>
+				<Spacer margin="large">
+					<Toolbar>
+						<ToolbarCenter>
+							<Button
+								label={t('Accepteer voorwaarden')}
+								type="primary"
+								onClick={handleAcceptConditions}
+							/>
+						</ToolbarCenter>
+					</Toolbar>
+				</Spacer>
+			</>
+		);
+	};
+
+	return (
+		<LoadingErrorLoadedComponent
+			loadingInfo={loadingInfo}
+			dataObject={pages[0]}
+			render={renderAcceptConditionsPage}
+		/>
+	);
+};
+
+const mapStateToProps = (state: AppState) => ({
+	user: selectUser(state),
+	loginState: selectLogin(state),
+});
+
+const mapDispatchToProps = (dispatch: Dispatch) => {
+	return {
+		getLoginState: () => dispatch(getLoginStateAction() as any),
+	};
+};
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(AcceptConditions));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -176,6 +176,11 @@ export const APP_PATH: Readonly<{ [pageId: string]: RouteInfo }> = {
 		showInContentPicker: true,
 		showForInteractiveTour: false,
 	},
+	ACCEPT_CONDITIONS: {
+		route: `/${ROUTE_PARTS.acceptConditions}`,
+		showInContentPicker: true,
+		showForInteractiveTour: false,
+	},
 	ERROR: {
 		route: `/${ROUTE_PARTS.error}`,
 		showInContentPicker: false,

--- a/src/content-page/views/ContentPage.tsx
+++ b/src/content-page/views/ContentPage.tsx
@@ -1,44 +1,18 @@
-import { intersection } from 'lodash-es';
 import React, { FunctionComponent } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import { Avo } from '@viaa/avo2-types';
 
 import { ContentBlockPreview } from '../../admin/content-block/components';
 import { parseContentBlocks } from '../../admin/content-block/helpers';
 import { ContentBlockConfig } from '../../admin/shared/types';
-import { getUserGroupIds } from '../../authentication/authentication.service';
-import { DefaultSecureRouteProps } from '../../authentication/components/SecuredRoute';
-import { ErrorView } from '../../error/views';
-import { CustomError } from '../../shared/helpers';
 
 import './ContentPage.scss';
 
-interface ContentPageDetailProps extends DefaultSecureRouteProps {
+interface ContentPageDetailProps {
 	contentPage: Avo.Content.Content;
 }
 
-const ContentPage: FunctionComponent<ContentPageDetailProps> = ({ contentPage, user }) => {
-	const [t] = useTranslation();
-
-	const pageUserGroups: number[] = contentPage.user_group_ids || [];
-	const userUserGroups: number[] = getUserGroupIds(user);
-	if (!intersection(pageUserGroups, userUserGroups).length) {
-		// User isn't allowed to see this page (this will in the future also be checked by the graphql instance
-		console.error(
-			new CustomError('Permissions for content page are not met', null, {
-				pageUserGroups,
-				userUserGroups,
-			})
-		);
-		return (
-			<ErrorView
-				message={t('error/views/error-view___de-pagina-werd-niet-gevonden')}
-				icon="search"
-				actionButtons={['home', 'helpdesk']}
-			/>
-		);
-	}
+const ContentPage: FunctionComponent<ContentPageDetailProps> = ({ contentPage }) => {
 	const contentBlockConfig: ContentBlockConfig[] = parseContentBlocks(
 		contentPage.contentBlockssBycontentId
 	);

--- a/src/dynamic-route-resolver/views/DynamicRouteResolver.tsx
+++ b/src/dynamic-route-resolver/views/DynamicRouteResolver.tsx
@@ -24,7 +24,7 @@ import { GET_EXTERNAL_ID_BY_MEDIAMOSA_ID } from '../../item/item.gql';
 import { LoadingErrorLoadedComponent, LoadingInfo } from '../../shared/components';
 import { buildLink, CustomError, generateSearchLinkString } from '../../shared/helpers';
 import { dataService } from '../../shared/services';
-import { getContentPageByPath } from '../../shared/services/navigation-items-service';
+import { ContentPageService } from '../../shared/services/content-page-service';
 import { AppState } from '../../store';
 
 type DynamicRouteType = 'contentPage' | 'bundle' | 'notFound';
@@ -49,7 +49,6 @@ const DynamicRouteResolver: FunctionComponent<DynamicRouteResolverProps> = ({
 	loginState,
 	loginStateError,
 	loginStateLoading,
-	match,
 	user,
 }) => {
 	const [t] = useTranslation();
@@ -98,7 +97,7 @@ const DynamicRouteResolver: FunctionComponent<DynamicRouteResolverProps> = ({
 			}
 
 			// Check if path points to a content page
-			const contentPage: Avo.Content.Content | null = await getContentPageByPath(
+			const contentPage: Avo.Content.Content | null = await ContentPageService.getContentPageByPath(
 				location.pathname
 			);
 			if (!contentPage) {
@@ -168,15 +167,7 @@ const DynamicRouteResolver: FunctionComponent<DynamicRouteResolverProps> = ({
 				return <Redirect to={generateSearchLinkString('serie', 'Klaar')} />;
 			}
 
-			return (
-				<ContentPage
-					contentPage={routeInfo.data}
-					history={history}
-					location={location}
-					match={match}
-					user={user}
-				/>
-			);
+			return <ContentPage contentPage={routeInfo.data} />;
 		}
 		console.error(
 			new CustomError("Route doesn't seem to be a bundle or content page", null, {

--- a/src/shared/components/Footer/Footer.tsx
+++ b/src/shared/components/Footer/Footer.tsx
@@ -6,7 +6,7 @@ import { Container } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
 import { connect } from 'react-redux';
-import { selectLoginMessage, selectUser } from '../../../authentication/store/selectors';
+import { selectUser } from '../../../authentication/store/selectors';
 import { AppState } from '../../../store';
 import { BooleanDictionary, mapNavElementsToNavigationItems } from '../../helpers/navigation';
 import {
@@ -79,7 +79,6 @@ export const Footer: FunctionComponent<FooterProps> = ({ history, location, matc
 };
 
 const mapStateToProps = (state: AppState) => ({
-	loginMessage: selectLoginMessage(state),
 	user: selectUser(state),
 });
 

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -36,6 +36,7 @@ export const ROUTE_PARTS = Object.freeze({
 	loggedInHome: 'home',
 	profile: 'profiel',
 	completeProfile: 'vervolledig-profiel',
+	acceptConditions: 'accepteer-voorwaarden',
 	account: 'account',
 	email: 'email',
 	notifications: 'notificaties',

--- a/src/shared/services/content-page-service.ts
+++ b/src/shared/services/content-page-service.ts
@@ -1,0 +1,40 @@
+import queryString from 'query-string';
+
+import { Avo } from '@viaa/avo2-types';
+
+import { CustomError, getEnv } from '../helpers';
+
+export class ContentPageService {
+	/**
+	 * Get a content page with all of its content without the user having o be logged in
+	 * @param path The path to identify the content page including the leading slash. eg: /over
+	 */
+	public static async getContentPageByPath(path: string): Promise<Avo.Content.Content | null> {
+		try {
+			const response = await fetch(
+				`${getEnv('PROXY_URL')}/content-pages?${queryString.stringify({
+					path,
+				})}`,
+				{
+					method: 'GET',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					credentials: 'include',
+				}
+			);
+			if (response.status === 404) {
+				return null;
+			}
+			if (response.status < 200 && response.status >= 400) {
+				throw new CustomError('Failed to get content page from /content-pages', null, {
+					path,
+					response,
+				});
+			}
+			return await response.json();
+		} catch (err) {
+			throw new CustomError('Failed to get all user groups', err);
+		}
+	}
+}

--- a/src/shared/services/navigation-items-service.ts
+++ b/src/shared/services/navigation-items-service.ts
@@ -1,8 +1,6 @@
 import { memoize } from 'lodash-es';
-import queryString from 'query-string';
 
 import { IconName } from '@viaa/avo2-components';
-import { Avo } from '@viaa/avo2-types';
 
 import { CustomError, getEnv } from '../helpers';
 
@@ -42,35 +40,6 @@ async function getNavItems(): Promise<NavItemMap> {
 		});
 		if (response.status < 200 && response.status >= 400) {
 			throw new CustomError('Failed to get navigation items from server', null, { response });
-		}
-		return await response.json();
-	} catch (err) {
-		throw new CustomError('Failed to get all user groups', err);
-	}
-}
-
-export async function getContentPageByPath(path: string): Promise<Avo.Content.Content | null> {
-	try {
-		const response = await fetch(
-			`${getEnv('PROXY_URL')}/content-pages?${queryString.stringify({
-				path,
-			})}`,
-			{
-				method: 'GET',
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				credentials: 'include',
-			}
-		);
-		if (response.status === 404) {
-			return null;
-		}
-		if (response.status < 200 && response.status >= 400) {
-			throw new CustomError('Failed to get content page from /content-pages', null, {
-				path,
-				response,
-			});
 		}
 		return await response.json();
 	} catch (err) {

--- a/src/shared/services/notification-service.gql.ts
+++ b/src/shared/services/notification-service.gql.ts
@@ -1,0 +1,46 @@
+import { gql } from 'apollo-boost';
+
+export const GET_NOTIFICATION = gql`
+	query getNotification($key: String!, $profileId: uuid!) {
+		users_notifications(where: { profile_id: { _eq: $profileId }, key: { _eq: $key } }) {
+			through_email
+			through_platform
+		}
+	}
+`;
+
+export const INSERT_NOTIFICATION = gql`
+	mutation insertNotification(
+		$key: String!
+		$profileId: uuid!
+		$throughEmail: Boolean!
+		$throughPlatform: Boolean!
+	) {
+		insert_users_notifications(
+			objects: {
+				key: $key
+				profile_id: $profileId
+				through_email: $throughEmail
+				through_platform: $throughPlatform
+			}
+		) {
+			affected_rows
+		}
+	}
+`;
+
+export const UPDATE_NOTIFICATION = gql`
+	mutation updateNotification(
+		$key: String!
+		$profileId: uuid!
+		$throughEmail: Boolean!
+		$throughPlatform: Boolean!
+	) {
+		update_users_notifications(
+			where: { profile_id: { _eq: $profileId }, key: { _eq: $key } }
+			_set: { through_email: $throughEmail, through_platform: $throughPlatform }
+		) {
+			affected_rows
+		}
+	}
+`;

--- a/src/shared/services/notification-service.ts
+++ b/src/shared/services/notification-service.ts
@@ -1,0 +1,99 @@
+import { get } from 'lodash-es';
+
+import { CustomError } from '../helpers';
+
+import { dataService } from './data-service';
+import {
+	GET_NOTIFICATION,
+	INSERT_NOTIFICATION,
+	UPDATE_NOTIFICATION,
+} from './notification-service.gql';
+
+export interface NotificationInfo {
+	through_email: boolean;
+	through_platform: boolean;
+}
+
+export class NotificationService {
+	public static async getNotification(
+		key: string,
+		profileId: string
+	): Promise<NotificationInfo | null> {
+		try {
+			const response = await dataService.query({
+				query: GET_NOTIFICATION,
+				variables: {
+					key,
+					profileId,
+				},
+			});
+
+			if (response.errors) {
+				throw new CustomError('Response from graphql contains errors', null, {
+					response,
+				});
+			}
+
+			return get(response, 'data.users_notifications[0]', null);
+		} catch (err) {
+			throw new CustomError('Failed to get user notification', err, {
+				notificationKey: key,
+				profileId,
+				query: 'GET_NOTIFICATION',
+			});
+		}
+	}
+
+	public static async setNotification(
+		key: string,
+		profileId: string,
+		throughEmail: boolean,
+		throughPlatform: boolean
+	): Promise<void> {
+		try {
+			const getResponse = await dataService.query({
+				query: GET_NOTIFICATION,
+				variables: {
+					profileId,
+					key,
+				},
+			});
+			if (getResponse.errors) {
+				throw new CustomError('Response from graphql contains errors', null, {
+					getResponse,
+				});
+			}
+			const notificationEntryExists: boolean = !!get(
+				getResponse,
+				'data.users_notifications[0]'
+			);
+			// If entry already exists => update existing entry
+			// If no entry exists in the notifications table => insert a new entry
+			const mutation = notificationEntryExists ? UPDATE_NOTIFICATION : INSERT_NOTIFICATION;
+			const mutateResponse = await dataService.mutate({
+				mutation,
+				variables: {
+					profileId,
+					key,
+					throughEmail,
+					throughPlatform,
+				},
+			});
+			if (mutateResponse.errors) {
+				throw new CustomError('Response from graphql contains errors', null, {
+					mutation,
+					mutateResponse,
+					getResponse,
+				});
+			}
+		} catch (err) {
+			throw new CustomError('Failed to set user notification', err, {
+				notificationKey: key,
+				profileId,
+				throughEmail,
+				throughPlatform,
+				query: ['GET_NOTIFICATION', 'UPDATE_NOTIFICATION', 'INSERT_NOTIFICATION'],
+			});
+		}
+	}
+}


### PR DESCRIPTION
closes: https://district01.atlassian.net/browse/AVO2-460

Twin PR: https://github.com/viaacode/avo2-proxy/pull/108

The accept conditions page loads 2 content page below each other with an accept conditions button at the bottom of the page.

We split this page into 2 because the privacy conditions also need to be accessible from the sites footer.

![image](https://user-images.githubusercontent.com/1710840/77329396-3d1d5380-6d1e-11ea-9799-f4585dcd86b8.png)
