### PR TITLE
fix(interactive-tour-edit): memoize tour step edit controls

### DIFF
--- a/src/admin/interactive-tour/views/InteractiveTourEdit.tsx
+++ b/src/admin/interactive-tour/views/InteractiveTourEdit.tsx
@@ -1,4 +1,4 @@
-import { cloneDeep, compact, get, isEmpty, isEqual, map, orderBy } from 'lodash-es';
+import { cloneDeep, compact, get, isEmpty, map, orderBy } from 'lodash-es';
 import React, {
 	FunctionComponent,
 	Reducer,
@@ -20,22 +20,10 @@ import {
 	FlexItem,
 	Form,
 	FormGroup,
-	Icon,
-	IconName,
-	Panel,
-	PanelBody,
-	PanelHeader,
 	Select,
 	SelectOption,
 	Spacer,
 	TextInput,
-	Toolbar,
-	ToolbarItem,
-	ToolbarLeft,
-	ToolbarRight,
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
 } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
@@ -43,10 +31,8 @@ import { DefaultSecureRouteProps } from '../../../authentication/components/Secu
 import { redirectToClientPage } from '../../../authentication/helpers/redirects';
 import { APP_PATH, GENERATE_SITE_TITLE } from '../../../constants';
 import { LoadingErrorLoadedComponent, LoadingInfo } from '../../../shared/components';
-import Html from '../../../shared/components/Html/Html';
-import WYSIWYGWrapper from '../../../shared/components/WYSIWYGWrapper/WYSIWYGWrapper';
-import { ROUTE_PARTS, WYSIWYG_OPTIONS_FULL } from '../../../shared/constants';
-import { buildLink, CustomError, navigate, sanitizeHtml, stripHtml } from '../../../shared/helpers';
+import { ROUTE_PARTS } from '../../../shared/constants';
+import { buildLink, CustomError, navigate, sanitizeHtml } from '../../../shared/helpers';
 import { dataService, ToastService } from '../../../shared/services';
 import { ADMIN_PATH } from '../../admin.const';
 import { ContentPicker } from '../../shared/components/ContentPicker/ContentPicker';
@@ -76,6 +62,7 @@ import {
 } from '../interactive-tour.types';
 
 import './InteractiveTourEdit.scss';
+import InteractiveTourEditStep from './InteractiveTourEditStep';
 
 export interface InteractiveTourEditProps extends DefaultSecureRouteProps<{ id: string }> {}
 
@@ -353,183 +340,22 @@ const InteractiveTourEdit: FunctionComponent<InteractiveTourEditProps> = ({
 		return undefined;
 	};
 
-	const renderReorderButton = (index: number, direction: 'up' | 'down', disabled: boolean) => (
-		<Button
-			type="secondary"
-			icon={`chevron-${direction}` as IconName}
-			title={
-				direction === 'up'
-					? t('admin/interactive-tour/views/interactive-tour-edit___verplaats-naar-boven')
-					: t('admin/interactive-tour/views/interactive-tour-edit___verplaats-naar-onder')
-			}
-			ariaLabel={
-				direction === 'up'
-					? t('admin/interactive-tour/views/interactive-tour-edit___verplaats-naar-boven')
-					: t('admin/interactive-tour/views/interactive-tour-edit___verplaats-naar-onder')
-			}
-			onClick={() => {
-				changeInteractiveTourState({
-					direction,
-					index,
-					type: InteractiveTourEditActionType.SWAP_STEPS,
-				});
-			}}
-			disabled={disabled}
-		/>
-	);
-
 	const renderStep = (step: EditableStep, index: number) => {
 		if (!interactiveTourState.currentInteractiveTour) {
 			return null;
 		}
 
 		return (
-			<div key={`step_${step.id}`}>
-				<Panel>
-					<PanelHeader>
-						<Toolbar>
-							<ToolbarLeft>
-								<ToolbarItem>
-									<div className="c-button-toolbar">
-										{renderReorderButton(index, 'up', index === 0)}
-										{renderReorderButton(
-											index,
-											'down',
-											index ===
-												(
-													interactiveTourState.currentInteractiveTour
-														.steps || []
-												).length -
-													1
-										)}
-									</div>
-								</ToolbarItem>
-							</ToolbarLeft>
-							<ToolbarRight>
-								<ToolbarItem>
-									<Button
-										icon="trash-2"
-										type="danger"
-										onClick={() => {
-											changeInteractiveTourState({
-												index,
-												type: InteractiveTourEditActionType.REMOVE_STEP,
-											});
-										}}
-										ariaLabel={t(
-											'admin/interactive-tour/views/interactive-tour-edit___verwijder-stap'
-										)}
-										title={t(
-											'admin/interactive-tour/views/interactive-tour-edit___verwijder-stap'
-										)}
-									/>
-								</ToolbarItem>
-							</ToolbarRight>
-						</Toolbar>
-					</PanelHeader>
-					<PanelBody>
-						<Form>
-							<FormGroup
-								label={t(
-									'admin/interactive-tour/views/interactive-tour-edit___titel'
-								)}
-								error={get(formErrors, `steps[${index}].title`)}
-							>
-								<TextInput
-									value={(step.title || '').toString()}
-									onChange={newTitle => {
-										changeInteractiveTourState({
-											type: InteractiveTourEditActionType.UPDATE_STEP_PROP,
-											stepIndex: index,
-											stepProp: 'title',
-											stepPropValue: newTitle,
-										});
-									}}
-								/>
-								<Spacer margin="top-small">{step.title.length} / 28</Spacer>
-							</FormGroup>
-							<FormGroup
-								label={t(
-									'admin/interactive-tour/views/interactive-tour-edit___tekst'
-								)}
-								error={get(formErrors, `steps[${index}].content`)}
-							>
-								<WYSIWYGWrapper
-									initialHtml={(step.content || '').toString()}
-									state={step.contentState}
-									onChange={newContentState => {
-										if (!isEqual(newContentState, step.contentState)) {
-											changeInteractiveTourState({
-												type:
-													InteractiveTourEditActionType.UPDATE_STEP_PROP,
-												stepIndex: index,
-												stepProp: 'contentState',
-												stepPropValue: newContentState,
-											});
-										}
-									}}
-									controls={WYSIWYG_OPTIONS_FULL}
-									fileType="INTERACTIVE_TOUR_IMAGE"
-									id={`content_editor_${index}`}
-									placeholder={t(
-										'admin/interactive-tour/views/interactive-tour-edit___vul-een-stap-tekst-in'
-									)}
-								/>
-								<Spacer margin="top-small">
-									{
-										(step.contentState
-											? stripHtml(
-													sanitizeHtml(step.contentState.toHTML(), 'link')
-											  )
-											: step.content || ''
-										).length
-									}{' '}
-									/ 200
-								</Spacer>
-							</FormGroup>
-
-							<FormGroup
-								label={t(
-									'admin/interactive-tour/views/interactive-tour-edit___element-css-selector'
-								)}
-							>
-								<TextInput
-									value={(step.target || '').toString()}
-									onChange={newTarget => {
-										changeInteractiveTourState({
-											type: InteractiveTourEditActionType.UPDATE_STEP_PROP,
-											stepIndex: index,
-											stepProp: 'target',
-											stepPropValue: newTarget,
-										});
-									}}
-									className="c-text-input__selector"
-								/>
-								<Tooltip position="top">
-									<TooltipTrigger>
-										<span>
-											<Icon
-												className="a-info-icon"
-												name="info"
-												size="small"
-											/>
-										</span>
-									</TooltipTrigger>
-									<TooltipContent>
-										<Spacer padding="small">
-											<Html
-												content={t(
-													'admin/interactive-tour/views/interactive-tour-edit___hoe-kopieer-je-een-css-selector'
-												)}
-												type="div"
-											/>
-										</Spacer>
-									</TooltipContent>
-								</Tooltip>
-							</FormGroup>
-						</Form>
-					</PanelBody>
-				</Panel>
+			<div key={`step_${step.target}_${step.id}`}>
+				<InteractiveTourEditStep
+					step={step}
+					index={index}
+					changeInteractiveTourState={changeInteractiveTourState}
+					numberOfSteps={
+						get(interactiveTourState, 'currentInteractiveTour.steps.length') || 1
+					}
+					stepErrors={get(formErrors, ['steps', index])}
+				/>
 				<InteractiveTourAdd
 					index={index + 1}
 					interactiveTour={interactiveTourState.currentInteractiveTour}

--- a/src/admin/interactive-tour/views/InteractiveTourEditStep.tsx
+++ b/src/admin/interactive-tour/views/InteractiveTourEditStep.tsx
@@ -1,0 +1,209 @@
+import { get, isEqual } from 'lodash-es';
+import React, { FunctionComponent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+	Button,
+	Form,
+	FormGroup,
+	Icon,
+	IconName,
+	Panel,
+	PanelBody,
+	PanelHeader,
+	Spacer,
+	TextInput,
+	Toolbar,
+	ToolbarItem,
+	ToolbarLeft,
+	ToolbarRight,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from '@viaa/avo2-components';
+
+import Html from '../../../shared/components/Html/Html';
+import WYSIWYGWrapper from '../../../shared/components/WYSIWYGWrapper/WYSIWYGWrapper';
+import { WYSIWYG_OPTIONS_FULL } from '../../../shared/constants';
+import { sanitizeHtml, stripHtml } from '../../../shared/helpers';
+import { InteractiveTourAction } from '../helpers/reducers';
+import { EditableStep, InteractiveTourEditActionType } from '../interactive-tour.types';
+
+import './InteractiveTourEdit.scss';
+
+export interface InteractiveTourEditStepProps {
+	step: EditableStep;
+	index: number;
+	numberOfSteps: number;
+	stepErrors: { title?: string; content?: string };
+	changeInteractiveTourState: (action: InteractiveTourAction) => void;
+}
+
+const InteractiveTourEditStep: FunctionComponent<InteractiveTourEditStepProps> = ({
+	step,
+	index,
+	numberOfSteps,
+	stepErrors,
+	changeInteractiveTourState,
+}) => {
+	const [t] = useTranslation();
+
+	const renderReorderButton = (index: number, direction: 'up' | 'down', disabled: boolean) => (
+		<Button
+			type="secondary"
+			icon={`chevron-${direction}` as IconName}
+			title={
+				direction === 'up'
+					? t('admin/interactive-tour/views/interactive-tour-edit___verplaats-naar-boven')
+					: t('admin/interactive-tour/views/interactive-tour-edit___verplaats-naar-onder')
+			}
+			ariaLabel={
+				direction === 'up'
+					? t('admin/interactive-tour/views/interactive-tour-edit___verplaats-naar-boven')
+					: t('admin/interactive-tour/views/interactive-tour-edit___verplaats-naar-onder')
+			}
+			onClick={() => {
+				changeInteractiveTourState({
+					direction,
+					index,
+					type: InteractiveTourEditActionType.SWAP_STEPS,
+				});
+			}}
+			disabled={disabled}
+		/>
+	);
+
+	if (!step) {
+		return null;
+	}
+
+	return (
+		<Panel>
+			<PanelHeader>
+				<Toolbar>
+					<ToolbarLeft>
+						<ToolbarItem>
+							<div className="c-button-toolbar">
+								{renderReorderButton(index, 'up', index === 0)}
+								{renderReorderButton(index, 'down', index === numberOfSteps - 1)}
+							</div>
+						</ToolbarItem>
+					</ToolbarLeft>
+					<ToolbarRight>
+						<ToolbarItem>
+							<Button
+								icon="trash-2"
+								type="danger"
+								onClick={() => {
+									changeInteractiveTourState({
+										index,
+										type: InteractiveTourEditActionType.REMOVE_STEP,
+									});
+								}}
+								ariaLabel={t(
+									'admin/interactive-tour/views/interactive-tour-edit___verwijder-stap'
+								)}
+								title={t(
+									'admin/interactive-tour/views/interactive-tour-edit___verwijder-stap'
+								)}
+							/>
+						</ToolbarItem>
+					</ToolbarRight>
+				</Toolbar>
+			</PanelHeader>
+			<PanelBody>
+				<Form>
+					<FormGroup
+						label={t('admin/interactive-tour/views/interactive-tour-edit___titel')}
+						error={get(stepErrors, 'title')}
+					>
+						<TextInput
+							value={(step.title || '').toString()}
+							onChange={newTitle => {
+								changeInteractiveTourState({
+									type: InteractiveTourEditActionType.UPDATE_STEP_PROP,
+									stepIndex: index,
+									stepProp: 'title',
+									stepPropValue: newTitle,
+								});
+							}}
+						/>
+						<Spacer margin="top-small">{step.title.length} / 28</Spacer>
+					</FormGroup>
+					<FormGroup
+						label={t('admin/interactive-tour/views/interactive-tour-edit___tekst')}
+						error={get(stepErrors, 'content')}
+					>
+						<WYSIWYGWrapper
+							initialHtml={(step.content || '').toString()}
+							state={step.contentState}
+							onChange={newContentState => {
+								if (!isEqual(newContentState, step.contentState)) {
+									changeInteractiveTourState({
+										type: InteractiveTourEditActionType.UPDATE_STEP_PROP,
+										stepIndex: index,
+										stepProp: 'contentState',
+										stepPropValue: newContentState,
+									});
+								}
+							}}
+							controls={WYSIWYG_OPTIONS_FULL}
+							fileType="INTERACTIVE_TOUR_IMAGE"
+							id={`content_editor_${index}`}
+							placeholder={t(
+								'admin/interactive-tour/views/interactive-tour-edit___vul-een-stap-tekst-in'
+							)}
+						/>
+						<Spacer margin="top-small">
+							{
+								(step.contentState
+									? stripHtml(sanitizeHtml(step.contentState.toHTML(), 'link'))
+									: step.content || ''
+								).length
+							}{' '}
+							/ 200
+						</Spacer>
+					</FormGroup>
+
+					<FormGroup
+						label={t(
+							'admin/interactive-tour/views/interactive-tour-edit___element-css-selector'
+						)}
+					>
+						<TextInput
+							value={(step.target || '').toString()}
+							onChange={newTarget => {
+								changeInteractiveTourState({
+									type: InteractiveTourEditActionType.UPDATE_STEP_PROP,
+									stepIndex: index,
+									stepProp: 'target',
+									stepPropValue: newTarget,
+								});
+							}}
+							className="c-text-input__selector"
+						/>
+						<Tooltip position="top">
+							<TooltipTrigger>
+								<span>
+									<Icon className="a-info-icon" name="info" size="small" />
+								</span>
+							</TooltipTrigger>
+							<TooltipContent>
+								<Spacer padding="small">
+									<Html
+										content={t(
+											'admin/interactive-tour/views/interactive-tour-edit___hoe-kopieer-je-een-css-selector'
+										)}
+										type="div"
+									/>
+								</Spacer>
+							</TooltipContent>
+						</Tooltip>
+					</FormGroup>
+				</Form>
+			</PanelBody>
+		</Panel>
+	);
+};
+
+export default React.memo(InteractiveTourEditStep);


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1081

example page that would go really slow when typing in the last step description: http://localhost:8080/beheer/interactieve-tours/21/bewerk

![image](https://user-images.githubusercontent.com/1710840/87684331-6d33ab00-c782-11ea-865e-c635ccf70e39.png)
