### PR TITLE
fix(content-picker): fix projects type for linking and allowedTypes

### DIFF
--- a/src/admin/shared/types/content-picker.ts
+++ b/src/admin/shared/types/content-picker.ts
@@ -9,7 +9,7 @@ export type ContentPickerType =
 	| 'EXTERNAL_LINK'
 	| 'BUNDLE'
 	| 'SEARCH_QUERY'
-	| 'PROJECTS';
+	| 'PROJECTS'; // TODO replace with type from typings repo after update to 2.16.0
 
 export type PickerItemControls = 'SELECT' | 'TEXT_INPUT';
 

--- a/src/shared/helpers/link.tsx
+++ b/src/shared/helpers/link.tsx
@@ -106,9 +106,12 @@ export const navigateToContentType = (action: ButtonAction, history: History) =>
 	if (action) {
 		const { type, value, target } = action;
 
-		switch (type as Avo.Core.ContentPickerType) {
+		switch (
+			type as Avo.Core.ContentPickerType | 'PROJECTS' // TODO remove after update to typings 2.16.0
+		) {
 			case 'INTERNAL_LINK':
 			case 'CONTENT_PAGE':
+			case 'PROJECTS':
 				navigateToAbsoluteOrRelativeUrl(String(value), history, target);
 				break;
 


### PR DESCRIPTION
Otherwise the "projecten in de kijker" block doesn't list PROJECT content pages but instead PAGINA content pages and the links on the block do not work correctly