### PR TITLE
feat(logout): redirect to /leerlingen when pupil logs out

### DIFF
--- a/src/authentication/helpers/redirects.ts
+++ b/src/authentication/helpers/redirects.ts
@@ -66,9 +66,9 @@ export function redirectToServerLoginPage(location: Location) {
 	})}`;
 }
 
-export function redirectToServerLogoutPage(location: Location) {
+export function redirectToServerLogoutPage(location: Location, routeAfterLogout: string) {
 	// Url to return to after logout is completed
-	const returnToUrl = `${getBaseUrl(location)}`;
+	const returnToUrl = `${getBaseUrl(location)}${routeAfterLogout}`;
 	window.location.href = `${getEnv('PROXY_URL')}/${SERVER_LOGOUT_PAGE}?${queryString.stringify({
 		returnToUrl,
 	})}`;

--- a/src/authentication/views/Logout.tsx
+++ b/src/authentication/views/Logout.tsx
@@ -1,13 +1,18 @@
+import { get } from 'lodash-es';
 import { FunctionComponent } from 'react';
 import { RouteComponentProps } from 'react-router';
 
+import withUser, { UserProps } from '../../shared/hocs/withUser';
 import { redirectToServerLogoutPage } from '../helpers/redirects';
 
-export interface LogoutProps extends RouteComponentProps {}
+export interface LogoutProps extends RouteComponentProps, UserProps {}
 
-export const Logout: FunctionComponent<LogoutProps> = ({ location }) => {
-	redirectToServerLogoutPage(location);
+export const Logout: FunctionComponent<LogoutProps> = ({ location, user }) => {
+	redirectToServerLogoutPage(
+		location,
+		get(user, 'role.name') === 'leerling' ? '/leerlingen' : '/'
+	);
 	return null;
 };
 
-export default Logout;
+export default withUser(Logout) as FunctionComponent<RouteComponentProps>;

--- a/src/error/views/ErrorView.tsx
+++ b/src/error/views/ErrorView.tsx
@@ -1,4 +1,4 @@
-import { uniq } from 'lodash-es';
+import { omit, uniq } from 'lodash-es';
 import queryString from 'query-string';
 import React, { FunctionComponent, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,13 +9,19 @@ import {
 	Button,
 	ButtonToolbar,
 	Container,
+	Flex,
 	IconName,
+	Spacer,
+	Spinner,
 	Toolbar,
 	ToolbarCenter,
 } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
-import { redirectToClientPage } from '../../authentication/helpers/redirects';
+import {
+	redirectToClientPage,
+	redirectToServerLogoutPage,
+} from '../../authentication/helpers/redirects';
 import { APP_PATH } from '../../constants';
 import { CustomError } from '../../shared/helpers';
 import i18n from '../../shared/translations/i18n';
@@ -49,6 +55,22 @@ const ErrorView: FunctionComponent<ErrorViewProps> = ({
 	const [t] = useTranslation();
 
 	const queryParams = queryString.parse((location.search || '').substring(1));
+
+	if (queryParams.logout) {
+		// redirect to logout route and afterwards redirect back to the error page
+		redirectToServerLogoutPage(
+			location,
+			`/error?${queryString.stringify(omit(queryParams, 'logout'))}`
+		);
+		return (
+			<Spacer margin={['top-large', 'bottom-large']}>
+				<Flex center>
+					<Spinner size="large" />
+				</Flex>
+			</Spacer>
+		);
+	}
+
 	const errorMessage: string =
 		(queryParams.message as string) ||
 		message ||

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -33,7 +33,7 @@ export const ROUTE_PARTS = Object.freeze({
 	settings: 'instellingen',
 	help: 'hulp',
 	feedback: 'feedback',
-	loggedInHome: 'home',
+	loggedInHome: 'start',
 	profile: 'profiel',
 	completeProfile: 'vervolledig-profiel',
 	acceptConditions: 'accepteer-voorwaarden',


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-455

This cannot be tested locally since there is a bug in the idp for localhost development.
You can go to http://localhost:8080/leerlingen and see the page
and you should end up on /start when you login instead of /home

testing logout for pupils will have to be done after deploying

![image](https://user-images.githubusercontent.com/1710840/81308461-145cdd80-9082-11ea-872e-8f3a406caaff.png)

![image](https://user-images.githubusercontent.com/1710840/81308468-158e0a80-9082-11ea-9c33-87fd236c0d9e.png)
