### PR TITLE
fix(content-picker): hide target switch

### DIFF
--- a/src/admin/content-block/helpers/generators/media-player-title-text-button.ts
+++ b/src/admin/content-block/helpers/generators/media-player-title-text-button.ts
@@ -56,6 +56,7 @@ export const MEDIA_PLAYER_TITLE_TEXT_BUTTON_BLOCK_CONFIG = (
 				editorType: ContentBlockEditor.ContentPicker,
 				editorProps: {
 					allowedTypes: ['ITEM'],
+					hideTargetSwitch: true,
 				},
 			},
 			headingTitle: TEXT_FIELD(

--- a/src/admin/content-block/helpers/generators/media-player.ts
+++ b/src/admin/content-block/helpers/generators/media-player.ts
@@ -39,6 +39,7 @@ export const MEDIA_PLAYER_BLOCK_CONFIG = (position: number = 0): ContentBlockCon
 				editorType: ContentBlockEditor.ContentPicker,
 				editorProps: {
 					allowedTypes: ['ITEM'],
+					hideTargetSwitch: true,
 				},
 			},
 			width: {

--- a/src/admin/shared/components/ContentPicker/ContentPicker.tsx
+++ b/src/admin/shared/components/ContentPicker/ContentPicker.tsx
@@ -26,6 +26,7 @@ export interface ContentPickerProps {
 	initialValue?: PickerItem;
 	onSelect: (value: PickerItem | null) => void;
 	hideTypeDropdown?: boolean;
+	hideTargetSwitch?: boolean;
 	errors?: string | string[];
 }
 
@@ -34,6 +35,7 @@ export const ContentPicker: FunctionComponent<ContentPickerProps> = ({
 	initialValue,
 	onSelect,
 	hideTypeDropdown = false,
+	hideTargetSwitch = false,
 	errors = [],
 }) => {
 	const [t] = useTranslation();
@@ -311,7 +313,7 @@ export const ContentPicker: FunctionComponent<ContentPickerProps> = ({
 			<Flex spaced="regular">
 				{!hideTypeDropdown && <FlexItem shrink>{renderTypePicker()}</FlexItem>}
 				<FlexItem>{renderItemControl()}</FlexItem>
-				<FlexItem shrink>{renderLinkTargetControl()}</FlexItem>
+				{!hideTargetSwitch && <FlexItem shrink>{renderLinkTargetControl()}</FlexItem>}
 			</Flex>
 		</FormGroup>
 	);


### PR DESCRIPTION
Mediaspeler-blok heeft geen targetSelf switch nodig.