### PR TITLE
fix(bundle-detail): default keywords to empty array for json-ld data

### DIFF
--- a/src/bundle/views/BundleDetail.tsx
+++ b/src/bundle/views/BundleDetail.tsx
@@ -792,7 +792,10 @@ const BundleDetail: FunctionComponent<BundleDetailProps> = ({ history, location,
 					author={getFullName(get(bundle, 'profile'))}
 					publishedAt={get(bundle, 'published_at')}
 					updatedAt={get(bundle, 'updated_at')}
-					keywords={[...get(bundle, 'lom_classification'), ...get(bundle, 'lom_context')]}
+					keywords={[
+						...(get(bundle, 'lom_classification') || []),
+						...(get(bundle, 'lom_context') || []),
+					]}
 				/>
 				<div
 					className={classnames(


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1223

newly created bundles do not have any keywords
![image](https://user-images.githubusercontent.com/1710840/89272637-b9199780-d63e-11ea-8957-b8835776076f.png)
