### PR TITLE
fix(fragment-cut): save start time

### DIFF
--- a/src/collection/components/modals/CutFragmentModal.tsx
+++ b/src/collection/components/modals/CutFragmentModal.tsx
@@ -105,7 +105,7 @@ const CutFragmentModal: FunctionComponent<CutFragmentModalProps> = ({
 			index,
 			type: 'UPDATE_FRAGMENT_PROP',
 			fragmentProp: 'start_oc',
-			fragmentPropValue: start,
+			fragmentPropValue: startTime,
 		});
 
 		changeCollectionState({


### PR DESCRIPTION
Start time of cut is now saved too.

Known issue: blue banner on video doesn't update but that's seperate ticket.