### PR TITLE
AVO-1048 Collecties: blanco scherm in bewerkmodus

### DIFF
--- a/src/collection/views/CollectionDetail.tsx
+++ b/src/collection/views/CollectionDetail.tsx
@@ -104,6 +104,23 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 		DEFAULT_BOOKMARK_VIEW_PLAY_COUNTS
 	);
 
+	const getRelatedCollections = useCallback(async () => {
+		try {
+			setRelatedCollections(await getRelatedItems(collectionId, 'collections', 4));
+		} catch (err) {
+			console.error('Failed to get related items', err, {
+				collectionId,
+				index: 'collections',
+				limit: 4,
+			});
+			ToastService.danger(
+				t(
+					'collection/views/collection-detail___het-ophalen-van-de-gerelateerde-collecties-is-mislukt'
+				)
+			);
+		}
+	}, [setRelatedCollections, t, collectionId]);
+
 	useEffect(() => {
 		setCollectionId(match.params.id);
 	}, [match.params.id]);
@@ -150,6 +167,7 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 					buildLink(APP_PATH.COLLECTION_DETAIL.route, { id: uuid }),
 					history
 				);
+				return;
 			}
 
 			const rawPermissions = await Promise.all([
@@ -206,6 +224,8 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 				return;
 			}
 
+			getRelatedCollections();
+
 			BookmarksViewsPlaysService.action('view', 'collection', collectionObj.id, user);
 			try {
 				setBookmarkViewPlayCounts(
@@ -251,30 +271,11 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 				icon: 'alert-triangle',
 			});
 		}
-	}, [collectionId, t, user, history]);
+	}, [collectionId, getRelatedCollections, t, user, history]);
 
 	useEffect(() => {
 		checkPermissionsAndGetCollection();
 	}, [checkPermissionsAndGetCollection]);
-
-	useEffect(() => {
-		getRelatedItems(collectionId, 'collections', 4)
-			.then(relatedItems => {
-				setRelatedCollections(relatedItems);
-			})
-			.catch(err => {
-				console.error('Failed to get related items', err, {
-					collectionId,
-					index: 'collections',
-					limit: 4,
-				});
-				ToastService.danger(
-					t(
-						'collection/views/collection-detail___het-ophalen-van-de-gerelateerde-collecties-is-mislukt'
-					)
-				);
-			});
-	}, [setRelatedCollections, t, collectionId]);
 
 	useEffect(() => {
 		if (!isEmpty(permissions) && collection) {


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1048

example page with avo1 collection id: http://localhost:8080/collecties/938051

before you saw a short flash of failed to load + error toast: failed to load related collections:
![image](https://user-images.githubusercontent.com/1710840/85574102-c2bee100-b636-11ea-8160-d453993249de.png)

Then you see the correct collection on the correct url:
![image](https://user-images.githubusercontent.com/1710840/85574144-cc484900-b636-11ea-9eaf-00654ae2ca71.png)


After this fix you see a spinner:
![image](https://user-images.githubusercontent.com/1710840/85574173-d407ed80-b636-11ea-8479-5662e192d39f.png)

And then the correct page on the correct url:
![image](https://user-images.githubusercontent.com/1710840/85574210-dcf8bf00-b636-11ea-8e34-dbd2e1f7b3d7.png)
