### PR TITLE
AVO-319 & AVO-295: Move personal notes to meta data tab

### DIFF
--- a/src/collection/components/CollectionOrBundleEditAdmin.tsx
+++ b/src/collection/components/CollectionOrBundleEditAdmin.tsx
@@ -15,7 +15,6 @@ import {
 	Table,
 	TagInfo,
 	TagsInput,
-	TextArea,
 } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
@@ -243,29 +242,6 @@ const CollectionOrBundleEditAdmin: FunctionComponent<CollectionOrBundleEditAdmin
 													collectionPropValue: value.value,
 												});
 											}}
-										/>
-									</FormGroup>
-									<FormGroup
-										label={t(
-											'collection/views/collection-edit-meta-data___persoonlijke-opmerkingen-notities'
-										)}
-										labelFor="personalRemarkId"
-									>
-										<TextArea
-											name="personalRemarkId"
-											value={collection.note || ''}
-											id="personalRemarkId"
-											height="medium"
-											placeholder={t(
-												'collection/views/collection-edit-meta-data___geef-hier-je-persoonlijke-opmerkingen-notities-in'
-											)}
-											onChange={(value: string) =>
-												changeCollectionState({
-													type: 'UPDATE_COLLECTION_PROP',
-													collectionProp: 'note',
-													collectionPropValue: value,
-												})
-											}
 										/>
 									</FormGroup>
 								</Column>

--- a/src/collection/components/CollectionOrBundleEditMetaData.tsx
+++ b/src/collection/components/CollectionOrBundleEditMetaData.tsx
@@ -202,6 +202,29 @@ const CollectionOrBundleEditMetaData: FunctionComponent<CollectionOrBundleEditMe
 											</label>
 										</FormGroup>
 									)}
+									<FormGroup
+										label={t(
+											'collection/views/collection-edit-meta-data___persoonlijke-opmerkingen-notities'
+										)}
+										labelFor="personalRemarkId"
+									>
+										<TextArea
+											name="personalRemarkId"
+											value={collection.note || ''}
+											id="personalRemarkId"
+											height="medium"
+											placeholder={t(
+												'collection/views/collection-edit-meta-data___geef-hier-je-persoonlijke-opmerkingen-notities-in'
+											)}
+											onChange={(value: string) =>
+												changeCollectionState({
+													type: 'UPDATE_COLLECTION_PROP',
+													collectionProp: 'note',
+													collectionPropValue: value,
+												})
+											}
+										/>
+									</FormGroup>
 								</Column>
 								<Column size="3-5">
 									<FormGroup


### PR DESCRIPTION
Bij bundels en collecties staat "Persoonlijke notities" nu weer onder meta data en niet onder beheer.

Fixes: AVO-319 & AVO-295