### PR TITLE
fix(workspace): show created data as data instead of fromNow

### DIFF
--- a/src/collection/components/CollectionOrBundleOverview.tsx
+++ b/src/collection/components/CollectionOrBundleOverview.tsx
@@ -284,7 +284,7 @@ const CollectionOrBundleOverview: FunctionComponent<CollectionOrBundleOverviewPr
 				<MetaData category={type}>
 					<MetaDataItem>
 						<span title={`Aangemaakt: ${formatDate(collection.created_at)}`}>
-							{fromNow(collection.created_at)}
+							{formatDate(collection.created_at)}
 						</span>
 					</MetaDataItem>
 					<MetaDataItem

--- a/src/workspace/views/BookmarksOverview.tsx
+++ b/src/workspace/views/BookmarksOverview.tsx
@@ -202,7 +202,7 @@ const BookmarksOverview: FunctionComponent<BookmarksOverviewProps> = ({
 					<MetaDataItem>
 						{contentCreatedAt && (
 							<span title={`Aangemaakt: ${formatDate(contentCreatedAt)}`}>
-								{fromNow(contentCreatedAt)}
+								{formatDate(contentCreatedAt)}
 							</span>
 						)}
 					</MetaDataItem>


### PR DESCRIPTION
For collections, bundles and bookmarks:
![image](https://user-images.githubusercontent.com/36598928/89519297-6b3a9600-d7dc-11ea-8e53-740665f46c35.png)

Resolves: https://meemoo.atlassian.net/browse/AVO-328