### PR TITLE
feat(admin-item-detail): allow entering notes for an item

### DIFF
--- a/src/admin/items/items.gql.ts
+++ b/src/admin/items/items.gql.ts
@@ -38,6 +38,7 @@ export const GET_ITEMS = gql`
 				label
 			}
 			updated_at
+			note
 			view_counts_aggregate {
 				aggregate {
 					count
@@ -81,6 +82,7 @@ export const GET_ITEM_BY_ID = gql`
 				label
 			}
 			updated_at
+			note
 			view_counts_aggregate {
 				aggregate {
 					count
@@ -124,6 +126,7 @@ export const GET_ITEM_BY_EXTERNAL_ID = gql`
 				label
 			}
 			updated_at
+			note
 			view_counts_aggregate {
 				aggregate {
 					count
@@ -133,9 +136,17 @@ export const GET_ITEM_BY_EXTERNAL_ID = gql`
 	}
 `;
 
-export const UPDATE_ITEM = gql`
+export const UPDATE_ITEM_PUBLISH_STATE = gql`
 	mutation updateItemPublishedState($id: uuid!, $isPublished: Boolean!) {
 		update_app_item_meta(where: { uid: { _eq: $id } }, _set: { is_published: $isPublished }) {
+			affected_rows
+		}
+	}
+`;
+
+export const UPDATE_ITEM_NOTES = gql`
+	mutation updateItemPublishedState($id: uuid!, $note: String) {
+		update_app_item_meta(where: { uid: { _eq: $id } }, _set: { note: $note }) {
 			affected_rows
 		}
 	}

--- a/src/admin/items/items.service.ts
+++ b/src/admin/items/items.service.ts
@@ -6,7 +6,13 @@ import { CustomError } from '../../shared/helpers';
 import { dataService } from '../../shared/services';
 
 import { ITEMS_PER_PAGE, TABLE_COLUMN_TO_DATABASE_ORDER_OBJECT } from './items.const';
-import { GET_ITEM_BY_EXTERNAL_ID, GET_ITEM_BY_ID, GET_ITEMS, UPDATE_ITEM } from './items.gql';
+import {
+	GET_ITEM_BY_EXTERNAL_ID,
+	GET_ITEM_BY_ID,
+	GET_ITEMS,
+	UPDATE_ITEM_NOTES,
+	UPDATE_ITEM_PUBLISH_STATE,
+} from './items.gql';
 import { ItemsOverviewTableCols } from './items.types';
 
 export class ItemsService {
@@ -121,7 +127,7 @@ export class ItemsService {
 			};
 			const response = await dataService.mutate({
 				variables,
-				mutation: UPDATE_ITEM,
+				mutation: UPDATE_ITEM_PUBLISH_STATE,
 			});
 
 			if (response.errors) {
@@ -135,9 +141,34 @@ export class ItemsService {
 				err,
 				{
 					variables,
-					query: 'UPDATE_ITEM',
+					query: 'UPDATE_ITEM_PUBLISH_STATE',
 				}
 			);
+		}
+	}
+
+	static async setItemNotes(id: string, note: string | null): Promise<void> {
+		let variables: any;
+		try {
+			variables = {
+				id,
+				note,
+			};
+			const response = await dataService.mutate({
+				variables,
+				mutation: UPDATE_ITEM_NOTES,
+			});
+
+			if (response.errors) {
+				throw new CustomError('Response from gragpql contains errors', null, {
+					response,
+				});
+			}
+		} catch (err) {
+			throw new CustomError('Failed to update note field for item in the database', err, {
+				variables,
+				query: 'UPDATE_ITEM_NOTES',
+			});
 		}
 	}
 }

--- a/src/admin/items/views/ItemDetail.tsx
+++ b/src/admin/items/views/ItemDetail.tsx
@@ -11,6 +11,9 @@ import {
 	Spacer,
 	Table,
 	Thumbnail,
+	Toolbar,
+	ToolbarRight,
+	WYSIWYG,
 } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
@@ -26,6 +29,7 @@ import { buildLink, CustomError } from '../../../shared/helpers';
 import { ToastService } from '../../../shared/services';
 import {
 	renderDateDetailRows,
+	renderDetailRow,
 	renderMultiOptionDetailRows,
 	renderSimpleDetailRows,
 } from '../../shared/helpers/render-detail-fields';
@@ -169,6 +173,19 @@ const ItemDetail: FunctionComponent<ItemDetailProps> = ({ history, match }) => {
 		);
 	};
 
+	const saveNotes = async () => {
+		try {
+			if (!item) {
+				return;
+			}
+			await ItemsService.setItemNotes(item.uid, (item as any).note || null);
+			ToastService.success(t('Opmerkingen opgeslagen'), false);
+		} catch (err) {
+			console.error(new CustomError('Failed to save item notes', err, { item }));
+			ToastService.danger(t('Het opslaan van de opmerkingen is mislukt'), false);
+		}
+	};
+
 	const renderCollectionCell = (
 		rowData: Partial<Avo.Collection.Collection>,
 		columnId: CollectionColumnId
@@ -288,6 +305,31 @@ const ItemDetail: FunctionComponent<ItemDetailProps> = ({ history, match }) => {
 									t('admin/items/views/item-detail___views'),
 								],
 							])}
+							{renderDetailRow(
+								<>
+									{/* TODO remove any cast after update to typings 2.16.0 */}
+									<div style={{ backgroundColor: '#FFF' }}>
+										<WYSIWYG
+											id="note"
+											data={(item as any).note}
+											onChange={(note: string | null) =>
+												setItem({ ...item, note } as Avo.Item.Item)
+											}
+										/>
+									</div>
+									<Spacer margin="top-small">
+										<Toolbar>
+											<ToolbarRight>
+												<Button
+													label={t('Opmerkingen opslaan')}
+													onClick={saveNotes}
+												/>
+											</ToolbarRight>
+										</Toolbar>
+									</Spacer>
+								</>,
+								t('Opmerkingen')
+							)}
 						</tbody>
 					</Table>
 					<Spacer margin="top-extra-large">


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-284

if any other fields need editing, we should create a separate edit page. For this single notes field, it seems a bit overkill.

![image](https://user-images.githubusercontent.com/1710840/80118128-494c3900-8588-11ea-9cf6-96b0c56603b1.png)
