### PR TITLE
fix(content-block-preview): resize header height on resize, state change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19718,9 +19718,8 @@
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resizable-panels-react": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/resizable-panels-react/-/resizable-panels-react-2.0.8.tgz",
-			"integrity": "sha512-noOZ+ENr6jc6E8WUbBVJWex6ogl6W7iWqGoy0TRVscXK4rW9iq8e17mf0hvyz8SybfgQfg129qALY/PVShy8vw==",
+			"version": "github:bertyhell/ResizablePanelsReact#b60559fddfd2d938ee61a71e89c906bb56299df0",
+			"from": "github:bertyhell/ResizablePanelsReact",
 			"requires": {
 				"react": "^16.8.4",
 				"react-dom": "^16.8.4",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"redux": "^4.0.1",
 		"redux-devtools-extension": "^2.13.8",
 		"redux-thunk": "^2.3.0",
-		"resizable-panels-react": "^2.0.8",
+		"resizable-panels-react": "github:bertyhell/ResizablePanelsReact",
 		"sanitize-html": "^1.20.1",
 		"use-query-params": "^0.6.0"
 	},

--- a/src/admin/content-block/components/ContentBlockPreview/ContentBlockPreview.tsx
+++ b/src/admin/content-block/components/ContentBlockPreview/ContentBlockPreview.tsx
@@ -69,7 +69,7 @@ const ContentBlockPreview: FunctionComponent<ContentBlockPreviewProps> = ({
 		}
 	}, [blockState.headerBackgroundColor]);
 
-	useEffect(updateHeaderHeight, [blockRef.current]);
+	useEffect(updateHeaderHeight, [blockRef.current, blockState, componentState]);
 
 	if (NAVIGABLE_CONTENT_BLOCKS.includes(blockState.blockType)) {
 		// Pass the navigate function to each element (deprecated) => prefer passing the navigate function once to the block

--- a/src/admin/content/views/ContentEditContentBlocks.tsx
+++ b/src/admin/content/views/ContentEditContentBlocks.tsx
@@ -137,6 +137,9 @@ const ContentEditContentBlocks: FunctionComponent<ContentEditContentBlocksProps>
 				panelsSize={[60, 40]}
 				sizeUnitMeasure="%"
 				resizerSize="15px"
+				onResize={() => {
+					window.dispatchEvent(new Event('resize'));
+				}}
 			>
 				<div className="c-content-edit-view__preview" ref={previewScrollable}>
 					<ContentPage


### PR DESCRIPTION
recloses: https://meemoo.atlassian.net/browse/AVO-652


![2020-04-29_10-58-44](https://user-images.githubusercontent.com/1710840/80578394-acb2ec80-8a08-11ea-9aa8-acd7abbbd5d8.gif)

