### PR TITLE
chore(image-grid-block): show slider numeric value

### DIFF
--- a/src/admin/content-block/helpers/generators/image-grid.ts
+++ b/src/admin/content-block/helpers/generators/image-grid.ts
@@ -84,6 +84,7 @@ export const IMAGE_GRID_BLOCK_CONFIG = (position: number = 0): ContentBlockConfi
 					max: 800,
 					step: 1,
 					values: [200],
+					showNumber: true,
 				} as MultiRangeProps,
 			},
 			imageHeight: {
@@ -97,6 +98,7 @@ export const IMAGE_GRID_BLOCK_CONFIG = (position: number = 0): ContentBlockConfi
 					max: 800,
 					step: 1,
 					values: [200],
+					showNumber: true,
 				} as MultiRangeProps,
 			},
 			itemWidth: {
@@ -108,6 +110,7 @@ export const IMAGE_GRID_BLOCK_CONFIG = (position: number = 0): ContentBlockConfi
 					max: 800,
 					step: 1,
 					values: [200],
+					showNumber: true,
 				} as MultiRangeProps,
 			},
 			fill: {


### PR DESCRIPTION
This way, claire will be able to pick some presets that work for her, and then we can replace these sliders with some dropdown select options

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/77789730-e12b3580-7063-11ea-99a4-e45a88cda0de.png)|![image](https://user-images.githubusercontent.com/1710840/77789740-e4262600-7063-11ea-804b-dd567fe84fd1.png)|