### PR TITLE
fix(login-page): avoid infinite reload loop due to 401 errors

### DIFF
--- a/src/shared/helpers/fetch-with-logout.ts
+++ b/src/shared/helpers/fetch-with-logout.ts
@@ -1,8 +1,21 @@
+const AVO_LAST_RELOAD_BECAUSE_UNAUTH = 'AVO_LAST_RELOAD_BECAUSE_UNAUTH';
+
 export async function fetchWithLogout(input: RequestInfo, init?: RequestInit): Promise<Response> {
 	const response = await fetch(input, init);
 	if (response.status === 401) {
 		// User is no longer logged in => force them to login again
-		window.location.reload();
+		goToLoginBecauseOfUnauthorizedError();
 	}
 	return response;
+}
+
+export function goToLoginBecauseOfUnauthorizedError() {
+	const lastReloadDate = localStorage.getItem(AVO_LAST_RELOAD_BECAUSE_UNAUTH);
+	if (
+		!lastReloadDate ||
+		new Date(lastReloadDate).getTime() < new Date().getTime() - 5 * 60 * 1000
+	) {
+		localStorage.setItem(AVO_LAST_RELOAD_BECAUSE_UNAUTH, new Date().toISOString());
+		window.location.reload();
+	}
 }

--- a/src/shared/services/data-service.ts
+++ b/src/shared/services/data-service.ts
@@ -4,13 +4,14 @@ import { onError } from 'apollo-link-error';
 import { get } from 'lodash-es';
 
 import { getEnv } from '../helpers';
+import { goToLoginBecauseOfUnauthorizedError } from '../helpers/fetch-with-logout';
 
 const cache = new InMemoryCache();
 const httpLink = new HttpLink({ uri: `${getEnv('PROXY_URL')}/data`, credentials: 'include' });
 
 const logoutMiddleware = onError(({ networkError }) => {
 	if (get(networkError, 'statusCode') === 401) {
-		window.location.reload();
+		goToLoginBecauseOfUnauthorizedError();
 	}
 });
 


### PR DESCRIPTION
steps to reproduce:
* logout
* goto http://localhost:8080

The page should only reload once, not infinitly due to 401 errors