### PR TITLE
AVO-702: Reeds in gebruikt toont nu in Danger toast in plaats van Success.

### DIFF
--- a/src/authentication/components/StamboekInput.tsx
+++ b/src/authentication/components/StamboekInput.tsx
@@ -104,7 +104,7 @@ export const StamboekInput: FunctionComponent<StamboekInputProps> = ({
 					.
 				</span>
 			),
-			status: ToastType.SUCCESS,
+			status: ToastType.DANGER,
 		},
 		SERVER_ERROR: {
 			message: t(


### PR DESCRIPTION
closes
AVO-703