### PR TITLE
fix(assignment-edit): ensure labels are saved correctly

### DIFF
--- a/src/assignment/views/AssignmentCreate.tsx
+++ b/src/assignment/views/AssignmentCreate.tsx
@@ -38,7 +38,7 @@ import {
 } from '../../shared/components';
 import { ROUTE_PARTS } from '../../shared/constants';
 import { buildLink, copyToClipboard, CustomError, navigate } from '../../shared/helpers';
-import { AssignmentLabelsService, ToastService } from '../../shared/services';
+import { ToastService } from '../../shared/services';
 import { trackEvents } from '../../shared/services/event-logging-service';
 import { ASSIGNMENTS_ID } from '../../workspace/workspace.const';
 import { CONTENT_LABEL_TO_EVENT_OBJECT_TYPE } from '../assignment.const';
@@ -72,9 +72,8 @@ const AssignmentCreate: FunctionComponent<DefaultSecureRouteProps> = ({
 		(assignment: Partial<Avo.Assignment.Assignment>) => {
 			setCurrentAssignment(assignment);
 			setInitialAssignment(assignment);
-			setAssignmentLabels(AssignmentLabelsService.getLabelsFromAssignment(assignment));
 		},
-		[setCurrentAssignment, setInitialAssignment, setAssignmentLabels]
+		[setCurrentAssignment, setInitialAssignment]
 	);
 
 	/**

--- a/src/assignment/views/AssignmentEdit.tsx
+++ b/src/assignment/views/AssignmentEdit.tsx
@@ -73,9 +73,8 @@ const AssignmentEdit: FunctionComponent<DefaultSecureRouteProps<{ id: string }>>
 		(assignment: Partial<Avo.Assignment.Assignment>) => {
 			setCurrentAssignment(assignment);
 			setInitialAssignment(assignment);
-			setAssignmentLabels(AssignmentLabelsService.getLabelsFromAssignment(assignment));
 		},
-		[setCurrentAssignment, setInitialAssignment, setAssignmentLabels]
+		[setCurrentAssignment, setInitialAssignment]
 	);
 
 	/**
@@ -104,6 +103,9 @@ const AssignmentEdit: FunctionComponent<DefaultSecureRouteProps<{ id: string }>>
 					...tempAssignment,
 					title: tempAssignment.title || get(tempAssignmentContent, 'title', ''),
 				});
+				setAssignmentLabels(
+					AssignmentLabelsService.getLabelsFromAssignment(tempAssignment)
+				);
 			} catch (err) {
 				setLoadingInfo({
 					state: 'error',
@@ -266,7 +268,7 @@ const AssignmentEdit: FunctionComponent<DefaultSecureRouteProps<{ id: string }>>
 			await AssignmentService.updateAssignment(
 				assignment,
 				AssignmentLabelsService.getLabelsFromAssignment(initialAssignment),
-				AssignmentLabelsService.getLabelsFromAssignment(currentAssignment)
+				assignmentLabels
 			);
 			setBothAssignments(assignment);
 			ToastService.success(


### PR DESCRIPTION
steps to reproduce before this patch:

* edit an assignment
* add a label
* save assignment

expected result: labels stay visible

result before patch: labels reset to initial labels