### PR TITLE
fix(block-preview): block padding handles padding, not block content

### DIFF
--- a/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.scss
+++ b/src/admin/content-block/components/ContentBlockForm/ContentBlockForm.scss
@@ -1,6 +1,8 @@
 @import '../../../../styles/settings/colors';
 
 .c-content-block-form {
+	margin-bottom: 2rem;
+
 	.o-form-group {
 		margin-bottom: 0.8rem;
 	}

--- a/src/admin/content-block/components/ContentBlockPreview/ContentBlockPreview.scss
+++ b/src/admin/content-block/components/ContentBlockPreview/ContentBlockPreview.scss
@@ -19,6 +19,13 @@
 
 		.c-content-block-preview {
 			z-index: 1;
+
+
+			> .o-container {
+				h1, h2, h3, h4, h5, h6 { // No margins on header blocks, the block margins should handle this: https://meemoo.atlassian.net/browse/AVO-315
+					margin: 0;
+				}
+			}
 		}
 	}
 }

--- a/src/admin/content-block/components/fields/PaddingSelect/PaddingSelect.tsx
+++ b/src/admin/content-block/components/fields/PaddingSelect/PaddingSelect.tsx
@@ -18,6 +18,10 @@ const PaddingSelect: FunctionComponent<PaddingSelectProps> = ({ onChange, value 
 	const generateOptions = (direction: PaddingDirection) =>
 		[
 			{
+				label: t('Geen'),
+				value: '',
+			},
+			{
 				label: t(
 					'admin/content-block/components/fields/padding-select/padding-select___klein'
 				),

--- a/src/admin/content-block/helpers/generators/defaults.ts
+++ b/src/admin/content-block/helpers/generators/defaults.ts
@@ -25,7 +25,6 @@ export const BLOCK_STATE_DEFAULTS = (
 	position: number,
 	backgroundColor: Color = Color.White,
 	headerBackgroundColor: Color = Color.Transparent,
-	headerHeight: string = '0', // Currently we only need 2 block background colors for the PageOverviewBlock component
 	padding: PaddingFieldState = {
 		top: 'top',
 		bottom: 'bottom',
@@ -36,7 +35,6 @@ export const BLOCK_STATE_DEFAULTS = (
 	position,
 	backgroundColor,
 	headerBackgroundColor,
-	headerHeight,
 	padding,
 	userGroupIds,
 });

--- a/src/admin/content-block/helpers/generators/heading.ts
+++ b/src/admin/content-block/helpers/generators/heading.ts
@@ -1,5 +1,6 @@
 import i18n from '../../../../shared/translations/i18n';
 import {
+	Color,
 	ContentBlockConfig,
 	ContentBlockEditor,
 	ContentBlockType,
@@ -17,7 +18,10 @@ export const INITIAL_HEADING_COMPONENTS_STATE = (): HeadingBlockComponentState =
 });
 
 export const INITIAL_HEADING_BLOCK_STATE = (position: number): DefaultContentBlockState =>
-	BLOCK_STATE_DEFAULTS(ContentBlockType.Heading, position);
+	BLOCK_STATE_DEFAULTS(ContentBlockType.Heading, position, Color.White, Color.White, {
+		top: 'top-extra-large',
+		bottom: 'bottom-small',
+	});
 
 export const HEADING_BLOCK_CONFIG = (position: number = 0): ContentBlockConfig => ({
 	name: i18n.t('admin/content-block/helpers/generators/heading___titel'),

--- a/src/admin/content-block/helpers/generators/page-overview.ts
+++ b/src/admin/content-block/helpers/generators/page-overview.ts
@@ -44,7 +44,10 @@ export const INITIAL_PAGE_OVERVIEW_BLOCK_STATE = (position: number): DefaultCont
 			position,
 			Color.White,
 			Color.Transparent,
-			'70px'
+			{
+				top: 'top-small',
+				bottom: 'bottom-extra-large',
+			}
 		),
 	};
 };

--- a/src/admin/content/views/ContentEdit.scss
+++ b/src/admin/content/views/ContentEdit.scss
@@ -9,7 +9,7 @@ $content-top-bar-and-tabs-height: 113px;
 		width: 100%;
 		height: calc(100vh - #{$content-top-bar-and-tabs-height} - 68px);
 		overflow-y: auto;
-		padding: 0 1.6rem 1.6rem;
+		padding: 2rem 1.6rem 8rem;
 	}
 
 	> .o-sidebar__content > .c-navbar {


### PR DESCRIPTION
closes: 
* https://meemoo.atlassian.net/browse/AVO-315
* https://meemoo.atlassian.net/browse/AVO-192

components pr: https://github.com/viaacode/avo2-components/pull/312

Problem where headersblock content has its own padding:
![image](https://user-images.githubusercontent.com/1710840/81044100-f04ba180-8eb3-11ea-9034-d665fbacd88c.png)

Fixed by removing padding from block content and increasing the block padding:
![image](https://user-images.githubusercontent.com/1710840/81044104-f3df2880-8eb3-11ea-812e-b7eded684fe9.png)

Add extra padding option:
![image](https://user-images.githubusercontent.com/1710840/81044159-0fe2ca00-8eb4-11ea-9b90-e7667df28a92.png)

Remove padding image block:
![image](https://user-images.githubusercontent.com/1710840/81047471-c053cc80-8eba-11ea-98a8-85159ad17dda.png)

Remove padding rich text block:
![image](https://user-images.githubusercontent.com/1710840/81047481-c649ad80-8eba-11ea-8fc3-c0a5ad0edfcb.png)
