### PR TITLE
fix(auth): redirect to originally requested page after logging in

### DIFF
--- a/src/authentication/components/LoginOptions.tsx
+++ b/src/authentication/components/LoginOptions.tsx
@@ -13,12 +13,14 @@ import './LoginOptions.scss';
 
 export interface LoginOptionsProps extends RouteComponentProps {
 	onOptionClicked?: () => void;
+	redirectAfterLogin: string;
 }
 
 const LoginOptions: FunctionComponent<LoginOptionsProps> = ({
 	history,
 	location,
 	onOptionClicked = () => {},
+	redirectAfterLogin,
 }) => {
 	const [t] = useTranslation();
 
@@ -35,7 +37,7 @@ const LoginOptions: FunctionComponent<LoginOptionsProps> = ({
 						className="c-login-with-archief"
 						onClick={() => {
 							onOptionClicked();
-							redirectToClientPage(APP_PATH.LOGIN.route, history);
+							redirectToClientPage(APP_PATH.LOGIN.route, history, redirectAfterLogin);
 						}}
 					/>
 				</Spacer>

--- a/src/authentication/components/LoginOptionsDropdown.tsx
+++ b/src/authentication/components/LoginOptionsDropdown.tsx
@@ -3,8 +3,9 @@ import { RouteComponentProps } from 'react-router';
 
 import { Container, Flex, FlexItem } from '@viaa/avo2-components';
 
-import LoginOptions from './LoginOptions';
+import { getFromPath } from '../helpers/redirects';
 
+import LoginOptions from './LoginOptions';
 import './LoginOptionsDropdown.scss';
 
 export interface LoginOptionsDropdownProps extends RouteComponentProps {
@@ -27,6 +28,7 @@ const LoginOptionsDropdown: FunctionComponent<LoginOptionsDropdownProps> = ({
 							location={location}
 							match={match}
 							onOptionClicked={closeDropdown}
+							redirectAfterLogin={getFromPath(location)}
 						/>
 					</FlexItem>
 				</Flex>

--- a/src/authentication/helpers/redirects.ts
+++ b/src/authentication/helpers/redirects.ts
@@ -14,8 +14,12 @@ import { STAMBOEK_LOCAL_STORAGE_KEY } from '../views/registration-flow/r3-stambo
  * Client redirect functions
  *
  **/
-export function redirectToClientPage(path: string, history: History) {
-	history.push(path);
+export function redirectToClientPage(path: string, history: History, fromPath?: string) {
+	if (fromPath) {
+		history.push(path, { from: { pathname: fromPath } });
+	} else {
+		history.push(path);
+	}
 }
 
 /**
@@ -73,6 +77,7 @@ export function redirectToServerLinkAccount(location: Location, idpType: Avo.Aut
 		idpType,
 	})}`;
 }
+
 export function redirectToServerUnlinkAccount(location: Location, idpType: Avo.Auth.IdpType) {
 	const returnToUrl = getBaseUrl(location) + getFromPath(location);
 	window.location.href = `${getEnv('PROXY_URL')}/auth/unlink-account?${queryString.stringify({
@@ -98,6 +103,9 @@ function getBaseUrl(location: Location): string {
 	return window.location.href.split(location.pathname)[0];
 }
 
-function getFromPath(location: Location, defaultPath: string = APP_PATH.SEARCH.route): string {
+export function getFromPath(
+	location: Location,
+	defaultPath: string = APP_PATH.SEARCH.route
+): string {
 	return get(location, 'state.from.pathname', defaultPath);
 }

--- a/src/authentication/views/RegisterOrLogin.tsx
+++ b/src/authentication/views/RegisterOrLogin.tsx
@@ -18,7 +18,7 @@ import {
 import { APP_PATH } from '../../constants';
 
 import LoginOptions from '../components/LoginOptions';
-import { redirectToClientPage } from '../helpers/redirects';
+import { getFromPath, redirectToClientPage } from '../helpers/redirects';
 import './RegisterOrLogin.scss';
 
 export interface RegisterOrLoginProps extends RouteComponentProps {}
@@ -99,6 +99,7 @@ const RegisterOrRegisterOrLogin: FunctionComponent<RegisterOrLoginProps> = ({
 											history={history}
 											location={location}
 											match={match}
+											redirectAfterLogin={getFromPath(location)}
 										/>
 									</FlexItem>
 								</Flex>


### PR DESCRIPTION
When you visit a url to a secure route, you need to login. But after the login, you are not redirected to the original page you requested, instead you go to the search page.

This PR fixes this

example:
http://localhost:8080/item/pk06x1db2t
http://localhost:8080/collecties/d2795434-7531-45fc-9552-fc1da8d01559