### PR TITLE
fix(asset-service): upload assets using multipart form upload

### DIFF
--- a/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
@@ -175,7 +175,7 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 			setCollectionCount(collectionsCountTemp);
 		} catch (err) {
 			console.error(
-				new CustomError('Failed to get users from the database', err, { tableState })
+				new CustomError('Failed to get collections from the database', err, { tableState })
 			);
 			setLoadingInfo({
 				state: 'error',

--- a/src/shared/services/file-upload-service.ts
+++ b/src/shared/services/file-upload-service.ts
@@ -68,28 +68,23 @@ export class FileUploadService {
 		ownerId: string
 	): Promise<string> {
 		let url: string | undefined;
-		let body: Avo.FileUpload.UploadAssetInfo | undefined;
 		try {
 			url = `${getEnv('PROXY_URL')}/assets/upload`;
-			const content = await this.fileToBase64(file);
-			if (!content) {
-				throw new CustomError("Failed to upload file: file doesn't have any content", null);
-			}
-			body = {
-				content,
-				ownerId,
-				filename: file.name,
-				mimeType: file.type,
-				type: assetType as any,
-			};
+
+			const formData = new FormData();
+			formData.append('ownerId', ownerId);
+			formData.append('filename', file.name);
+			formData.append('mimeType', file.type);
+			formData.append('type', assetType as any);
+			formData.append('content', file, file.name);
 
 			const response = await fetchWithLogout(url, {
 				method: 'POST',
 				headers: {
-					'Content-Type': 'application/json',
+					// 'content-type': 'multipart/form-data',
 				},
 				credentials: 'include',
-				body: JSON.stringify(body),
+				body: formData,
 			});
 
 			const data: Avo.FileUpload.AssetInfo | any = await response.json();
@@ -102,7 +97,7 @@ export class FileUploadService {
 			}
 			return data.url;
 		} catch (err) {
-			throw new CustomError('Failed to upload file', err, { file, url, body });
+			throw new CustomError('Failed to upload file', err, { file, url });
 		}
 	}
 


### PR DESCRIPTION
closes:
* https://meemoo.atlassian.net/browse/AVO-1018
* https://meemoo.atlassian.net/browse/AVO-735

Proxy PR: https://github.com/viaacode/avo2-proxy/pull/169

allow upload of bigger files for the regular files. Zendesk attachments still use the old upload approach since those files generally are not that big (word/excel/pdf)

![image](https://user-images.githubusercontent.com/1710840/86242163-87776180-bba4-11ea-93ba-d0e084816f00.png)
