### PR TITLE
fix(content-picker): fix target switch resetting value

### DIFF
--- a/src/admin/menu/views/MenuEdit.tsx
+++ b/src/admin/menu/views/MenuEdit.tsx
@@ -258,8 +258,8 @@ const MenuEdit: FunctionComponent<MenuEditProps> = ({ history, match }) => {
 		if (key === 'content') {
 			setMenuForm({
 				...menuForm,
-				content_type: get(value as PickerItem, 'type'),
-				content_path: get(value as PickerItem, 'value'),
+				content_type: get(value, 'type'),
+				content_path: get(value, 'value'),
 			});
 		} else {
 			setMenuForm({

--- a/src/admin/shared/components/ContentPicker/ContentPicker.tsx
+++ b/src/admin/shared/components/ContentPicker/ContentPicker.tsx
@@ -194,7 +194,7 @@ export const ContentPicker: FunctionComponent<ContentPickerProps> = ({
 		} else if (selectedType.picker === 'TEXT_INPUT') {
 			newValue = input;
 		} else if (selectedType.picker === 'SELECT' && selectedItem) {
-			newValue = get(selectedItem as PickerItem, 'value.value');
+			newValue = get(selectedItem, 'value.value');
 		} else {
 			newValue = null;
 		}

--- a/src/admin/shared/components/ContentPicker/ContentPicker.tsx
+++ b/src/admin/shared/components/ContentPicker/ContentPicker.tsx
@@ -194,7 +194,7 @@ export const ContentPicker: FunctionComponent<ContentPickerProps> = ({
 		} else if (selectedType.picker === 'TEXT_INPUT') {
 			newValue = input;
 		} else if (selectedType.picker === 'SELECT' && selectedItem) {
-			newValue = (selectedItem as PickerItem).value;
+			newValue = get(selectedItem as PickerItem, 'value.value');
 		} else {
 			newValue = null;
 		}


### PR DESCRIPTION
- Switching the target toggle made it that the value was an object instead of the id of whatever was selected, hence the link didn't work anymore, and the second content picker select field showed empty as the object was not part of the options.

