### PR TITLE
fix(search): remove language name capitalization in search filter

### DIFF
--- a/src/search/components/SearchFilterControls.tsx
+++ b/src/search/components/SearchFilterControls.tsx
@@ -1,4 +1,4 @@
-import { capitalize, get } from 'lodash-es';
+import { get } from 'lodash-es';
 import React, { FunctionComponent, ReactNode, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -14,7 +14,7 @@ import { SearchFilterControlsProps } from '../search.types';
 import './SearchFilterControls.scss';
 
 const languageCodeToLabel = (code: string): string => {
-	return capitalize(LANGUAGES.nl[code]) || code;
+	return LANGUAGES.nl[code] || code;
 };
 
 const SearchFilterControls: FunctionComponent<SearchFilterControlsProps> = ({


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-200

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/79957344-b923cc00-8481-11ea-9ab2-3ad719f8233a.png)|![image](https://user-images.githubusercontent.com/1710840/79957352-bb862600-8481-11ea-8b47-0d372e1bfffd.png)|
