### PR TITLE
AVO-1004 Collecties: bij niet-geknipte items wordt opnieuw de eerste still getoond, ipv de standaardstill

### DIFF
--- a/src/item/components/modals/AddToCollectionModal.tsx
+++ b/src/item/components/modals/AddToCollectionModal.tsx
@@ -154,10 +154,9 @@ const AddToCollectionModal: FunctionComponent<AddToCollectionModalProps> = ({
 			collection_uuid: collection.id,
 			item_meta: itemMetaData,
 			type: 'ITEM',
-			thumbnail_path: await VideoStillService.getVideoStill(
-				externalId,
-				fragmentStartTime * 1000
-			),
+			thumbnail_path: !!fragmentStartTime
+				? await VideoStillService.getVideoStill(externalId, fragmentStartTime * 1000)
+				: null,
 		};
 	};
 

--- a/src/shared/services/video-stills-service.ts
+++ b/src/shared/services/video-stills-service.ts
@@ -1,4 +1,4 @@
-import { compact, uniq } from 'lodash-es';
+import { compact, isNil, uniq, without } from 'lodash-es';
 
 import { Avo } from '@viaa/avo2-types';
 
@@ -63,17 +63,12 @@ export class VideoStillService {
 		);
 		const cutVideoFragments = videoFragments.filter(
 			fragment =>
-				fragment.start_oc !== 0 ||
+				(fragment.start_oc !== 0 && !isNil(fragment.start_oc)) ||
 				(fragment.item_meta &&
+					!isNil(fragment.end_oc) &&
 					fragment.end_oc !== toSeconds((fragment.item_meta as Avo.Item.Item).duration))
 		);
-		const uncutVideoFragments = videoFragments.filter(
-			fragment =>
-				(!fragment.start_oc && !fragment.end_oc) ||
-				(fragment.start_oc === 0 &&
-					fragment.item_meta &&
-					fragment.end_oc === toSeconds((fragment.item_meta as Avo.Item.Item).duration))
-		);
+		const uncutVideoFragments = without(videoFragments, ...cutVideoFragments);
 		const cutVideoStillRequests: Avo.Stills.StillRequest[] = compact(
 			cutVideoFragments.map(fragment => ({
 				externalId: fragment.external_id,


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1004

collection thumbnail before and after
![image](https://user-images.githubusercontent.com/1710840/85386031-59aa7100-b543-11ea-9e45-b564bae74aef.png)

collection detail before:
![image](https://user-images.githubusercontent.com/1710840/85386071-68912380-b543-11ea-9209-42210bea3088.png)


collection detail after
![image](https://user-images.githubusercontent.com/1710840/85386099-734bb880-b543-11ea-83f6-0f2a9efd80d6.png)
