### PR TITLE
fix(content-blocks): avoid crashing on pages that contain an accordion

### DIFF
--- a/src/admin/content-block/helpers/parsers.ts
+++ b/src/admin/content-block/helpers/parsers.ts
@@ -1,8 +1,11 @@
-import { get } from 'lodash-es';
+import { compact, get } from 'lodash-es';
 
 import { Avo } from '@viaa/avo2-types';
 
+import { CustomError } from '../../../shared/helpers';
+import { ToastService } from '../../../shared/services';
 import { ContentBlockConfig, ContentBlockType } from '../../shared/types';
+
 import { CONTENT_BLOCK_CONFIG_MAP } from '../content-block.const';
 
 // Parse content-block config to valid request body
@@ -35,31 +38,43 @@ export const parseContentBlocks = (
 ): ContentBlockConfig[] => {
 	const sortedContentBlocks = contentBlocks.sort((a, b) => a.position - b.position);
 
-	return sortedContentBlocks.map(contentBlock => {
-		const { content_block_type, id, variables } = contentBlock;
-		const cleanConfig = CONTENT_BLOCK_CONFIG_MAP[content_block_type as ContentBlockType](
-			contentBlock.position
-		);
+	return compact(
+		sortedContentBlocks.map(contentBlock => {
+			const { content_block_type, id, variables } = contentBlock;
+			const configForType = CONTENT_BLOCK_CONFIG_MAP[content_block_type as ContentBlockType];
+			if (!configForType) {
+				console.error(
+					new CustomError('Failed to find content block config for type', null, {
+						content_block_type,
+						contentBlock,
+						CONTENT_BLOCK_CONFIG_MAP,
+					})
+				);
+				ToastService.danger('Er ging iets mis bij het laden van de pagina');
+				return null;
+			}
+			const cleanConfig = configForType(contentBlock.position);
 
-		const rawComponentState = get(variables, 'componentState', null);
-		const componentState = Array.isArray(rawComponentState)
-			? rawComponentState
-			: { ...cleanConfig.components.state, ...rawComponentState };
+			const rawComponentState = get(variables, 'componentState', null);
+			const componentState = Array.isArray(rawComponentState)
+				? rawComponentState
+				: { ...cleanConfig.components.state, ...rawComponentState };
 
-		return {
-			...cleanConfig,
-			id,
-			components: {
-				...cleanConfig.components,
-				state: componentState,
-			},
-			block: {
-				...cleanConfig.block,
-				state: {
-					...cleanConfig.block.state,
-					...get(variables, 'blockState', {}),
+			return {
+				...cleanConfig,
+				id,
+				components: {
+					...cleanConfig.components,
+					state: componentState,
 				},
-			},
-		} as ContentBlockConfig;
-	});
+				block: {
+					...cleanConfig.block,
+					state: {
+						...cleanConfig.block.state,
+						...get(variables, 'blockState', {}),
+					},
+				},
+			} as ContentBlockConfig;
+		})
+	);
 };


### PR DESCRIPTION
Since we disabled accordions, pages that still contain this block crash hard.
This PR will just omit the blocks for which a configuration cannot be found and show an error toast.

example: http://localhost:8080/beheer/content/36

![image](https://user-images.githubusercontent.com/1710840/78589662-d7ae8400-7840-11ea-9dd4-d13bfff8062b.png)
