### PR TITLE
AVO-928 RTE: ik kan geen tekst meer centreren

### DIFF
--- a/src/shared/helpers/sanitize/presets/index.ts
+++ b/src/shared/helpers/sanitize/presets/index.ts
@@ -23,6 +23,7 @@ const basic = {
 	],
 	allowedAttributes: {
 		span: ['style'],
+		p: ['style'],
 	},
 };
 


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-928

before: 
![image](https://user-images.githubusercontent.com/1710840/84487518-2b08dc80-ac9f-11ea-936a-c727a9f31123.png)

after:
![image](https://user-images.githubusercontent.com/1710840/84487524-2cd2a000-ac9f-11ea-96c4-40454c8a22f9.png)
