### PR TITLE
fix(error-view): logout if error occurs during login flow

### DIFF
--- a/src/error/views/ErrorView.tsx
+++ b/src/error/views/ErrorView.tsx
@@ -1,4 +1,4 @@
-import { uniq } from 'lodash-es';
+import { omit, uniq } from 'lodash-es';
 import queryString from 'query-string';
 import React, { FunctionComponent, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,13 +9,19 @@ import {
 	Button,
 	ButtonToolbar,
 	Container,
+	Flex,
 	IconName,
+	Spacer,
+	Spinner,
 	Toolbar,
 	ToolbarCenter,
 } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
-import { redirectToClientPage } from '../../authentication/helpers/redirects';
+import {
+	redirectToClientPage,
+	redirectToServerLogoutPage,
+} from '../../authentication/helpers/redirects';
 import { APP_PATH } from '../../constants';
 import { CustomError } from '../../shared/helpers';
 import i18n from '../../shared/translations/i18n';
@@ -49,6 +55,22 @@ const ErrorView: FunctionComponent<ErrorViewProps> = ({
 	const [t] = useTranslation();
 
 	const queryParams = queryString.parse((location.search || '').substring(1));
+
+	if (queryParams.logout) {
+		// redirect to logout route and afterwards redirect back to the error page
+		redirectToServerLogoutPage(
+			location,
+			`/error?${queryString.stringify(omit(queryParams, 'logout'))}`
+		);
+		return (
+			<Spacer margin={['top-large', 'bottom-large']}>
+				<Flex center>
+					<Spinner size="large" />
+				</Flex>
+			</Spacer>
+		);
+	}
+
 	const errorMessage: string =
 		(queryParams.message as string) ||
 		message ||


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-675

Proxy pr: https://github.com/viaacode/avo2-proxy/pull/137

This way, the saml ticket gets refreshed between login attempts, so new settings made in ldap are reflected in the new saml ticket.

steps:
* user tries to login
* server sees that the user does not have access to avo
* server redirects to client error page with logout=true query param
* client error page logs the user out by redirecting to the server logout route
* server logs the user off of the idp
* server redirects back to error page without query param: logout=true
* user can contact the helpdesk
* helpdesk can give the user access to avo through the meemoo account manager dashboard
* user tries to login again
* the server receives a NEW saml ticket with the avo group
* user is logged in succesfully