### PR TITLE
feat(content-page-edit): move select to top + scroll when adding block

### DIFF
--- a/src/admin/content-block/content-block.const.ts
+++ b/src/admin/content-block/content-block.const.ts
@@ -90,7 +90,7 @@ export const CONTENT_BLOCKS_RESULT_PATH = {
 
 export const GET_CONTENT_BLOCK_TYPE_OPTIONS: () => SelectOption[] = () => [
 	{
-		label: i18n.t('admin/content-block/content-block___kies-een-content-block'),
+		label: i18n.t('Voeg een content blok toe'),
 		value: '',
 		disabled: true,
 	},

--- a/src/admin/content/views/ContentEdit.scss
+++ b/src/admin/content/views/ContentEdit.scss
@@ -1,9 +1,40 @@
 @import '../../../styles/settings/colors';
 
-.c-content-edit-view__sidebar,
+$content-top-bar-and-tabs-height: 113px;
+
+.c-content-edit-view__sidebar {
+	height: calc(100vh - #{$content-top-bar-and-tabs-height});
+
+	> .o-sidebar__content > .c-scrollable {
+		width: 100%;
+		height: calc(100vh - #{$content-top-bar-and-tabs-height} - 68px);
+		overflow-y: auto;
+		padding: 0 1.6rem 1.6rem;
+	}
+
+	> .o-sidebar__content > .c-navbar {
+		padding: 1.6rem;
+		height: 70px;
+
+		.c-select__control {
+			border: 1px solid #25a4cf;
+			background: #25a4cf;
+
+			.c-select__single-value,
+			svg {
+				color: #fff;
+			}
+		}
+
+		.c-select__placeholder {
+			color: #fff;
+		}
+	}
+}
+
 .c-content-edit-view__preview {
 	width: 100%;
-	height: calc(100vh - 113px);
+	height: calc(100vh - #{$content-top-bar-and-tabs-height});
 	overflow-y: auto;
 }
 
@@ -16,14 +47,10 @@
 	}
 }
 
-.c-content-edit-view__sidebar {
-	padding: 0 1.6rem 1.6rem;
-}
-
 .m-resizable-panels.m-edit-content-blocks {
 	> div {
 		> div:not(.resizable-fragment) {
-			height: calc(100vh - 113px) !important;
+			height: calc(100vh - #{$content-top-bar-and-tabs-height}) !important;
 		}
 	}
 }

--- a/src/admin/content/views/ContentEditContentBlocks.tsx
+++ b/src/admin/content/views/ContentEditContentBlocks.tsx
@@ -1,8 +1,8 @@
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, RefObject, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ResizablePanels from 'resizable-panels-react';
 
-import { FlexItem, Form, FormGroup, Select } from '@viaa/avo2-components';
+import { Navbar, Select } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
 import { ContentBlockForm, ContentBlockPreview } from '../../content-block/components';
@@ -45,10 +45,13 @@ const ContentEditContentBlocks: FunctionComponent<ContentEditContentBlocksProps>
 	addComponentToState,
 	removeComponentFromState,
 }) => {
+	const [t] = useTranslation();
+
 	// Hooks
 	const [accordionsOpenState, setAccordionsOpenState] = useState<{ [key: string]: boolean }>({});
 
-	const [t] = useTranslation();
+	const previewScrollable: RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
+	const sidebarScrollable: RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
 
 	// Methods
 	const getFormKey = (name: string, blockIndex: number, stateIndex: number = 0) =>
@@ -63,6 +66,18 @@ const ContentEditContentBlocks: FunctionComponent<ContentEditContentBlocksProps>
 
 		// Set newly added config accordion as open
 		setAccordionsOpenState({ [contentBlockFormKey]: true });
+
+		// Scroll preview and sidebar to the bottom
+		scrollToBottom(previewScrollable);
+		scrollToBottom(sidebarScrollable);
+	};
+
+	const scrollToBottom = (ref: RefObject<HTMLDivElement>) => {
+		setTimeout(() => {
+			if (ref.current) {
+				ref.current.scroll({ left: 0, top: 1000000, behavior: 'smooth' });
+			}
+		}, 0);
 	};
 
 	const handleReorderContentBlock = (configIndex: number, indexUpdate: number) => {
@@ -129,24 +144,21 @@ const ContentEditContentBlocks: FunctionComponent<ContentEditContentBlocksProps>
 				sizeUnitMeasure="%"
 				resizerSize="15px"
 			>
-				<FlexItem className="c-content-edit-view__preview">
+				<div className="c-content-edit-view__preview" ref={previewScrollable}>
 					{renderBlockPreviews()}
-				</FlexItem>
+				</div>
 				<Sidebar className="c-content-edit-view__sidebar" light>
-					{renderContentBlockForms()}
-					<Form>
-						<FormGroup
-							label={t(
-								'admin/content/views/content-edit-content-blocks___voeg-een-content-block-toe'
-							)}
-						>
-							<Select
-								options={GET_CONTENT_BLOCK_TYPE_OPTIONS()}
-								onChange={value => handleAddContentBlock(value as ContentBlockType)}
-								value={GET_CONTENT_BLOCK_TYPE_OPTIONS()[0].value}
-							/>
-						</FormGroup>
-					</Form>
+					<Navbar background="alt">
+						<Select
+							options={GET_CONTENT_BLOCK_TYPE_OPTIONS()}
+							onChange={value => handleAddContentBlock(value as ContentBlockType)}
+							placeholder={t('Voeg een content blok toe')}
+							value={null}
+						/>
+					</Navbar>
+					<div className="c-scrollable" ref={sidebarScrollable}>
+						{renderContentBlockForms()}
+					</div>
 				</Sidebar>
 			</ResizablePanels>
 		</div>


### PR DESCRIPTION
* Move block select dropdown to the top
* make primary color to draw attention
* do not scroll it out of view when scrolling in the sidebar
* always show the placeholder in the select component (requires component change)
* when adding a block, scroll to the bottom, so the user sees something

Component twin PR: https://github.com/viaacode/avo2-components/pull/272

![image](https://user-images.githubusercontent.com/1710840/78232608-c712ac80-74d4-11ea-9937-d07071320778.png)
