### PR TITLE
fix(user-detail): only show ban button for SS users without ldap account

### DIFF
--- a/src/admin/users/views/UserDetail.tsx
+++ b/src/admin/users/views/UserDetail.tsx
@@ -124,6 +124,10 @@ const UserDetail: FunctionComponent<UserDetailProps> = ({ match, user }) => {
 		return PermissionService.hasPerm(user, PermissionName.EDIT_BAN_USER_STATUS);
 	};
 
+	const isPupil = (): boolean => {
+		return get(storedProfile, 'profile_user_groups[0].groups[0].id') === 4; // Leerling user group
+	};
+
 	const renderList = (list: { id: number; label: string }[], path?: string): ReactNode => {
 		return (
 			<Table horizontal variant="invisible" className="c-table_detail-page">
@@ -277,7 +281,7 @@ const UserDetail: FunctionComponent<UserDetailProps> = ({ match, user }) => {
 		>
 			<AdminLayoutTopBarRight>
 				<ButtonToolbar>
-					{canBanUser() && (
+					{canBanUser() && isPupil() && (
 						<Button
 							type="danger"
 							label={t('admin/users/views/user-detail___bannen')}


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-731

Smartschool user should be bannable from the avo platform:
![image](https://user-images.githubusercontent.com/1710840/86027169-a94fd780-ba30-11ea-8dc6-70349946a238.png)

Ldap users should be banned from the account manager by removing their avo app access:
![image](https://user-images.githubusercontent.com/1710840/86027280-cbe1f080-ba30-11ea-8646-7289a6e7150e.png)
