### PR TITLE
fix(content-page-meta): show published date instead of update date

### DIFF
--- a/src/admin/content-block/components/wrappers/BlockContentPageMeta/BlockContentPageMeta.tsx
+++ b/src/admin/content-block/components/wrappers/BlockContentPageMeta/BlockContentPageMeta.tsx
@@ -8,6 +8,7 @@ import { getProfileName } from '../../../../../authentication/helpers/get-profil
 import { ROUTE_PARTS } from '../../../../../shared/constants';
 import { normalizeTimestamp } from '../../../../../shared/helpers/formatters';
 import { ContentPageInfo } from '../../../../content/content.types';
+import { getPublishedDate } from '../../../../content/helpers/get-published-state';
 
 export interface BlockContentPageMetaProps {
 	contentPageInfo: ContentPageInfo;
@@ -59,14 +60,17 @@ const BlockContentPageMeta: FunctionComponent<BlockContentPageMetaProps> = ({
 		);
 	};
 
+	const publishedDate = getPublishedDate(contentPageInfo);
 	return (
 		<span>
 			{t(
 				'admin/content-block/components/wrappers/block-content-page-meta/block-content-page-meta___gepubliceerd-op'
 			)}{' '}
-			{normalizeTimestamp(contentPageInfo.updated_at || contentPageInfo.created_at).format(
-				'D MMMM YYYY'
-			)}{' '}
+			{publishedDate
+				? normalizeTimestamp(publishedDate)
+						.local()
+						.format('D MMMM YYYY')
+				: '-'}{' '}
 			{renderLabels()}
 			{`${t(
 				'admin/content-block/components/wrappers/block-content-page-meta/block-content-page-meta___door'


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1144

example page: http://localhost:8080/beheer/content/356

ignore the american formatting

![image](https://user-images.githubusercontent.com/1710840/89179969-20790e00-d591-11ea-9062-e95bd56d748e.png)

![image](https://user-images.githubusercontent.com/1710840/89179977-2373fe80-d591-11ea-9b92-053557c57086.png)
