### PR TITLE
AVO-929 CB hero / header startpagina: kan geen link leggen naar bepaalde pagina's voor de knoppen

### DIFF
--- a/src/admin/content/content.service.ts
+++ b/src/admin/content/content.service.ts
@@ -7,7 +7,6 @@ import { CustomError, performQuery, sanitizeHtml } from '../../shared/helpers';
 import { SanitizePreset } from '../../shared/helpers/sanitize/presets';
 import { ApolloCacheManager, dataService, ToastService } from '../../shared/services';
 import i18n from '../../shared/translations/i18n';
-import { convertBlocksToDatabaseFormat } from '../content-block/helpers';
 import { ContentBlockService } from '../content-block/services/content-block.service';
 import { mapDeep } from '../shared/helpers/map-deep';
 import { ContentBlockConfig } from '../shared/types';
@@ -82,7 +81,7 @@ export class ContentService {
 	public static async getContentItemsByTitle(
 		title: string,
 		limit?: number
-	): Promise<ContentPageInfo[] | null> {
+	): Promise<ContentPageInfo[]> {
 		const query = {
 			query: GET_CONTENT_PAGES_BY_TITLE,
 			variables: {
@@ -92,13 +91,13 @@ export class ContentService {
 			},
 		};
 
-		return convertBlocksToDatabaseFormat(
+		return (
 			(await performQuery(
 				query,
 				CONTENT_RESULT_PATH.GET,
 				'Failed to retrieve content pages by title.'
 			)) || []
-		) as ContentPageInfo[];
+		);
 	}
 
 	public static async getProjectContentItemsByTitle(

--- a/src/admin/shared/components/ContentPicker/ContentPicker.tsx
+++ b/src/admin/shared/components/ContentPicker/ContentPicker.tsx
@@ -100,10 +100,14 @@ export const ContentPicker: FunctionComponent<ContentPickerProps> = ({
 				}
 				return items;
 			} catch (err) {
-				throw new CustomError('[Content Picker] - Failed to inflate.', err, {
-					keyword,
-					selectedType,
-				});
+				console.error(
+					new CustomError('[Content Picker] - Failed to inflate.', err, {
+						keyword,
+						selectedType,
+					})
+				);
+				ToastService.danger('Het ophalen van de opties is mislukt', false);
+				return [];
 			}
 		},
 		[selectedType, hasAppliedInitialItem, initialValue]

--- a/src/admin/shared/helpers/content-picker/content-page.ts
+++ b/src/admin/shared/helpers/content-picker/content-page.ts
@@ -1,3 +1,4 @@
+import { CustomError } from '../../../../shared/helpers';
 import { ContentService } from '../../../content/content.service';
 import { ContentPageInfo } from '../../../content/content.types';
 import { PickerSelectItem } from '../../types';
@@ -9,11 +10,18 @@ export const retrieveContentPages = async (
 	title: string | null,
 	limit: number = 5
 ): Promise<PickerSelectItem[]> => {
-	const contentItems: ContentPageInfo[] | null = title
-		? await ContentService.getContentItemsByTitle(`%${title}%`, limit)
-		: await ContentService.getContentItems(limit);
+	try {
+		const contentItems: ContentPageInfo[] | null = title
+			? await ContentService.getContentItemsByTitle(`%${title}%`, limit)
+			: await ContentService.getContentItems(limit);
 
-	return parseContentPages(contentItems || []);
+		return parseContentPages(contentItems || []);
+	} catch (err) {
+		throw new CustomError('Failed to fetch content pages for content picker', err, {
+			title,
+			limit,
+		});
+	}
 };
 
 // Fetch content items of type PROJECT from GQL


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-929

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/84486445-b84b3180-ac9d-11ea-83fa-de335717d600.png)|![image](https://user-images.githubusercontent.com/1710840/84486453-ba14f500-ac9d-11ea-969e-a6fe6e488000.png)|

since these only contain the title and the path, there is little use to pull them through the converter function

also improved the error handling, so we get a toast message when the content picker fails to "inflate"