### PR TITLE
fix(admin-bundle-overview): set correct prop for boolean filters

### DIFF
--- a/src/admin/shared/helpers/filters.ts
+++ b/src/admin/shared/helpers/filters.ts
@@ -36,7 +36,7 @@ export function getBooleanFilters(filters: any, booleanProps: string[]): any[] {
 		booleanProps.map((booleanProp: string) => {
 			const booleanValue = (filters as any)[booleanProp];
 			if (!isNil(booleanValue)) {
-				return { is_published: { _eq: booleanValue ? 'true' : 'false' } };
+				return { [booleanProp]: { _eq: booleanValue ? 'true' : 'false' } };
 			}
 			return null;
 		})


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-515

steps to reproduce bug before this patch:
* go to bundle overview in admin dashboard
* filter bundels by public: true

expected result: only public bundles are shown

result before this patch: error page