### PR TITLE
fix(translations): only update changed translations in the database

### DIFF
--- a/src/admin/translations/translations.service.ts
+++ b/src/admin/translations/translations.service.ts
@@ -1,7 +1,7 @@
 import { get } from 'lodash-es';
 
 import { CustomError } from '../../shared/helpers';
-import { dataService } from '../../shared/services';
+import { ApolloCacheManager, dataService } from '../../shared/services';
 
 import { GET_TRANSLATIONS, UPDATE_TRANSLATIONS } from './translations.gql';
 
@@ -10,7 +10,10 @@ const TRANSLATIONS_RESULT_PATH = 'app_site_variables';
 export const fetchTranslations = async (): Promise<any> => {
 	try {
 		// retrieve translations
-		const response = await dataService.query({ query: GET_TRANSLATIONS });
+		const response = await dataService.query({
+			query: GET_TRANSLATIONS,
+			fetchPolicy: 'no-cache',
+		});
 
 		return get(response, `data.${TRANSLATIONS_RESULT_PATH}`, null);
 	} catch (err) {
@@ -34,6 +37,7 @@ export const updateTranslations = async (name: string, translations: any) => {
 				name,
 				translations,
 			},
+			update: ApolloCacheManager.clearTranslations,
 		});
 	} catch (err) {
 		// handle error

--- a/src/admin/translations/views/TranslationsOverview.tsx
+++ b/src/admin/translations/views/TranslationsOverview.tsx
@@ -53,7 +53,7 @@ const TranslationsOverview: FunctionComponent<TranslationsOverviewProps> = () =>
 
 		const freshTranslations = convertTranslationsToData(await fetchTranslations());
 
-		const updatedTranslations = freshTranslations.map((freshTranslation: [string, string]): [
+		const updatedTranslations = freshTranslations.map((freshTranslation: Translation): [
 			string,
 			string
 		] => {
@@ -106,7 +106,7 @@ const TranslationsOverview: FunctionComponent<TranslationsOverviewProps> = () =>
 		}
 	};
 
-	const convertTranslationsToData = (translations: TranslationsState[]): [string, string][] => {
+	const convertTranslationsToData = (translations: TranslationsState[]): Translation[] => {
 		// convert translations to state format
 		return flatten(
 			translations.map((context: TranslationsState) => {

--- a/src/shared/services/data-service.ts
+++ b/src/shared/services/data-service.ts
@@ -88,6 +88,9 @@ export class ApolloCacheManager {
 	public static clearUserCache = (cache: ApolloCache) =>
 		ApolloCacheManager.deleteFromCache(cache, 'shared_users');
 
+	public static clearTranslations = (cache: ApolloCache) =>
+		ApolloCacheManager.deleteFromCache(cache, 'app_site_variables');
+
 	private static deleteFromCache(cache: ApolloCache, substring: string) {
 		Object.keys(cache.data.data).forEach((key: string) => {
 			// Also match keys starting with $ROOT_QUERY. for clearing aggregates cache


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1240

This fixes 90% of the overwrite issues with translations, by only saving the changed values to the database.
Users can still overwrite the same translation if the change it at the same time.

![image](https://user-images.githubusercontent.com/1710840/89196140-1283b700-d5aa-11ea-93a7-c8805780835e.png)

After step 4 this is the result:
![image](https://user-images.githubusercontent.com/1710840/89196169-1e6f7900-d5aa-11ea-9a03-596df971a984.png)

After step 6 this is the result:
![image](https://user-images.githubusercontent.com/1710840/89196185-24fdf080-d5aa-11ea-9f32-591a3fc2ca6b.png)
