### PR TITLE
fix(content-blocks): add missing function brackets to const options

### DIFF
--- a/src/admin/content-block/components/ContentBlockFieldEditor/ContentBlockFieldEditor.tsx
+++ b/src/admin/content-block/components/ContentBlockFieldEditor/ContentBlockFieldEditor.tsx
@@ -65,9 +65,9 @@ const ContentBlockFieldEditor: FunctionComponent<ContentBlockFieldProps> = ({
 			editorProps = {
 				onChange: (option: SelectOption) =>
 					handleChange(type, fieldKey, get(option, 'value', ''), stateIndex),
-				value: defaultProps
-					.options()
-					.find((opt: SelectOption) => opt.value === (state as any)[fieldKey]),
+				value: defaultProps.options.find(
+					(opt: SelectOption) => opt.value === (state as any)[fieldKey]
+				),
 			};
 			break;
 		case ContentBlockEditor.WYSIWYG:

--- a/src/admin/content-block/helpers/generators/buttons.ts
+++ b/src/admin/content-block/helpers/generators/buttons.ts
@@ -1,6 +1,6 @@
 import i18n from '../../../../shared/translations/i18n';
 
-import { ADMIN_ICON_OPTIONS } from '../../../shared/constants';
+import { GET_ADMIN_ICON_OPTIONS } from '../../../shared/constants';
 import {
 	ButtonsBlockComponentState,
 	ContentBlockConfig,
@@ -36,7 +36,7 @@ export const BUTTONS_BLOCK_CONFIG = (position: number = 0): ContentBlockConfig =
 				label: i18n.t('admin/content-block/helpers/generators/buttons___type'),
 				editorType: ContentBlockEditor.Select,
 				editorProps: {
-					options: GET_BUTTON_TYPE_OPTIONS,
+					options: GET_BUTTON_TYPE_OPTIONS(),
 				},
 			},
 			label: TEXT_FIELD(
@@ -50,7 +50,7 @@ export const BUTTONS_BLOCK_CONFIG = (position: number = 0): ContentBlockConfig =
 				label: i18n.t('admin/content-block/helpers/generators/buttons___icoon'),
 				editorType: ContentBlockEditor.IconPicker,
 				editorProps: {
-					options: ADMIN_ICON_OPTIONS,
+					options: GET_ADMIN_ICON_OPTIONS(),
 				},
 			},
 			buttonAction: {

--- a/src/admin/content-block/helpers/generators/ctas.ts
+++ b/src/admin/content-block/helpers/generators/ctas.ts
@@ -1,6 +1,6 @@
 import i18n from '../../../../shared/translations/i18n';
 
-import { ADMIN_ICON_OPTIONS } from '../../../shared/constants';
+import { GET_ADMIN_ICON_OPTIONS } from '../../../shared/constants';
 import {
 	ContentBlockConfig,
 	ContentBlockEditor,
@@ -42,7 +42,7 @@ export const CTAS_BLOCK_CONFIG = (position: number = 0): ContentBlockConfig => (
 				label: i18n.t('admin/content-block/helpers/generators/ctas___titel-stijl'),
 				editorType: ContentBlockEditor.Select,
 				editorProps: {
-					options: GET_HEADING_TYPE_OPTIONS,
+					options: GET_HEADING_TYPE_OPTIONS(),
 				},
 			},
 			heading: TEXT_FIELD(
@@ -57,7 +57,7 @@ export const CTAS_BLOCK_CONFIG = (position: number = 0): ContentBlockConfig => (
 				label: i18n.t('admin/content-block/helpers/generators/ctas___knop-type'),
 				editorType: ContentBlockEditor.Select,
 				editorProps: {
-					options: GET_BUTTON_TYPE_OPTIONS,
+					options: GET_BUTTON_TYPE_OPTIONS(),
 				},
 			},
 			buttonLabel: TEXT_FIELD(
@@ -71,7 +71,7 @@ export const CTAS_BLOCK_CONFIG = (position: number = 0): ContentBlockConfig => (
 				label: i18n.t('admin/content-block/helpers/generators/ctas___knop-icoon'),
 				editorType: ContentBlockEditor.IconPicker,
 				editorProps: {
-					options: ADMIN_ICON_OPTIONS,
+					options: GET_ADMIN_ICON_OPTIONS(),
 				},
 			},
 			buttonAction: {

--- a/src/admin/content-block/helpers/generators/defaults.ts
+++ b/src/admin/content-block/helpers/generators/defaults.ts
@@ -40,7 +40,7 @@ export const BACKGROUND_COLOR_FIELD = (
 	label,
 	editorType: ContentBlockEditor.ColorSelect,
 	editorProps: {
-		options: GET_BACKGROUND_COLOR_OPTIONS,
+		options: GET_BACKGROUND_COLOR_OPTIONS(),
 		defaultValue: GET_BACKGROUND_COLOR_OPTIONS()[0],
 	},
 });
@@ -58,7 +58,7 @@ export const ALIGN_FIELD = (
 	label,
 	editorType: ContentBlockEditor.AlignSelect,
 	editorProps: {
-		options: GET_ALIGN_OPTIONS,
+		options: GET_ALIGN_OPTIONS(),
 	},
 });
 

--- a/src/admin/content-block/helpers/generators/heading.ts
+++ b/src/admin/content-block/helpers/generators/heading.ts
@@ -36,7 +36,7 @@ export const HEADING_BLOCK_CONFIG = (position: number = 0): ContentBlockConfig =
 				label: i18n.t('admin/content-block/helpers/generators/heading___stijl'),
 				editorType: ContentBlockEditor.Select,
 				editorProps: {
-					options: GET_HEADING_TYPE_OPTIONS,
+					options: GET_HEADING_TYPE_OPTIONS(),
 				},
 			},
 			align: ALIGN_FIELD(),

--- a/src/admin/content-block/helpers/generators/image-grid.ts
+++ b/src/admin/content-block/helpers/generators/image-grid.ts
@@ -114,14 +114,14 @@ export const IMAGE_GRID_BLOCK_CONFIG = (position: number = 0): ContentBlockConfi
 				label: i18n.t('admin/content-block/helpers/generators/image-grid___zoom'),
 				editorType: ContentBlockEditor.Select,
 				editorProps: {
-					options: GET_FILL_OPTIONS,
+					options: GET_FILL_OPTIONS(),
 				},
 			},
 			textAlign: {
 				label: i18n.t('admin/content-block/helpers/generators/image-grid___text-alignatie'),
 				editorType: ContentBlockEditor.Select,
 				editorProps: {
-					options: GET_ALIGN_OPTIONS,
+					options: GET_ALIGN_OPTIONS(),
 				},
 			},
 		},

--- a/src/admin/content-block/helpers/generators/image.ts
+++ b/src/admin/content-block/helpers/generators/image.ts
@@ -52,7 +52,7 @@ export const IMAGE_BLOCK_CONFIG = (position: number = 0): ContentBlockConfig => 
 				label: i18n.t('admin/content-block/helpers/generators/image___breedte'),
 				editorType: ContentBlockEditor.Select,
 				editorProps: {
-					options: GET_WIDTH_OPTIONS,
+					options: GET_WIDTH_OPTIONS(),
 				},
 			},
 		},

