### PR TITLE
fix(item-overview): only query for items the user is allowed to see

### DIFF
--- a/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
@@ -153,6 +153,7 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 			) {
 				andFilters.push({ is_public: { _eq: true } });
 			}
+
 			andFilters.push({
 				type_id: {
 					_eq: isCollection ? ContentTypeNumber.collection : ContentTypeNumber.bundle,

--- a/src/admin/items/views/ItemsOverview.tsx
+++ b/src/admin/items/views/ItemsOverview.tsx
@@ -25,10 +25,14 @@ import { AdminLayout, AdminLayoutBody } from '../../shared/layouts';
 import { GET_ITEM_OVERVIEW_TABLE_COLS, ITEMS_PER_PAGE } from '../items.const';
 import { ItemsService } from '../items.service';
 import { ItemsOverviewTableCols, ItemsTableState } from '../items.types';
+import {
+	PermissionName,
+	PermissionService,
+} from '../../../authentication/helpers/permission-service';
 
 interface ItemsOverviewProps extends DefaultSecureRouteProps {}
 
-const ItemsOverview: FunctionComponent<ItemsOverviewProps> = ({ history }) => {
+const ItemsOverview: FunctionComponent<ItemsOverviewProps> = ({ history, user }) => {
 	const [t] = useTranslation();
 
 	const [items, setItems] = useState<Avo.Item.Item[] | null>(null);
@@ -65,6 +69,15 @@ const ItemsOverview: FunctionComponent<ItemsOverviewProps> = ({ history }) => {
 					'published_at',
 				])
 			);
+
+			// Only show published/unpublished items based on permissions
+			if (!PermissionService.hasPerm(user, PermissionName.VIEW_ANY_PUBLISHED_ITEMS)) {
+				andFilters.push({ is_published: { _eq: false } });
+			}
+			if (!PermissionService.hasPerm(user, PermissionName.VIEW_ANY_UNPUBLISHED_ITEMS)) {
+				andFilters.push({ is_published: { _eq: true } });
+			}
+
 			if (filters.type && filters.type.length) {
 				andFilters.push({ type: { label: { _in: filters.type } } });
 			}


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-878

item overview without the VIEW_ANY_UNPUBLISHED_ITEMS should not throw this error, but instead only show published items
![image](https://user-images.githubusercontent.com/1710840/86377964-5755be80-bc89-11ea-8943-6ce5c3a50963.png)

items detail in the admin dashboard is already correct:
![image](https://user-images.githubusercontent.com/1710840/86378052-78b6aa80-bc89-11ea-96e1-d4786d03c9fe.png)

