### PR TITLE
feat(collection): warn if collection used by assignment on delete

### DIFF
--- a/src/assignment/assignment.gql.ts
+++ b/src/assignment/assignment.gql.ts
@@ -39,6 +39,24 @@ export const GET_ASSIGNMENT_BY_ID = gql`
 	}
 `;
 
+export const GET_ASSIGNMENT_BY_CONTENT_ID_AND_TYPE = gql`
+	query getAssignmentsByContentIdAndType(
+		$contentId: String!
+		$contentType: lookup_enum_assignment_content_labels_enum!
+	) {
+		app_assignments(
+			where: {
+				content_id: { _eq: $contentId }
+				content_label: { _eq: $contentType }
+				is_deleted: { _eq: false }
+			}
+		) {
+			id
+			title
+		}
+	}
+`;
+
 export const GET_ASSIGNMENTS_BY_OWNER_ID = gql`
 	query getAssignmentsByOwner(
 		$owner_profile_id: uuid

--- a/src/assignment/views/AssignmentOverview.tsx
+++ b/src/assignment/views/AssignmentOverview.tsx
@@ -91,7 +91,7 @@ const AssignmentOverview: FunctionComponent<AssignmentOverviewProps> = ({
 		null
 	);
 	const [page, setPage] = useState<number>(0);
-	const [canEditAssignments, setCanEditAssignments] = useState<boolean>(false);
+	const [canEditAssignments, setCanEditAssignments] = useState<boolean | null>(null);
 
 	const [sortColumn, sortOrder, handleColumnClick] = useTableSort<
 		AssignmentOverviewTableColumns | 'created_at'
@@ -99,9 +99,11 @@ const AssignmentOverview: FunctionComponent<AssignmentOverviewProps> = ({
 
 	const checkPermissions = useCallback(async () => {
 		try {
-			setCanEditAssignments(
-				await PermissionService.hasPermissions(PermissionName.EDIT_ASSIGNMENTS, user)
-			);
+			if (user) {
+				setCanEditAssignments(
+					await PermissionService.hasPermissions(PermissionName.EDIT_ASSIGNMENTS, user)
+				);
+			}
 		} catch (err) {
 			console.error('Failed to check permissions', err, {
 				user,
@@ -117,6 +119,9 @@ const AssignmentOverview: FunctionComponent<AssignmentOverviewProps> = ({
 
 	const fetchAssignments = useCallback(async () => {
 		try {
+			if (isNil(canEditAssignments)) {
+				return;
+			}
 			const response = await AssignmentService.fetchAssignments(
 				canEditAssignments,
 				user,

--- a/src/collection/collection.service.ts
+++ b/src/collection/collection.service.ts
@@ -25,6 +25,7 @@ import {
 	GET_COLLECTIONS,
 	GET_COLLECTIONS_BY_FRAGMENT_ID,
 	GET_COLLECTIONS_BY_ID,
+	GET_COLLECTIONS_BY_OWNER,
 	GET_COLLECTIONS_BY_TITLE,
 	GET_ITEMS_BY_IDS,
 	GET_QUALITY_LABELS,
@@ -979,7 +980,7 @@ export class CollectionService {
 		}
 	}
 
-	static async fetchCollectionsByFragmentId(
+	public static async fetchCollectionsByFragmentId(
 		fragmentId: string
 	): Promise<Avo.Collection.Collection[]> {
 		try {
@@ -989,12 +990,51 @@ export class CollectionService {
 				variables: { fragmentId },
 			});
 
+			if (response.errors) {
+				throw new CustomError('graphql response contains errors', null, { response });
+			}
+
 			return get(response, 'data.app_collections', []);
 		} catch (err) {
 			// handle error
 			throw new CustomError('Fetch collections by fragment id failed', err, {
 				query: 'GET_COLLECTIONS_BY_FRAGMENT_ID',
 				variables: { fragmentId },
+			});
+		}
+	}
+
+	public static async fetchCollectionsByOwner(
+		user: Avo.User.User,
+		offset: number,
+		limit: number,
+		order: any,
+		contentTypeId: ContentTypeNumber.collection | ContentTypeNumber.bundle
+	) {
+		let variables: any;
+		try {
+			variables = {
+				offset,
+				limit,
+				order,
+				type_id: contentTypeId,
+				owner_profile_id: getProfileId(user),
+			};
+			const response = await dataService.query({
+				variables,
+				query: GET_COLLECTIONS_BY_OWNER,
+			});
+
+			if (response.errors) {
+				throw new CustomError('graphql response contains errors', null, { response });
+			}
+
+			return get(response, 'data.app_collections', []);
+		} catch (err) {
+			// handle error
+			throw new CustomError('Fetch collections by fragment id failed', err, {
+				variables,
+				query: 'GET_COLLECTIONS_BY_OWNER',
 			});
 		}
 	}

--- a/src/collection/components/CollectionOrBundleEdit.tsx
+++ b/src/collection/components/CollectionOrBundleEdit.tsx
@@ -44,7 +44,6 @@ import { redirectToClientPage } from '../../authentication/helpers/redirects';
 import { APP_PATH, GENERATE_SITE_TITLE } from '../../constants';
 import {
 	ControlledDropdown,
-	DeleteObjectModal,
 	DraggableListModal,
 	InputModal,
 	InteractiveTour,
@@ -78,6 +77,7 @@ import { getFragmentProperty } from '../helpers';
 import CollectionOrBundleEditAdmin from './CollectionOrBundleEditAdmin';
 import CollectionOrBundleEditContent from './CollectionOrBundleEditContent';
 import CollectionOrBundleEditMetaData from './CollectionOrBundleEditMetaData';
+import DeleteCollectionModal from './modals/DeleteCollectionModal';
 
 type FragmentPropUpdateAction = {
 	type: 'UPDATE_FRAGMENT_PROP';
@@ -557,6 +557,9 @@ const CollectionOrBundleEdit: FunctionComponent<CollectionOrBundleEditProps &
 			);
 
 			navigate(history, APP_PATH.WORKSPACE_TAB.route, { tabId: COLLECTIONS_ID });
+			ToastService.success(
+				t('collection/views/collection-detail___de-collectie-werd-succesvol-verwijderd')
+			);
 		} catch (err) {
 			console.error(err);
 			ToastService.info(
@@ -1063,19 +1066,10 @@ const CollectionOrBundleEdit: FunctionComponent<CollectionOrBundleEditProps &
 					match={match}
 					user={user}
 				/>
-				<DeleteObjectModal
-					title={
-						isCollection
-							? t(
-									'collection/components/collection-or-bundle-edit___ben-je-zeker-dat-je-deze-collectie-wil-verwijderen'
-							  )
-							: t(
-									'collection/components/collection-or-bundle-edit___ben-je-zeker-dat-je-deze-bundel-wil-verwijderen'
-							  )
+				<DeleteCollectionModal
+					collectionId={
+						(collectionState.currentCollection as Avo.Collection.Collection).id
 					}
-					body={t(
-						'collection/components/collection-or-bundle-edit___deze-actie-kan-niet-ongedaan-gemaakt-worden'
-					)}
 					isOpen={isDeleteModalOpen}
 					onClose={() => setIsDeleteModalOpen(false)}
 					deleteObjectCallback={onDeleteCollection}

--- a/src/collection/components/CollectionOrBundleOverview.tsx
+++ b/src/collection/components/CollectionOrBundleOverview.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from '@apollo/react-hooks';
-import React, { FunctionComponent, ReactText, useState } from 'react';
+import { isNil } from 'lodash-es';
+import React, { FunctionComponent, ReactText, useCallback, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
@@ -22,11 +23,14 @@ import {
 import { Avo } from '@viaa/avo2-types';
 
 import { DefaultSecureRouteProps } from '../../authentication/components/SecuredRoute';
-import { getProfileId } from '../../authentication/helpers/get-profile-info';
 import { BUNDLE_PATH } from '../../bundle/bundle.const';
 import { APP_PATH } from '../../constants';
 import { ErrorView } from '../../error/views';
-import { DataQueryComponent, DeleteObjectModal } from '../../shared/components';
+import {
+	DeleteObjectModal,
+	LoadingErrorLoadedComponent,
+	LoadingInfo,
+} from '../../shared/components';
 import {
 	buildLink,
 	createDropdownMenuItem,
@@ -40,10 +44,12 @@ import {
 import { truncateTableValue } from '../../shared/helpers/truncate';
 import { ApolloCacheManager, ToastService } from '../../shared/services';
 import { ITEMS_PER_PAGE } from '../../workspace/workspace.const';
-import { DELETE_COLLECTION, GET_COLLECTIONS_BY_OWNER } from '../collection.gql';
+import { DELETE_COLLECTION } from '../collection.gql';
+import { CollectionService } from '../collection.service';
 import { ContentTypeNumber } from '../collection.types';
 
 import './CollectionOrBundleOverview.scss';
+import DeleteCollectionModal from './modals/DeleteCollectionModal';
 
 interface CollectionOrBundleOverviewProps extends DefaultSecureRouteProps {
 	numberOfItems: number;
@@ -61,9 +67,11 @@ const CollectionOrBundleOverview: FunctionComponent<CollectionOrBundleOverviewPr
 	const [t] = useTranslation();
 
 	// State
+	const [loadingInfo, setLoadingInfo] = useState<LoadingInfo>({ state: 'loading' });
+	const [collections, setCollections] = useState<Avo.Collection.Collection[] | null>(null);
+
 	const [dropdownOpen, setDropdownOpen] = useState<{ [key: string]: boolean }>({});
 	const [idToDelete, setIdToDelete] = useState<string | null>(null);
-	const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
 	const [sortColumn, setSortColumn] = useState<keyof Avo.Collection.Collection>('updated_at');
 	const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
 	const [page, setPage] = useState<number>(0);
@@ -75,12 +83,44 @@ const CollectionOrBundleOverview: FunctionComponent<CollectionOrBundleOverviewPr
 	const onClickDelete = (collectionId: string) => {
 		setDropdownOpen({ [collectionId]: false });
 		setIdToDelete(collectionId);
-		setIsDeleteModalOpen(true);
 	};
 
 	const isCollection = type === 'collection';
 
-	const onDeleteCollection = async (refetchCollections: () => void) => {
+	const fetchCollections = useCallback(async () => {
+		try {
+			setCollections(
+				await CollectionService.fetchCollectionsByOwner(
+					user,
+					page * ITEMS_PER_PAGE,
+					ITEMS_PER_PAGE,
+					{ [sortColumn]: sortOrder },
+					isCollection ? ContentTypeNumber.collection : ContentTypeNumber.bundle
+				)
+			);
+		} catch (err) {
+			console.error('Failed to fetch collections', err, {});
+			setLoadingInfo({
+				state: 'error',
+				message: isCollection
+					? t('Het ophalen van de collecties is mislukt')
+					: t('Het ophalen van de bundels is mislukt'),
+				actionButtons: ['home'],
+			});
+		}
+	}, [user, page, sortColumn, sortOrder, isCollection]);
+
+	useEffect(() => {
+		fetchCollections();
+	}, [fetchCollections]);
+
+	useEffect(() => {
+		if (collections) {
+			setLoadingInfo({ state: 'loaded' });
+		}
+	}, [setLoadingInfo, collections]);
+
+	const onDeleteCollection = async () => {
 		try {
 			await triggerCollectionDelete({
 				variables: {
@@ -99,7 +139,7 @@ const CollectionOrBundleOverview: FunctionComponent<CollectionOrBundleOverviewPr
 					  )
 			);
 			onUpdate();
-			refetchCollections();
+			fetchCollections();
 		} catch (err) {
 			console.error(err);
 			ToastService.danger(
@@ -449,52 +489,42 @@ const CollectionOrBundleOverview: FunctionComponent<CollectionOrBundleOverviewPr
 		</ErrorView>
 	);
 
-	const renderCollections = (
-		collections: Avo.Collection.Collection[],
-		refetchCollections: () => void
-	) => (
-		<>
-			{collections.length ? renderTable(collections) : renderEmptyFallback()}
+	const renderDeleteModal = () => {
+		if (isCollection) {
+			return (
+				<DeleteCollectionModal
+					collectionId={idToDelete as string}
+					isOpen={!isNil(idToDelete)}
+					onClose={() => setIdToDelete(null)}
+					deleteObjectCallback={onDeleteCollection}
+				/>
+			);
+		}
+		return (
 			<DeleteObjectModal
-				title={
-					isCollection
-						? t('collection/views/collection-overview___verwijder-collectie')
-						: t(
-								'collection/components/collection-or-bundle-overview___verwijder-bundel'
-						  )
-				}
+				title={t('collection/components/collection-or-bundle-overview___verwijder-bundel')}
 				body={t(
 					'collection/views/collection-overview___bent-u-zeker-deze-actie-kan-niet-worden-ongedaan-gemaakt'
 				)}
-				isOpen={isDeleteModalOpen}
-				onClose={() => setIsDeleteModalOpen(false)}
-				deleteObjectCallback={() => onDeleteCollection(refetchCollections)}
+				isOpen={!isNil(idToDelete)}
+				onClose={() => setIdToDelete(null)}
+				deleteObjectCallback={onDeleteCollection}
 			/>
+		);
+	};
+
+	const renderCollections = () => (
+		<>
+			{collections && collections.length ? renderTable(collections) : renderEmptyFallback()}
+			{!isNil(idToDelete) && renderDeleteModal()}
 		</>
 	);
 
 	return (
-		<DataQueryComponent
-			query={GET_COLLECTIONS_BY_OWNER}
-			variables={{
-				owner_profile_id: getProfileId(user),
-				offset: page * ITEMS_PER_PAGE,
-				limit: ITEMS_PER_PAGE,
-				order: { [sortColumn]: sortOrder },
-				type_id: isCollection ? ContentTypeNumber.collection : ContentTypeNumber.bundle,
-			}}
-			resultPath="app_collections"
-			renderData={renderCollections}
-			notFoundMessage={
-				isCollection
-					? t(
-							'collection/views/collection-overview___er-konden-geen-collecties-worden-gevonden'
-					  )
-					: t(
-							'collection/components/collection-or-bundle-overview___er-konden-geen-bundels-worden-gevonden'
-					  )
-			}
-			actionButtons={['home']}
+		<LoadingErrorLoadedComponent
+			loadingInfo={loadingInfo}
+			dataObject={collections}
+			render={renderCollections}
 		/>
 	);
 };

--- a/src/collection/components/modals/DeleteCollectionModal.tsx
+++ b/src/collection/components/modals/DeleteCollectionModal.tsx
@@ -1,0 +1,160 @@
+import { noop } from 'lodash-es';
+import React, { FunctionComponent, useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+
+import {
+	Button,
+	ButtonToolbar,
+	Modal,
+	ModalBody,
+	Toolbar,
+	ToolbarItem,
+	ToolbarRight,
+} from '@viaa/avo2-components';
+import { Avo } from '@viaa/avo2-types';
+
+import { AssignmentService } from '../../../assignment/assignment.service';
+import { APP_PATH } from '../../../constants';
+import { LoadingErrorLoadedComponent, LoadingInfo } from '../../../shared/components';
+import { buildLink, CustomError } from '../../../shared/helpers';
+
+interface DeleteCollectionModalProps {
+	collectionId: string;
+	isOpen: boolean;
+	onClose?: () => void;
+	deleteObjectCallback: () => void;
+}
+
+const DeleteCollectionModal: FunctionComponent<DeleteCollectionModalProps> = ({
+	collectionId,
+	isOpen,
+	onClose,
+	deleteObjectCallback,
+}) => {
+	const [t] = useTranslation();
+
+	const [loadingInfo, setLoadingInfo] = useState<LoadingInfo>({ state: 'loading' });
+	const [assignments, setAssignments] = useState<Partial<Avo.Assignment.Assignment>[] | null>(
+		null
+	);
+
+	const fetchAssignmentsUsedByCollection = useCallback(async () => {
+		try {
+			setAssignments(
+				await AssignmentService.fetchAssignmentByContentIdAndType(collectionId, 'COLLECTIE')
+			);
+		} catch (err) {
+			console.error(
+				new CustomError('Failed to get assignments used by collection', err, {
+					collectionId,
+				})
+			);
+			setLoadingInfo({
+				state: 'error',
+				message: t(
+					'Het controleren of deze collectie gebruikt wordt door een van je opdrachten is mislukt'
+				),
+			});
+		}
+	}, [setAssignments]);
+
+	useEffect(() => {
+		if (assignments) {
+			setLoadingInfo({
+				state: 'loaded',
+			});
+		}
+	}, [assignments, setLoadingInfo]);
+
+	useEffect(() => {
+		if (isOpen) {
+			fetchAssignmentsUsedByCollection();
+		}
+	}, [isOpen, fetchAssignmentsUsedByCollection]);
+
+	const handleDelete = async () => {
+		deleteObjectCallback();
+		(onClose || noop)();
+		setAssignments(null);
+	};
+
+	const renderConfirmButtons = () => {
+		return (
+			<Toolbar spaced>
+				<ToolbarRight>
+					<ToolbarItem>
+						<ButtonToolbar>
+							<Button type="secondary" label={t('Annuleer')} onClick={onClose} />
+							<Button type="danger" label={t('Verwijder')} onClick={handleDelete} />
+						</ButtonToolbar>
+					</ToolbarItem>
+				</ToolbarRight>
+			</Toolbar>
+		);
+	};
+
+	const renderConfirmUsedByAssignment = () => {
+		return (
+			<>
+				<p>{t('Deze collectie wordt nog gebruikt door deze opdrachten:')}</p>
+				<ul>
+					{(assignments || []).map(assigment => (
+						<li key={assigment.id}>
+							<Link
+								to={buildLink(APP_PATH.ASSIGNMENT_EDIT.route, {
+									id: assigment.id,
+								})}
+							>
+								{assigment.title}
+							</Link>
+						</li>
+					))}
+				</ul>
+				{renderDeleteMessage()}
+			</>
+		);
+	};
+
+	const renderDeleteMessage = () => {
+		return (
+			<p>
+				{t('ben je zeker dat je deze collectie wil verwijderen?')}
+				<br />
+				{t('Deze operatie kan niet meer ongedaan gemaakt worden.')}
+			</p>
+		);
+	};
+
+	const renderModalBody = () => {
+		return (
+			<>
+				{!!assignments && !!assignments.length
+					? renderConfirmUsedByAssignment()
+					: renderDeleteMessage()}
+				{renderConfirmButtons()}
+			</>
+		);
+	};
+
+	return (
+		<Modal
+			isOpen={isOpen}
+			title={t('Verwijder deze collectie')}
+			size="large"
+			onClose={onClose}
+			scrollable
+			className="c-content"
+		>
+			<ModalBody>
+				<LoadingErrorLoadedComponent
+					loadingInfo={loadingInfo}
+					dataObject={assignments}
+					render={renderModalBody}
+				/>
+			</ModalBody>
+		</Modal>
+	);
+};
+
+export default DeleteCollectionModal;

--- a/src/collection/views/CollectionDetail.tsx
+++ b/src/collection/views/CollectionDetail.tsx
@@ -36,7 +36,6 @@ import { redirectToClientPage } from '../../authentication/helpers/redirects';
 import { APP_PATH, GENERATE_SITE_TITLE } from '../../constants';
 import {
 	ControlledDropdown,
-	DeleteObjectModal,
 	InteractiveTour,
 	LoadingErrorLoadedComponent,
 	LoadingInfo,
@@ -63,6 +62,7 @@ import { CollectionService } from '../collection.service';
 import { ContentTypeString, toEnglishContentType } from '../collection.types';
 import { FragmentList, ShareCollectionModal } from '../components';
 import AddToBundleModal from '../components/modals/AddToBundleModal';
+import DeleteCollectionModal from '../components/modals/DeleteCollectionModal';
 
 import './CollectionDetail.scss';
 
@@ -833,13 +833,8 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 						onClose={() => setIsAddToBundleModalOpen(false)}
 					/>
 				)}
-				<DeleteObjectModal
-					title={t(
-						'collection/views/collection-detail___ben-je-zeker-dat-je-deze-collectie-wil-verwijderen'
-					)}
-					body={t(
-						'collection/views/collection-detail___deze-actie-kan-niet-ongedaan-gemaakt-worden'
-					)}
+				<DeleteCollectionModal
+					collectionId={(collection as Avo.Collection.Collection).id}
 					isOpen={isDeleteModalOpen}
 					onClose={() => setIsDeleteModalOpen(false)}
 					deleteObjectCallback={onDeleteCollection}


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-386

This creates a DeleteCollectionModal that is used on:
* collectionOverview
* collectionDetail
* collectionOrBundleEdit

This PR also reworks the way we fetch the collections in the overview using the useCallback/service method instead of the dataFetchComponent

Finally i also fixed a glitch where the assignments would show the assignment responses instead. This was due to the assignments being fetched before we determined the correct user permissions, so the fetch function would assume you were a pupil instead of a teacher

![image](https://user-images.githubusercontent.com/1710840/81806906-6cca2a00-951d-11ea-9af3-491aaecf71ab.png)

![image](https://user-images.githubusercontent.com/1710840/81806911-6f2c8400-951d-11ea-804a-f4425833d589.png)

![image](https://user-images.githubusercontent.com/1710840/81806916-72277480-951d-11ea-814a-2ec3a0f6eb84.png)
