### PR TITLE
fix(cb-media-player): validate onClear content picker

### DIFF
--- a/src/admin/content-block/helpers/generators/defaults.ts
+++ b/src/admin/content-block/helpers/generators/defaults.ts
@@ -151,6 +151,28 @@ export const FILE_FIELD = (
 	...propOverride,
 });
 
+export const VIDEO_FIELD = (
+	emptyFieldValidatorMessage = i18n.t('Selecteren van video-item is verplicht.'),
+	propOverride?: Partial<ContentBlockField>
+): ContentBlockField => ({
+	label: i18n.t('admin/content-block/helpers/generators/media-player___video-of-audio-item'),
+	editorType: ContentBlockEditor.ContentPicker,
+	validator: (value: string) => {
+		const errorArray: string[] = [];
+
+		if (isNil(value) || isEmpty(value)) {
+			errorArray.push(emptyFieldValidatorMessage);
+		}
+
+		return errorArray;
+	},
+	editorProps: {
+		allowedTypes: ['ITEM'],
+		hideTargetSwitch: true,
+	},
+	...propOverride,
+});
+
 export const CONTENT_TYPE_AND_LABELS_INPUT = (
 	propOverride?: Partial<ContentBlockField>
 ): ContentBlockField => ({

--- a/src/admin/content-block/helpers/generators/media-player-title-text-button.ts
+++ b/src/admin/content-block/helpers/generators/media-player-title-text-button.ts
@@ -11,7 +11,13 @@ import {
 } from '../../../shared/types';
 import { GET_BUTTON_TYPE_OPTIONS, GET_HEADING_TYPE_OPTIONS } from '../../content-block.const';
 
-import { ALIGN_FIELD, BLOCK_FIELD_DEFAULTS, BLOCK_STATE_DEFAULTS, TEXT_FIELD } from './defaults';
+import {
+	ALIGN_FIELD,
+	BLOCK_FIELD_DEFAULTS,
+	BLOCK_STATE_DEFAULTS,
+	TEXT_FIELD,
+	VIDEO_FIELD,
+} from './defaults';
 
 export const INITIAL_MEDIA_PLAYER_TITLE_TEXT_BUTTON_COMPONENTS_STATE = (): MediaPlayerTitleTextButtonBlockComponentState => ({
 	mediaTitle: '',
@@ -49,15 +55,7 @@ export const MEDIA_PLAYER_TITLE_TEXT_BUTTON_BLOCK_CONFIG = (
 					editorType: ContentBlockEditor.TextInput,
 				}
 			),
-			mediaItem: {
-				label: i18n.t(
-					'admin/content-block/helpers/generators/media-player-title-text-button___video-of-audio-item'
-				),
-				editorType: ContentBlockEditor.ContentPicker,
-				editorProps: {
-					allowedTypes: ['ITEM'],
-				},
-			},
+			mediaItem: VIDEO_FIELD(),
 			headingTitle: TEXT_FIELD(
 				i18n.t('admin/content-block/helpers/generators/heading___titel-is-verplicht'),
 				{

--- a/src/admin/content-block/helpers/generators/media-player.ts
+++ b/src/admin/content-block/helpers/generators/media-player.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../shared/types';
 import { GET_WIDTH_OPTIONS } from '../../content-block.const';
 
-import { BLOCK_FIELD_DEFAULTS, BLOCK_STATE_DEFAULTS, TEXT_FIELD } from './defaults';
+import { BLOCK_FIELD_DEFAULTS, BLOCK_STATE_DEFAULTS, TEXT_FIELD, VIDEO_FIELD } from './defaults';
 
 export const INITIAL_MEDIA_PLAYER_COMPONENTS_STATE = (): MediaPlayerBlockComponentState => ({
 	title: '',
@@ -32,15 +32,7 @@ export const MEDIA_PLAYER_BLOCK_CONFIG = (position: number = 0): ContentBlockCon
 					editorType: ContentBlockEditor.TextInput,
 				}
 			),
-			item: {
-				label: i18n.t(
-					'admin/content-block/helpers/generators/media-player___video-of-audio-item'
-				),
-				editorType: ContentBlockEditor.ContentPicker,
-				editorProps: {
-					allowedTypes: ['ITEM'],
-				},
-			},
+			item: VIDEO_FIELD(),
 			width: {
 				label: i18n.t('admin/content-block/helpers/generators/media-player___breedte'),
 				editorType: ContentBlockEditor.Select,

--- a/src/admin/shared/components/ContentPicker/ContentPicker.tsx
+++ b/src/admin/shared/components/ContentPicker/ContentPicker.tsx
@@ -135,6 +135,7 @@ export const ContentPicker: FunctionComponent<ContentPickerProps> = ({
 	const onSelectItem = (selectedItem: ValueType<PickerItem>, event?: ActionMeta) => {
 		// reset `selectedItem` when clearing item picker
 		if (get(event, 'action') === 'clear') {
+			propertyChanged('selectedItem', null);
 			setSelectedItem(null);
 			return null;
 		}


### PR DESCRIPTION
- This implements the error when you clear the content picker after an item was selected. It will say that the video-item is mandatory.