### PR TITLE
fix(page-overview-block): reset labels when changing content type

### DIFF
--- a/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
@@ -56,7 +56,7 @@ interface PageOverviewWrapperProps {
 const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteComponentProps> = ({
 	contentTypeAndTabs = {
 		selectedContentType: 'PROJECT',
-		selectedLabels: [],
+		selectedLabels: null,
 	},
 	tabStyle = 'MENU_BAR',
 	allowMultiple = false,
@@ -165,7 +165,7 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteCom
 			const hasLabel = queryParams.label && isString(queryParams.label);
 			const hasItem = queryParams.item && isString(queryParams.item);
 			if (hasLabel) {
-				const labelObj = contentTypeAndTabs.selectedLabels.find(
+				const labelObj = (contentTypeAndTabs.selectedLabels || []).find(
 					l => l.label === queryParams.label
 				);
 				if (labelObj) {
@@ -222,7 +222,7 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteCom
 		}
 		return (
 			<BlockPageOverview
-				tabs={contentTypeAndTabs.selectedLabels}
+				tabs={contentTypeAndTabs.selectedLabels || []}
 				selectedTabs={selectedTabs}
 				onSelectedTabsChanged={handleSelectedTabsChanged}
 				currentPage={currentPage}

--- a/src/admin/shared/components/ContentTypeAndLabelsPicker/ContentTypeAndLabelsPicker.tsx
+++ b/src/admin/shared/components/ContentTypeAndLabelsPicker/ContentTypeAndLabelsPicker.tsx
@@ -21,7 +21,7 @@ import { useContentTypes } from '../../../content/hooks';
 
 export interface ContentTypeAndLabelsValue {
 	selectedContentType: Avo.ContentPage.Type;
-	selectedLabels: Avo.ContentPage.Label[];
+	selectedLabels: Avo.ContentPage.Label[] | null;
 }
 
 export interface ContentTypeAndLabelsProps {
@@ -33,7 +33,7 @@ export interface ContentTypeAndLabelsProps {
 export const ContentTypeAndLabelsPicker: FunctionComponent<ContentTypeAndLabelsProps> = ({
 	value = {
 		selectedContentType: 'PROJECT',
-		selectedLabels: [],
+		selectedLabels: null,
 	},
 	onChange,
 	errors,
@@ -64,7 +64,7 @@ export const ContentTypeAndLabelsPicker: FunctionComponent<ContentTypeAndLabelsP
 	const handleContentTypeChanged = (selectedValue: string) => {
 		onChange({
 			selectedContentType: selectedValue as Avo.ContentPage.Type,
-			selectedLabels: get(value, 'selectedLabels', []),
+			selectedLabels: null,
 		});
 	};
 
@@ -94,36 +94,39 @@ export const ContentTypeAndLabelsPicker: FunctionComponent<ContentTypeAndLabelsP
 				/>
 			</Column>
 			<Column size="3">
-				<TagsInput
-					options={(labels || []).map(
-						(labelObj): SelectOption<number> => ({
-							label: labelObj.label,
-							value: labelObj.id,
-						})
-					)}
-					allowMulti
-					allowCreate={false}
-					value={compact(
-						((value.selectedLabels || []) as LabelObj[]).map(
-							(labelObj: LabelObj): SelectOption<number> => ({
+				{/* Force reload tagInput when content type changes */}
+				<div key={(value.selectedLabels || []).length}>
+					<TagsInput
+						options={(labels || []).map(
+							(labelObj): SelectOption<number> => ({
 								label: labelObj.label,
 								value: labelObj.id,
 							})
-						)
-					)}
-					onChange={handleLabelsChanged}
-					disabled={!value || !value.selectedContentType}
-					isLoading={isLoading}
-					placeholder={
-						!value || !value.selectedContentType
-							? t(
-									'admin/shared/components/content-type-and-labels-picker/content-type-and-labels-picker___kies-eerst-een-content-type'
-							  )
-							: t(
-									'admin/shared/components/content-type-and-labels-picker/content-type-and-labels-picker___labels'
-							  )
-					}
-				/>
+						)}
+						allowMulti
+						allowCreate={false}
+						value={compact(
+							(value.selectedLabels || []).map(
+								(labelObj: LabelObj): SelectOption<number> => ({
+									label: labelObj.label,
+									value: labelObj.id,
+								})
+							)
+						)}
+						onChange={handleLabelsChanged}
+						disabled={!value || !value.selectedContentType}
+						isLoading={isLoading}
+						placeholder={
+							!value || !value.selectedContentType
+								? t(
+										'admin/shared/components/content-type-and-labels-picker/content-type-and-labels-picker___kies-eerst-een-content-type'
+								  )
+								: t(
+										'admin/shared/components/content-type-and-labels-picker/content-type-and-labels-picker___labels'
+								  )
+						}
+					/>
+				</div>
 			</Column>
 		</Grid>
 	);


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-937

![image](https://user-images.githubusercontent.com/1710840/87018785-04708f80-c1d2-11ea-8c90-1d5e5045e728.png)

![image](https://user-images.githubusercontent.com/1710840/87018791-05a1bc80-c1d2-11ea-8820-bed838929e17.png)
