### PR TITLE
fix(media-tiles-block): correctly map button action to media tile

### DIFF
--- a/src/admin/content-block/components/wrappers/MediaGridWrapper/MediaGridWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/MediaGridWrapper/MediaGridWrapper.tsx
@@ -3,10 +3,9 @@ import React, { FunctionComponent, useCallback, useEffect, useState } from 'reac
 import { useTranslation } from 'react-i18next';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
-import { BlockMediaList, ButtonAction, LinkTarget, MediaListItem } from '@viaa/avo2-components';
+import { BlockMediaList, ButtonAction, MediaListItem } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
-import { toEnglishContentType } from '../../../../../collection/collection.types';
 import { LoadingErrorLoadedComponent, LoadingInfo } from '../../../../../shared/components';
 import { CustomError, formatDate, navigateToContentType } from '../../../../../shared/helpers';
 import { parseIntOrDefault } from '../../../../../shared/helpers/parsers/number';
@@ -118,15 +117,7 @@ const MediaGridWrapper: FunctionComponent<MediaGridWrapperProps> = ({
 			buttonLabel: element.buttonLabel,
 			buttonType: element.buttonType,
 			buttonIcon: element.buttonIcon,
-			buttonAction: element.buttonAction || {
-				type: (isItem
-					? 'ITEM'
-					: toEnglishContentType(
-							get(itemOrCollection, 'type.label')
-					  ).toUpperCase()) as Avo.Core.ContentPickerType,
-				value: (isItem ? itemOrCollection.external_id : itemOrCollection.id) as string,
-				target: get(searchQuery, 'target') || LinkTarget.Self,
-			},
+			buttonAction: element.mediaItem,
 			title: itemOrCollection.title || '',
 			thumbnail: {
 				label: itemLabel,


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-215

When you do not select a custom media tile button action, it should correctly link to the media item that was selected for the time