### PR TITLE
fix(page-overview-block): show title bar bg color only for this block

### DIFF
--- a/src/admin/content-block/helpers/generators/defaults.ts
+++ b/src/admin/content-block/helpers/generators/defaults.ts
@@ -44,13 +44,6 @@ export const BLOCK_STATE_DEFAULTS = (
 
 export const BLOCK_FIELD_DEFAULTS = () => ({
 	backgroundColor: BACKGROUND_COLOR_FIELD(),
-	headerBackgroundColor: BACKGROUND_COLOR_FIELD(
-		i18n.t('admin/content-block/helpers/generators/defaults___titelbalk-achtergrondkleur'),
-		{
-			label: i18n.t('admin/content-block/helpers/generators/defaults___transparant'),
-			value: Color.Transparent,
-		}
-	),
 	padding: PADDING_FIELD(),
 	userGroupIds: USER_GROUP_SELECT(),
 

--- a/src/admin/content-block/helpers/generators/page-overview.ts
+++ b/src/admin/content-block/helpers/generators/page-overview.ts
@@ -17,6 +17,7 @@ import {
 } from '../../content-block.const';
 
 import {
+	BACKGROUND_COLOR_FIELD,
 	BLOCK_FIELD_DEFAULTS,
 	BLOCK_STATE_DEFAULTS,
 	CONTENT_TYPE_AND_LABELS_INPUT,
@@ -142,6 +143,17 @@ export const PAGE_OVERVIEW_BLOCK_CONFIG = (position: number = 0): ContentBlockCo
 		block: {
 			state: INITIAL_PAGE_OVERVIEW_BLOCK_STATE(position),
 			fields: {
+				headerBackgroundColor: BACKGROUND_COLOR_FIELD(
+					i18n.t(
+						'admin/content-block/helpers/generators/defaults___titelbalk-achtergrondkleur'
+					),
+					{
+						label: i18n.t(
+							'admin/content-block/helpers/generators/defaults___transparant'
+						),
+						value: Color.Transparent,
+					}
+				),
 				...BLOCK_FIELD_DEFAULTS(),
 			},
 		},


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-653

Textblock doesn't show it anymore:
![image](https://user-images.githubusercontent.com/1710840/79963552-d9578900-8489-11ea-8ddd-40e7cecc5a60.png)

page overview block still shows it:
![image](https://user-images.githubusercontent.com/1710840/79963571-dfe60080-8489-11ea-8f99-7ff406de055d.png)
