### PR TITLE
fix(collection-detail): show collection even if no subjects/edu levels

### DIFF
--- a/src/collection/views/CollectionDetail.tsx
+++ b/src/collection/views/CollectionDetail.tsx
@@ -785,8 +785,8 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 					publishedAt={get(collection, 'published_at')}
 					updatedAt={get(collection, 'updated_at')}
 					keywords={[
-						...get(collection, 'lom_classification'),
-						...get(collection, 'lom_context'),
+						...(get(collection, 'lom_classification') || []),
+						...(get(collection, 'lom_context') || []),
 					]}
 				/>
 				<div


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1222

proxy PR: https://github.com/viaacode/avo2-proxy/pull/201

example url that didn't work: http://localhost:8080/collecties/5491d72a-f136-44b4-86fa-dd44f1deea3d