### PR TITLE
feat(checkbox-dropdown): disable button if no filter

### DIFF
--- a/src/shared/components/CheckboxDropdownModal/CheckboxDropdownModal.tsx
+++ b/src/shared/components/CheckboxDropdownModal/CheckboxDropdownModal.tsx
@@ -167,10 +167,14 @@ export const CheckboxDropdownModal: FunctionComponent<CheckboxDropdownModalProps
 											}
 										/>
 									))}
+									{!options.length && (
+										<span>Er zijn geen zoekfilters in deze categorie.</span>
+									)}
 								</CheckboxGroup>
 							</FormGroup>
 							<FormGroup>
 								<Button
+									disabled={!options.length}
 									label={t(
 										'shared/components/checkbox-dropdown-modal/checkbox-dropdown-modal___toepassen'
 									)}


### PR DESCRIPTION
When there are no filters in search, disable "Toepassen" button and display text.