### PR TITLE
fix(cta): allow one or two CTAs in a CTA block

### DIFF
--- a/src/admin/content-block/helpers/generators/ctas.ts
+++ b/src/admin/content-block/helpers/generators/ctas.ts
@@ -33,7 +33,7 @@ export const CTAS_BLOCK_CONFIG = (position: number = 0): ContentBlockConfig => (
 	components: {
 		name: i18n.t('admin/content-block/helpers/generators/ctas___cta'),
 		limits: {
-			min: 2,
+			min: 1,
 			max: 2,
 		},
 		state: INITIAL_CTAS_COMPONENTS_STATE(),


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-100

Thi PR also has a component twin, but they do not depend on each other: 
https://github.com/viaacode/avo2-components/pull/265

![image](https://user-images.githubusercontent.com/1710840/77355295-82ed1280-6d44-11ea-9d5f-bd974f640594.png)

![image](https://user-images.githubusercontent.com/1710840/77355299-841e3f80-6d44-11ea-9214-ca3f4c2aac31.png)
