### PR TITLE
fix(wysiwyg-wrapper): remove margin so caret and placeholder align

### DIFF
--- a/src/shared/components/WYSIWYGWrapper/WYSIWYGWrapper.scss
+++ b/src/shared/components/WYSIWYGWrapper/WYSIWYGWrapper.scss
@@ -1,0 +1,3 @@
+.DraftEditor-editorContainer .public-DraftEditor-content > div > div:first-child {
+	margin-top: 0;
+}

--- a/src/shared/components/WYSIWYGWrapper/WYSIWYGWrapper.tsx
+++ b/src/shared/components/WYSIWYGWrapper/WYSIWYGWrapper.tsx
@@ -10,6 +10,8 @@ import { CustomError } from '../../helpers';
 import { ToastService } from '../../services';
 import { FileUploadService } from '../../services/file-upload-service';
 
+import './WYSIWYGWrapper.scss';
+
 export type WYSIWYGWrapperProps = WYSIWYGProps & {
 	fileType?: Avo.FileUpload.AssetType; // Required to enable file upload
 	ownerId?: string;


### PR DESCRIPTION
|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/87684673-d1566f00-c782-11ea-86df-6cdee7b90b89.png)|![image](https://user-images.githubusercontent.com/1710840/87684680-d3b8c900-c782-11ea-9064-0b3783ef5650.png)|