### PR TITLE
fix(content-pages): hide nav, check permissions before edit/detail

### DIFF
--- a/src/admin/admin.const.ts
+++ b/src/admin/admin.const.ts
@@ -1,5 +1,6 @@
 import { every, some } from 'lodash-es';
 
+import { PermissionName } from '../authentication/helpers/permission-service';
 import { buildLink, CustomError } from '../shared/helpers';
 import { ToastService } from '../shared/services';
 import i18n from '../shared/translations/i18n';
@@ -214,24 +215,29 @@ export const GET_NAV_ITEMS = async (userPermissions: string[]): Promise<Navigati
 				key: 'faqs',
 				exact: true,
 			},
-			{
-				label: i18n.t('admin/admin___start-uitgelogd'),
-				location: await getContentPageDetailRouteByPath('/'),
-				key: 'faqs',
-				exact: true,
-			},
-			{
-				label: i18n.t('admin/admin___start-uitgelogd-leerlingen'),
-				location: await getContentPageDetailRouteByPath('/leerlingen'),
-				key: 'faqs',
-				exact: true,
-			},
-			{
-				label: i18n.t('admin/admin___start-ingelogd-lesgever'),
-				location: await getContentPageDetailRouteByPath('/start'),
-				key: 'faqs',
-				exact: true,
-			},
+			// Only show the startpages to the users that can edit all pages
+			...(userPermissions.includes(PermissionName.EDIT_ANY_CONTENT_PAGES)
+				? [
+						{
+							label: i18n.t('admin/admin___start-uitgelogd'),
+							location: await getContentPageDetailRouteByPath('/'),
+							key: 'faqs',
+							exact: true,
+						},
+						{
+							label: i18n.t('admin/admin___start-uitgelogd-leerlingen'),
+							location: await getContentPageDetailRouteByPath('/leerlingen'),
+							key: 'faqs',
+							exact: true,
+						},
+						{
+							label: i18n.t('admin/admin___start-ingelogd-lesgever'),
+							location: await getContentPageDetailRouteByPath('/start'),
+							key: 'faqs',
+							exact: true,
+						},
+				  ]
+				: []),
 		],
 	}),
 	...hasPermissions(['EDIT_CONTENT_PAGE_LABELS'], 'OR', userPermissions, {

--- a/src/admin/content/views/ContentDetail.tsx
+++ b/src/admin/content/views/ContentDetail.tsx
@@ -107,7 +107,29 @@ const ContentDetail: FunctionComponent<ContentDetailProps> = ({ history, match, 
 
 	const fetchContentPageById = useCallback(async () => {
 		try {
-			setContentPageInfo(await ContentService.getContentPageById(id));
+			if (
+				!PermissionService.hasPerm(user, PermissionName.EDIT_ANY_CONTENT_PAGES) &&
+				!PermissionService.hasPerm(user, PermissionName.EDIT_OWN_CONTENT_PAGES)
+			) {
+				setLoadingInfo({
+					state: 'error',
+					message: t('Je hebt geen rechten om deze content pagina te bekijken'),
+					icon: 'lock',
+				});
+				return;
+			}
+			const contentPageObj = await ContentService.getContentPageById(id);
+			if (!contentPageObj) {
+				setLoadingInfo({
+					state: 'error',
+					message: t(
+						'De content pagina kon niet worden gevonden of je hebt geen rechten om deze te bekijken'
+					),
+					icon: 'lock',
+				});
+				return;
+			}
+			setContentPageInfo(contentPageObj);
 		} catch (err) {
 			console.error(
 				new CustomError('Failed to get content page by id', err, {
@@ -130,7 +152,7 @@ const ContentDetail: FunctionComponent<ContentDetailProps> = ({ history, match, 
 				icon: notFound ? 'search' : 'alert-triangle',
 			});
 		}
-	}, [setContentPageInfo, setLoadingInfo, t, id]);
+	}, [setContentPageInfo, setLoadingInfo, user, t, id]);
 
 	useEffect(() => {
 		fetchContentPageById();

--- a/src/admin/content/views/ContentEdit.tsx
+++ b/src/admin/content/views/ContentEdit.tsx
@@ -104,10 +104,33 @@ const ContentEdit: FunctionComponent<ContentEditProps> = ({ history, match, user
 			if (isNil(id)) {
 				return;
 			}
+			if (
+				!PermissionService.hasPerm(user, PermissionName.EDIT_ANY_CONTENT_PAGES) &&
+				!PermissionService.hasPerm(user, PermissionName.EDIT_OWN_CONTENT_PAGES)
+			) {
+				setLoadingInfo({
+					state: 'error',
+					message: t('Je hebt geen rechten om deze content pagina te bekijken'),
+					icon: 'lock',
+				});
+				return;
+			}
+			const contentPageObj = await ContentService.getContentPageById(id);
+			if (
+				!PermissionService.hasPerm(user, PermissionName.EDIT_ANY_CONTENT_PAGES) &&
+				contentPageObj.user_profile_id !== getProfileId(user)
+			) {
+				setLoadingInfo({
+					state: 'error',
+					message: t('Je hebt geen rechten om deze content pagina te bekijken'),
+					icon: 'lock',
+				});
+				return;
+			}
 			changeContentPageState({
 				type: ContentEditActionType.SET_CONTENT_PAGE,
 				payload: {
-					contentPageInfo: await ContentService.getContentPageById(id),
+					contentPageInfo: contentPageObj,
 					replaceInitial: true,
 				},
 			});
@@ -120,7 +143,7 @@ const ContentEdit: FunctionComponent<ContentEditProps> = ({ history, match, user
 				false
 			);
 		}
-	}, [id, t]);
+	}, [id, user, t]);
 
 	useEffect(() => {
 		fetchContentPage();

--- a/src/admin/content/views/ContentOverview.tsx
+++ b/src/admin/content/views/ContentOverview.tsx
@@ -82,7 +82,10 @@ const ContentOverview: FunctionComponent<ContentOverviewProps> = ({ history, use
 
 	const [t] = useTranslation();
 
-	const hasPerm = (permission: PermissionName) => PermissionService.hasPerm(user, permission);
+	const hasPerm = useCallback(
+		(permission: PermissionName) => PermissionService.hasPerm(user, permission),
+		[user]
+	);
 
 	const fetchContentPages = useCallback(async () => {
 		try {
@@ -170,7 +173,7 @@ const ContentOverview: FunctionComponent<ContentOverviewProps> = ({ history, use
 				icon: 'alert-triangle',
 			});
 		}
-	}, [user, setContentPages, setContentPageCount, setLoadingInfo, tableState, t]);
+	}, [user, setContentPages, setContentPageCount, setLoadingInfo, tableState, hasPerm, t]);
 
 	useEffect(() => {
 		fetchContentPages();


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-1108

This PR adds additional checks on top of: https://github.com/viaacode/avo2-client/pull/912

* only show start page menu items to users that can edit all content pages. So educatonal partners do not see these, since they can't edit them anyway.
* Check permissions before loading detail and edit pages, otherwise users that know the url can still see these really easily. The perminant fix for this is: https://meemoo.atlassian.net/browse/AVO-260
* Fix issues with dependency arrays for useCallback functions in the ContentOverview page

![image](https://user-images.githubusercontent.com/1710840/89166867-f1f03880-d57a-11ea-80c4-5eafbb27ece9.png)

![image](https://user-images.githubusercontent.com/1710840/89166895-ff0d2780-d57a-11ea-8d65-4f6084ff7196.png)
