### PR TITLE
feat(dynamic-route-resolver): after login redirect pupils to workspace

### DIFF
--- a/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
@@ -387,7 +387,7 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 				return user ? truncateTableValue(`${user.first_name} ${user.last_name}`) : '-';
 
 			case 'author_role':
-				return get(rowData, 'profile.usersByuserId.role.label', '-');
+				return UserService.getUserRoleLabel(get(rowData, 'profile')) || '-';
 
 			case 'last_updated_by_profile':
 				const lastEditUser: Avo.User.User | undefined = get(

--- a/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
@@ -94,7 +94,7 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps &
 		};
 	};
 
-	const getLabelFilter = (): any[] => {
+	const getLabelFilter = useCallback((): any[] => {
 		const selectedLabelIds = selectedTabs.map(labelObj => labelObj.id);
 		const blockLabelIds = ((get(contentTypeAndTabs, 'selectedLabels') ||
 			[]) as Avo.Content.ContentLabel[]).map(labelObj => labelObj.id);
@@ -119,7 +119,7 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps &
 			];
 		}
 		return [];
-	};
+	}, [selectedTabs, contentTypeAndTabs]);
 
 	const fetchPages = useCallback(async () => {
 		try {
@@ -172,18 +172,18 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps &
 			);
 		}
 	}, [
-		selectedTabs,
 		itemStyle,
 		currentPage,
 		debouncedItemsPerPage,
 		setPages,
 		setPageCount,
 		contentTypeAndTabs,
+		getLabelFilter,
 		user,
 		t,
 	]);
 
