### PR TITLE
fix(omit-by-deep): avoid cloning the rte state, since it is huge

### DIFF
--- a/src/admin/content/content.service.ts
+++ b/src/admin/content/content.service.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, get, omit } from 'lodash-es';
+import { get, omit } from 'lodash-es';
 
 import { Avo } from '@viaa/avo2-types';
 
@@ -435,6 +435,6 @@ export class ContentService {
 	public static convertRichTextEditorStatesToHtml(
 		blockConfigs: ContentBlockConfig[]
 	): ContentBlockConfig[] {
-		return omitByDeep(cloneDeep(blockConfigs), key => String(key).endsWith(RichEditorStateKey));
+		return omitByDeep(blockConfigs, key => String(key).endsWith(RichEditorStateKey));
 	}
 }

--- a/src/admin/shared/helpers/omitByDeep.ts
+++ b/src/admin/shared/helpers/omitByDeep.ts
@@ -1,14 +1,17 @@
-import { forIn, isObject } from 'lodash-es';
+import { forIn, isArray, isObject } from 'lodash-es';
 
 export function omitByDeep(obj: any, predicate: (key: string, value: any) => boolean): any {
+	const returnObj: any = isArray(obj) ? [] : {};
 	forIn(obj, (value, key) => {
-		if (predicate(key, value)) {
-			// delete before checking the inner object to avoid circular references that will be deleted anyways
-			delete obj[key];
-		} else if (isObject(value)) {
-			// Recursively omit inner object properties
-			obj[key] = omitByDeep(value, predicate);
+		if (!predicate(key, value)) {
+			if (isObject(value)) {
+				// Recursively omit inner object properties
+				returnObj[key] = omitByDeep(value, predicate);
+			} else {
+				returnObj[key] = value;
+			}
 		}
+		// else if predicate is true => we do not need to copy the property to the returnObj
 	});
-	return obj;
+	return returnObj;
 }


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-786

We cloned the state before omitting the rte editor state, but the editor state is either so huge that is locks up the browser or more likely: the editorstate contains circulr references which put the clone deep function in an infinite loop.

Solved by combining the cloneDeep and the omitByRecursive functions into one, so we can omit the rte states and clone the object at the same time.

with styles:
![image](https://user-images.githubusercontent.com/1710840/82188600-64dc0280-98ee-11ea-93d7-bcc5f38cd512.png)

without styles:
![image](https://user-images.githubusercontent.com/1710840/82188606-686f8980-98ee-11ea-82ab-b85e2f649a12.png)
