### PR TITLE
feat(collection-detail): show cut on fragments

### DIFF
--- a/src/collection/components/fragment/FragmentDetail.tsx
+++ b/src/collection/components/fragment/FragmentDetail.tsx
@@ -71,6 +71,10 @@ const FragmentDetail: FunctionComponent<FragmentDetailProps> = ({
 			)}
 			onTitleClicked={getTitleClickedHandler()}
 			history={history}
+			cuePoints={{
+				start: collectionFragment.start_oc,
+				end: collectionFragment.end_oc,
+			}}
 			{...rest}
 		/>
 	) : (

--- a/src/item/components/ItemVideoDescription.tsx
+++ b/src/item/components/ItemVideoDescription.tsx
@@ -31,6 +31,11 @@ import { fetchPlayerTicket } from '../../shared/services/player-ticket-service';
 
 import './ItemVideoDescription.scss';
 
+interface CuePoints {
+	start: number | null;
+	end: number | null;
+}
+
 interface ItemVideoDescriptionProps extends DefaultSecureRouteProps {
 	itemMetaData: Avo.Item.Item;
 	showTitleOnVideo?: boolean;
@@ -38,6 +43,7 @@ interface ItemVideoDescriptionProps extends DefaultSecureRouteProps {
 	showTitle?: boolean;
 	title?: string;
 	description?: string;
+	cuePoints?: CuePoints;
 	onTitleClicked?: () => void;
 }
 
@@ -51,6 +57,7 @@ const ItemVideoDescription: FunctionComponent<ItemVideoDescriptionProps> = ({
 	title = itemMetaData.title,
 	description = itemMetaData.description,
 	onTitleClicked,
+	cuePoints,
 	user,
 }) => {
 	const [t] = useTranslation();
@@ -182,6 +189,7 @@ const ItemVideoDescription: FunctionComponent<ItemVideoDescriptionProps> = ({
 				token={getEnv('FLOW_PLAYER_TOKEN')}
 				dataPlayerId={getEnv('FLOW_PLAYER_ID')}
 				logo={get(itemMetaData, 'organisation.logo_url')}
+				{...cuePoints}
 				autoplay
 				itemUuid={itemMetaData.uid}
 			/>


### PR DESCRIPTION
Het was niet zichtbaar op de collectiedetail pagina dat een fragment ge-cut was. Nu wel.

Voorbeeld: fragment 2 op http://localhost:8080/collecties/86307cca-c264-4aa6-a219-a8a63df51534