### PR TITLE
fix(collection-edit): fragment reorder buttons have inverted directions

### DIFF
--- a/src/collection/components/CollectionOrBundleEdit.tsx
+++ b/src/collection/components/CollectionOrBundleEdit.tsx
@@ -199,7 +199,7 @@ const CollectionOrBundleEdit: FunctionComponent<CollectionOrBundleEditProps &
 
 				const fragments1 = getFragmentsFromCollection(newCurrentCollection);
 
-				const delta = action.direction === 'up' ? 1 : -1;
+				const delta = action.direction === 'up' ? -1 : 1;
 
 				// Make the swap
 				const tempFragment = fragments1[action.index];


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-272

![image](https://user-images.githubusercontent.com/1710840/78541670-4aded880-77f6-11ea-97b7-a89a3eb5182d.png)