-	const checkFocusedPage = async () => {
+	const checkFocusedPage = useCallback(async () => {
 		try {
 			const queryParams = queryString.parse(location.search);
 			if (queryParams.focus && isString(queryParams.focus)) {
@@ -199,12 +199,12 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps &
 			});
 			ToastService.danger(t('Het ophalen van het te focussen item is mislukt'));
 		}
-	};
+	}, [location.search, setFocusedPageId, t]);
 
 	useEffect(() => {
 		fetchPages();
 		checkFocusedPage();
-	}, [fetchPages]);
+	}, [fetchPages, checkFocusedPage]);
 
 	const handleCurrentPageChanged = (pageIndex: number) => {
 		setCurrentPage(pageIndex);

--- a/src/admin/content/views/ContentDetailMetaData.tsx
+++ b/src/admin/content/views/ContentDetailMetaData.tsx
@@ -22,6 +22,7 @@ import {
 	renderDetailRow,
 	renderSimpleDetailRows,
 } from '../../shared/helpers/render-detail-fields';
+import { UserService } from '../../users/user.service';
 import { GET_CONTENT_WIDTH_OPTIONS } from '../content.const';
 import { DbContent } from '../content.types';
 
@@ -151,7 +152,7 @@ export const ContentDetailMetaData: FunctionComponent<ContentDetailMetaDataProps
 							t('admin/content/views/content-detail___auteur')
 						)}
 						{renderDetailRow(
-							get(contentPage, 'profile.user.role.label'),
+							UserService.getUserRoleLabel(get(contentPage, 'profile')),
 							t('admin/content/views/content-detail___auteur-rol')
 						)}
 						{renderDateDetailRows(contentPage, [

--- a/src/admin/content/views/ContentOverview.tsx
+++ b/src/admin/content/views/ContentOverview.tsx
@@ -33,7 +33,6 @@ import {
 	CustomError,
 	formatDate,
 	getFullName,
-	getRole,
 	navigate,
 	navigateToAbsoluteOrRelativeUrl,
 } from '../../../shared/helpers';
@@ -51,6 +50,7 @@ import {
 	getQueryFilter,
 } from '../../shared/helpers/filters';
 import { AdminLayout, AdminLayoutBody, AdminLayoutTopBarRight } from '../../shared/layouts';
+import { UserService } from '../../users/user.service';
 import { CONTENT_PATH, ITEMS_PER_PAGE } from '../content.const';
 import { ContentService } from '../content.service';
 import { ContentOverviewTableCols, ContentTableState } from '../content.types';
@@ -289,7 +289,7 @@ const ContentOverview: FunctionComponent<ContentOverviewProps> = ({ history, use
 			case 'author':
 				return getFullName(profile) || '-';
 			case 'role':
-				return getRole(profile) || '-';
+				return UserService.getUserRoleLabel(profile) || '-';
 			case 'publish_at':
 			case 'depublish_at':
 			case 'created_at':

--- a/src/admin/users/user.service.ts
+++ b/src/admin/users/user.service.ts
@@ -81,4 +81,26 @@ export class UserService {
 			});
 		}
 	}
+
+	/**
+	 * Get user role name from user of profile object
+	 * @param userOrProfile
+	 * @returns userRole eg: leerling, lesgever, admin, ...  See database for all options: shared.user_roles
+	 */
+	public static getUserRole(
+		userOrProfile: Avo.User.User | Avo.User.Profile | undefined | null
+	): string | null {
+		return get(userOrProfile, 'role.name') || get(userOrProfile, 'user.role.name') || null;
+	}
+
+	/**
+	 * Get user role label from user of profile object
+	 * @param userOrProfile
+	 * @returns userRole eg: Leerling, Lesgever, Beheerder, ...  See database for all options: shared.user_roles
+	 */
+	public static getUserRoleLabel(
+		userOrProfile: Avo.User.User | Avo.User.Profile | undefined | null
+	): string | null {
+		return get(userOrProfile, 'role.label') || get(userOrProfile, 'user.role.label') || null;
+	}
 }

--- a/src/authentication/authentication.const.ts
+++ b/src/authentication/authentication.const.ts
@@ -1,12 +1,1 @@
-import { UserState } from './authentication.types';
-
-export const INITIAL_USER_STATE: UserState = {
-	firstName: '',
-	lastName: '',
-	email: '',
-	password: '',
-	type: 'Leerkracht',
-	stamboekNumber: '',
-};
-
 export const SERVER_LOGOUT_PAGE = 'auth/global-logout';

--- a/src/authentication/authentication.types.ts
+++ b/src/authentication/authentication.types.ts
@@ -1,21 +1,3 @@
-export type UserRole = 'Leerkracht' | 'Leerling';
-
-export interface UserState {
-	firstName: string;
-	lastName: string;
-	email: string;
-	password: string;
-	type: UserRole;
-	stamboekNumber: string;
-}
-
-export type ActionPayload = string | boolean;
-
-export interface Action {
-	type: string;
-	payload: ActionPayload;
-}
-
 export enum LoginMessage {
 	LOGGED_IN = 'LOGGED_IN',
 	LOGGED_OUT = 'LOGGED_OUT',

--- a/src/authentication/views/Login.tsx
+++ b/src/authentication/views/Login.tsx
@@ -8,6 +8,7 @@ import { Dispatch } from 'redux';
 import { Button, Flex, Spacer, Spinner } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
+import { UserService } from '../../admin/users/user.service';
 import { APP_PATH } from '../../constants';
 import { ErrorView } from '../../error/views';
 import { AppState } from '../../store';
@@ -41,9 +42,17 @@ const Login: FunctionComponent<LoginProps> = ({
 			return;
 		}
 
-		// Redirect to previous requested path or home page
+		// Redirect to previous requested path or the default page for that role (LOGGED_IN_HOME or WORKSPACE_ASSIGNMENTS)
 		if (loginState && loginState.message === LoginMessage.LOGGED_IN && !loginStateLoading) {
-			history.push(get(location, 'state.from.pathname', APP_PATH.LOGGED_IN_HOME.route));
+			let path = get(location, 'state.from.pathname');
+			if (!path) {
+				if (UserService.getUserRole(get(loginState, 'userInfo')) === 'leerling') {
+					path = APP_PATH.WORKSPACE_ASSIGNMENTS.route;
+				} else {
+					path = APP_PATH.LOGGED_IN_HOME.route;
+				}
+			}
+			history.push(path);
 			return;
 		}
 

--- a/src/dynamic-route-resolver/views/DynamicRouteResolver.tsx
+++ b/src/dynamic-route-resolver/views/DynamicRouteResolver.tsx
@@ -9,6 +9,7 @@ import { Dispatch } from 'redux';
 import { Avo } from '@viaa/avo2-types';
 
 import { ItemsService } from '../../admin/items/items.service';
+import { UserService } from '../../admin/users/user.service';
 import { SpecialPermissionGroups } from '../../authentication/authentication.types';
 import { PermissionName, PermissionService } from '../../authentication/helpers/permission-service';
 import { getLoginStateAction } from '../../authentication/store/actions';
@@ -16,7 +17,6 @@ import {
 	selectLogin,
 	selectLoginError,
 	selectLoginLoading,
-	selectUser,
 } from '../../authentication/store/selectors';
 import { GET_COLLECTIONS_BY_AVO1_ID } from '../../bundle/bundle.gql';
 import { APP_PATH, GENERATE_SITE_TITLE } from '../../constants';
@@ -40,7 +40,6 @@ interface DynamicRouteResolverProps extends RouteComponentProps {
 	loginState: Avo.Auth.LoginResponse | null;
 	loginStateError: boolean;
 	loginStateLoading: boolean;
-	user: Avo.User.User;
 }
 
 const DynamicRouteResolver: FunctionComponent<DynamicRouteResolverProps> = ({
@@ -50,7 +49,6 @@ const DynamicRouteResolver: FunctionComponent<DynamicRouteResolverProps> = ({
 	loginState,
 	loginStateError,
 	loginStateLoading,
-	user,
 }) => {
 	const [t] = useTranslation();
 
@@ -60,9 +58,20 @@ const DynamicRouteResolver: FunctionComponent<DynamicRouteResolverProps> = ({
 
 	const analyseRoute = useCallback(async () => {
 		try {
+			if (!loginState) {
+				setLoadingInfo({
+					state: 'error',
+					message: t('Het controleren van je login status is mislukt'),
+					actionButtons: ['home', 'helpdesk'],
+				});
+				return;
+			}
+
+			const pathname = location.pathname;
+
 			// Check if path is an old media url
-			if (/\/media\/[^/]+\/[^/]+/g.test(location.pathname)) {
-				const avo1Id = (location.pathname.split('/').pop() || '').trim();
+			if (/\/media\/[^/]+\/[^/]+/g.test(pathname)) {
+				const avo1Id = (pathname.split('/').pop() || '').trim();
 				if (avo1Id) {
 					// Check if id matches an item mediamosa id
 					const itemExternalId = await ItemsService.fetchItemExternalIdByMediamosaId(
@@ -92,15 +101,35 @@ const DynamicRouteResolver: FunctionComponent<DynamicRouteResolverProps> = ({
 			}
 
 			// Check if path is old item id
-			if (/\/pid\/[^/]+/g.test(location.pathname)) {
-				const itemPid = (location.pathname.split('/').pop() || '').trim();
+			if (/\/pid\/[^/]+/g.test(pathname)) {
+				const itemPid = (pathname.split('/').pop() || '').trim();
 				history.push(buildLink(APP_PATH.ITEM_DETAIL.route, { id: itemPid }));
+				return;
+			}
+
+			// Special route exception
+			// /klaar/archief: redirect teachers to search page with klaar filter
+			if (
+				pathname === '/klaar/archief' &&
+				PermissionService.hasPerm(loginState.userInfo, PermissionName.SEARCH)
+			) {
+				history.push(generateSearchLinkString('serie', 'Klaar'));
+				return;
+			}
+
+			// Special route exception
+			// /start when user is a pupil => should be redirected to /werkruimte/opdrachten
+			if (
+				pathname === APP_PATH.LOGGED_IN_HOME.route &&
+				UserService.getUserRole(loginState.userInfo) === 'leerling'
+			) {
+				history.push(APP_PATH.WORKSPACE_ASSIGNMENTS.route);
 				return;
 			}
 
 			// Check if path points to a content page
 			const contentPage: Avo.Content.Content | null = await ContentPageService.getContentPageByPath(
-				location.pathname
+				pathname
 			);
 			if (!contentPage) {
 				setRouteInfo({ type: 'notFound', data: null });
@@ -121,26 +150,39 @@ const DynamicRouteResolver: FunctionComponent<DynamicRouteResolverProps> = ({
 				icon: 'search',
 			});
 		}
-	}, [location.pathname, history, t]);
-
-	// Analyse the path and determine the routeType
-	useEffect(() => {
-		if (!location.pathname) {
-			return;
-		}
-
-		analyseRoute();
-	}, [location.pathname, analyseRoute]);
+	}, [loginState, location.pathname, setRouteInfo, setLoadingInfo, history, t]);
 
 	// Check if current user is logged in
 	useEffect(() => {
 		if (!loginState && !loginStateLoading && !loginStateError) {
 			getLoginState();
-		} else if (routeInfo && loginState) {
-			// Prevent seeing the content-page before loginState and routeInfo are both done
+		} else if (loginStateError) {
+			console.error(
+				new CustomError('Login error was encountered', null, {
+					loginStateError,
+					loginState,
+				})
+			);
+			setLoadingInfo({
+				state: 'error',
+				message: t('Er ging iets mis bij het inloggen'),
+				actionButtons: ['home', 'helpdesk'],
+			});
+		}
+	}, [getLoginState, loginState, loginStateError, loginStateLoading]);
+
+	useEffect(() => {
+		if (loginState && location.pathname) {
+			// Analyse the path and determine the routeType
+			analyseRoute();
+		}
+	}, [loginState, location.pathname]);
+
+	useEffect(() => {
+		if (routeInfo) {
 			setLoadingInfo({ state: 'loaded' });
 		}
-	}, [getLoginState, loginState, loginStateError, loginStateLoading, routeInfo, user]);
+	}, [routeInfo]);
 
 	const renderRouteComponent = () => {
 		if (routeInfo && routeInfo.type === 'contentPage') {
@@ -158,16 +200,6 @@ const DynamicRouteResolver: FunctionComponent<DynamicRouteResolverProps> = ({
 						}}
 					/>
 				);
-			}
-
-			// Special route exceptions
-			// /klaar/archief: redirect teachers to search page with klaar filter
-			const routePath = get(routeInfo, 'data.path', '');
-			if (
-				routePath === '/klaar/archief' &&
-				PermissionService.hasPerm(user, PermissionName.SEARCH)
-			) {
-				return <Redirect to={generateSearchLinkString('serie', 'Klaar')} />;
 			}
 
 			return (
@@ -215,7 +247,6 @@ const mapStateToProps = (state: AppState) => ({
 	loginState: selectLogin(state),
 	loginStateLoading: selectLoginLoading(state),
 	loginStateError: selectLoginError(state),
-	user: selectUser(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/src/dynamic-route-resolver/views/DynamicRouteResolver.tsx
+++ b/src/dynamic-route-resolver/views/DynamicRouteResolver.tsx
@@ -169,14 +169,14 @@ const DynamicRouteResolver: FunctionComponent<DynamicRouteResolverProps> = ({
 				actionButtons: ['home', 'helpdesk'],
 			});
 		}
-	}, [getLoginState, loginState, loginStateError, loginStateLoading]);
+	}, [getLoginState, loginState, loginStateError, loginStateLoading, t]);
 
 	useEffect(() => {
 		if (loginState && location.pathname) {
 			// Analyse the path and determine the routeType
 			analyseRoute();
 		}
-	}, [loginState, location.pathname]);
+	}, [loginState, location.pathname, analyseRoute]);
 
 	useEffect(() => {
 		if (routeInfo) {

--- a/src/shared/helpers/formatters/avatar.tsx
+++ b/src/shared/helpers/formatters/avatar.tsx
@@ -4,6 +4,8 @@ import React, { ReactNode } from 'react';
 import { Avatar, AvatarList, AvatarProps } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
+import { UserService } from '../../../admin/users/user.service';
+
 const getProfile = (obj: Avo.User.Profile | Avo.User.User | null | undefined) => {
 	if (!obj) {
 		return null;
@@ -37,9 +39,6 @@ export const getFullName = (userOrProfile: Avo.User.Profile | Avo.User.User | nu
 export const getAbbreviatedFullName = (profile: Avo.User.Profile | null) =>
 	`${get(profile, 'user.first_name', '')[0]}. ${get(profile, 'user.last_name')}`;
 
-export const getRole = (profile: Avo.User.Profile | null | undefined) =>
-	get(profile, 'user.role.label');
-
 export const getAvatarProps = (
 	profile: Avo.User.Profile | null,
 	options: {
@@ -51,7 +50,7 @@ export const getAvatarProps = (
 	const name: string = options.abbreviatedName
 		? getAbbreviatedFullName(profile)
 		: getFullName(profile) || '';
-	const role = getRole(profile);
+	const role = UserService.getUserRoleLabel(profile);
 	const nameAndRole: string = options.includeRole && role ? `${name} (${role})` : name;
 
 	return {


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-463

after login by pupil, they are redirected to their workspace:
![image](https://user-images.githubusercontent.com/1710840/83653196-c1f8d900-a5bb-11ea-8929-2e34bf03be23.png)