--- a/src/admin/content-block/helpers/generators/media-player-title-text-button.ts
+++ b/src/admin/content-block/helpers/generators/media-player-title-text-button.ts
@@ -1,6 +1,6 @@
 import i18n from '../../../../shared/translations/i18n';
 
-import { ADMIN_ICON_OPTIONS } from '../../../shared/constants';
+import { GET_ADMIN_ICON_OPTIONS } from '../../../shared/constants';
 
 import {
 	ContentBlockConfig,
@@ -69,7 +69,7 @@ export const MEDIA_PLAYER_TITLE_TEXT_BUTTON_BLOCK_CONFIG = (
 				label: i18n.t('admin/content-block/helpers/generators/heading___stijl'),
 				editorType: ContentBlockEditor.Select,
 				editorProps: {
-					options: GET_HEADING_TYPE_OPTIONS,
+					options: GET_HEADING_TYPE_OPTIONS(),
 				},
 			},
 			content: TEXT_FIELD(),
@@ -77,7 +77,7 @@ export const MEDIA_PLAYER_TITLE_TEXT_BUTTON_BLOCK_CONFIG = (
 				label: i18n.t('admin/content-block/helpers/generators/ctas___knop-type'),
 				editorType: ContentBlockEditor.Select,
 				editorProps: {
-					options: GET_BUTTON_TYPE_OPTIONS,
+					options: GET_BUTTON_TYPE_OPTIONS(),
 				},
 			},
 			buttonLabel: TEXT_FIELD(
@@ -91,7 +91,7 @@ export const MEDIA_PLAYER_TITLE_TEXT_BUTTON_BLOCK_CONFIG = (
 				label: i18n.t('admin/content-block/helpers/generators/ctas___knop-icoon'),
 				editorType: ContentBlockEditor.IconPicker,
 				editorProps: {
-					options: ADMIN_ICON_OPTIONS,
+					options: GET_ADMIN_ICON_OPTIONS(),
 				},
 			},
 			buttonAction: {

--- a/src/admin/content-block/helpers/generators/media-player.ts
+++ b/src/admin/content-block/helpers/generators/media-player.ts
@@ -45,7 +45,7 @@ export const MEDIA_PLAYER_BLOCK_CONFIG = (position: number = 0): ContentBlockCon
 				label: i18n.t('admin/content-block/helpers/generators/media-player___breedte'),
 				editorType: ContentBlockEditor.Select,
 				editorProps: {
-					options: GET_WIDTH_OPTIONS,
+					options: GET_WIDTH_OPTIONS(),
 				},
 			},
 		},

--- a/src/admin/content-block/helpers/generators/page-overview.ts
+++ b/src/admin/content-block/helpers/generators/page-overview.ts
@@ -58,7 +58,7 @@ export const PAGE_OVERVIEW_BLOCK_CONFIG = (position: number = 0): ContentBlockCo
 					),
 					editorType: ContentBlockEditor.Select,
 					editorProps: {
-						options: GET_PAGE_OVERVIEW_TAB_STYLE_OPTIONS,
+						options: GET_PAGE_OVERVIEW_TAB_STYLE_OPTIONS(),
 					},
 				},
 				allowMultiple: {
@@ -75,7 +75,7 @@ export const PAGE_OVERVIEW_BLOCK_CONFIG = (position: number = 0): ContentBlockCo
 					),
 					editorType: ContentBlockEditor.Select,
 					editorProps: {
-						options: GET_PAGE_OVERVIEW_ITEM_STYLE_OPTIONS,
+						options: GET_PAGE_OVERVIEW_ITEM_STYLE_OPTIONS(),
 					},
 				},
 				showTitle: {

--- a/src/admin/menu/components/MenuEditForm/MenuEditForm.tsx
+++ b/src/admin/menu/components/MenuEditForm/MenuEditForm.tsx
@@ -10,7 +10,7 @@ import { ReactSelectOption, ValueOf } from '../../../../shared/types';
 import { UserGroupSelect } from '../../../shared/components';
 import { ContentPicker } from '../../../shared/components/ContentPicker/ContentPicker';
 import { IconPicker } from '../../../shared/components/IconPicker/IconPicker';
-import { ADMIN_ICON_OPTIONS } from '../../../shared/constants';
+import { GET_ADMIN_ICON_OPTIONS } from '../../../shared/constants';
 import { PickerItem } from '../../../shared/types';
 import { MenuEditFormErrorState, MenuEditFormState } from '../../menu.types';
 
@@ -82,11 +82,11 @@ const MenuEditForm: FunctionComponent<MenuEditFormProps> = ({
 			)}
 			<FormGroup label={t('admin/menu/components/menu-edit-form/menu-edit-form___icoon')}>
 				<IconPicker
-					options={ADMIN_ICON_OPTIONS}
+					options={GET_ADMIN_ICON_OPTIONS()}
 					onChange={(option: ValueType<ReactSelectOption<string>>) =>
 						onChange('icon', get(option, 'value', ''))
 					}
-					value={ADMIN_ICON_OPTIONS.find(
+					value={GET_ADMIN_ICON_OPTIONS().find(
 						(option: ReactSelectOption<string>) => option.value === formState.icon
 					)}
 				/>

--- a/src/admin/shared/components/ContentPicker/ContentPicker.helpers.ts
+++ b/src/admin/shared/components/ContentPicker/ContentPicker.helpers.ts
@@ -26,11 +26,12 @@ export const setInitialInput = (
 	return isInput ? get(initialValues, 'value', '') : '';
 };
 
-export const setInitialItem = (options: PickerSelectItem[], initialValues?: PickerItem) => {
-	const currentItem = options.find(
+export const setInitialItem = (
+	options: PickerSelectItem[],
+	initialValues?: PickerItem
+): ValueType<PickerItem> => {
+	return options.find(
 		(option: PickerSelectItem) =>
 			option.value.value === get(initialValues, 'value', 'EMPTY_SELECTION')
 	) as ValueType<PickerItem>;
-
-	return currentItem;
 };

--- a/src/admin/shared/components/IconPicker/IconPicker.test.tsx
+++ b/src/admin/shared/components/IconPicker/IconPicker.test.tsx
@@ -1,13 +1,13 @@
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 
-import { ADMIN_ICON_OPTIONS } from '../../constants';
+import { GET_ADMIN_ICON_OPTIONS } from '../../constants';
 
 import { IconPicker } from './IconPicker';
 
 const iconPickerProps = {
 	className: 'c-icon-picker-custom',
-	options: ADMIN_ICON_OPTIONS,
+	options: GET_ADMIN_ICON_OPTIONS(),
 };
 
 describe('<IconPicker />', () => {
@@ -28,10 +28,10 @@ describe('<IconPicker />', () => {
 		const iconPickerIcon = iconPickeMenu.find('.react-select__option .o-svg-icon');
 
 		expect(
-			iconPickerIcon.at(0).hasClass(`o-svg-icon--${ADMIN_ICON_OPTIONS[0].value}`)
+			iconPickerIcon.at(0).hasClass(`o-svg-icon--${GET_ADMIN_ICON_OPTIONS()[0].value}`)
 		).toBeTruthy();
 		expect(
-			iconPickerIcon.at(1).hasClass(`o-svg-icon--${ADMIN_ICON_OPTIONS[1].value}`)
+			iconPickerIcon.at(1).hasClass(`o-svg-icon--${GET_ADMIN_ICON_OPTIONS()[1].value}`)
 		).toBeTruthy();
 	});
 });

--- a/src/admin/shared/constants/index.ts
+++ b/src/admin/shared/constants/index.ts
@@ -3,7 +3,7 @@ import { IconName } from '@viaa/avo2-components';
 import i18n from '../../../shared/translations/i18n';
 import { ReactSelectOption } from '../../../shared/types';
 
-export const ADMIN_ICON_OPTIONS: ReactSelectOption<IconName>[] = [
+export const GET_ADMIN_ICON_OPTIONS: () => ReactSelectOption<IconName>[] = () => [
 	{ label: i18n.t('admin/shared/constants/index___afbeelding'), value: 'image' },
 	{ label: i18n.t('admin/shared/constants/index___aktetas'), value: 'briefcase' },
 	{ label: i18n.t('admin/shared/constants/index___audio'), value: 'headphone' },

--- a/src/admin/shared/types/content-picker.ts
+++ b/src/admin/shared/types/content-picker.ts
@@ -29,8 +29,3 @@ export interface PickerItem {
 	type: ContentPickerType;
 	value: string;
 }
-
-export interface PickerSelectItemGroup {
-	label: string;
-	options: PickerSelectItem[];
-}


### PR DESCRIPTION
This is a cleaner fix than defaultProps.options() since it doesn't require options to be handled any differently

This fixes the bug:
![image (17)](https://user-images.githubusercontent.com/1710840/77789136-c73d2300-7062-11ea-954b-81977f653cc8.png)
