### PR TITLE
fix(content-block-preview): make cb z-index 1 only if header bg color

### DIFF
--- a/src/admin/content-block/components/ContentBlockPreview/ContentBlockPreview.scss
+++ b/src/admin/content-block/components/ContentBlockPreview/ContentBlockPreview.scss
@@ -2,7 +2,6 @@
 
 .c-content-block {
 	position: relative;
-	z-index: 1;
 
 	> div {
 		z-index: 2;

--- a/src/admin/content-block/components/ContentBlockPreview/ContentBlockPreview.tsx
+++ b/src/admin/content-block/components/ContentBlockPreview/ContentBlockPreview.tsx
@@ -113,7 +113,10 @@ const ContentBlockPreview: FunctionComponent<ContentBlockPreviewProps &
 	return (
 		<div
 			className={classnames('c-content-block', className)}
-			style={{ backgroundColor: blockState.backgroundColor }}
+			style={{
+				backgroundColor: blockState.backgroundColor,
+				...(blockState.headerBackgroundColor !== Color.Transparent ? { zIndex: 1 } : {}),
+			}}
 			id={blockState.anchor}
 			data-anchor={blockState.anchor}
 			ref={blockRef}


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1185

![image](https://user-images.githubusercontent.com/1710840/87155924-19c1e880-c2bc-11ea-96ac-a5bbcb9a6c1d.png)


![image](https://user-images.githubusercontent.com/1710840/87155911-13337100-c2bc-11ea-9f87-c6a55ec12a14.png)
