### PR TITLE
fix(error-view): redirect to logged in homepage if logged in

### DIFF
--- a/src/authentication/helpers/redirects.ts
+++ b/src/authentication/helpers/redirects.ts
@@ -32,6 +32,10 @@ export function redirectToLoggedOutHome(location: Location) {
 	window.location.href = getBaseUrl(location);
 }
 
+export function redirectToLoggedInHome(location: Location) {
+	window.location.href = `${getBaseUrl(location)}/start`;
+}
+
 /**
  *
  * Server redirect functions

--- a/src/dynamic-route-resolver/views/DynamicRouteResolver.tsx
+++ b/src/dynamic-route-resolver/views/DynamicRouteResolver.tsx
@@ -13,10 +13,7 @@ import { getPublishedDate } from '../../admin/content/helpers/get-published-stat
 import { ItemsService } from '../../admin/items/items.service';
 import { SpecialPermissionGroups } from '../../authentication/authentication.types';
 import { PermissionName, PermissionService } from '../../authentication/helpers/permission-service';
-import {
-	redirectToErrorPage,
-	redirectToLoggedInHome,
-} from '../../authentication/helpers/redirects';
+import { redirectToErrorPage } from '../../authentication/helpers/redirects';
 import { getLoginStateAction } from '../../authentication/store/actions';
 import {
 	selectLogin,

--- a/src/dynamic-route-resolver/views/DynamicRouteResolver.tsx
+++ b/src/dynamic-route-resolver/views/DynamicRouteResolver.tsx
@@ -13,7 +13,10 @@ import { getPublishedDate } from '../../admin/content/helpers/get-published-stat
 import { ItemsService } from '../../admin/items/items.service';
 import { SpecialPermissionGroups } from '../../authentication/authentication.types';
 import { PermissionName, PermissionService } from '../../authentication/helpers/permission-service';
-import { redirectToErrorPage } from '../../authentication/helpers/redirects';
+import {
+	redirectToErrorPage,
+	redirectToLoggedInHome,
+} from '../../authentication/helpers/redirects';
 import { getLoginStateAction } from '../../authentication/store/actions';
 import {
 	selectLogin,
@@ -88,6 +91,12 @@ const DynamicRouteResolver: FunctionComponent<DynamicRouteResolverProps> = ({
 			);
 			if (key && redirects[key]) {
 				window.location.href = redirects[key];
+				return;
+			}
+
+			if (pathname === '/' && loginState.message === 'LOGGED_IN') {
+				// Redirect the logged out homepage to the logged in homepage is the user is logged in
+				history.push('/start');
 				return;
 			}
 

--- a/src/error/views/ErrorView.tsx
+++ b/src/error/views/ErrorView.tsx
@@ -3,6 +3,7 @@ import queryString from 'query-string';
 import React, { FunctionComponent, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RouteComponentProps, withRouter } from 'react-router';
+import { compose } from 'redux';
 
 import {
 	Blankslate,
@@ -19,10 +20,12 @@ import {
 import { Avo } from '@viaa/avo2-types';
 
 import {
+	redirectToLoggedInHome,
 	redirectToLoggedOutHome,
 	redirectToServerLogoutPage,
 } from '../../authentication/helpers/redirects';
 import { CustomError } from '../../shared/helpers';
+import withUser, { UserProps } from '../../shared/hocs/withUser';
 import i18n from '../../shared/translations/i18n';
 
 export interface ErrorViewQueryParams {
@@ -31,24 +34,20 @@ export interface ErrorViewQueryParams {
 	actionButtons?: Avo.Auth.ErrorActionButton[];
 }
 
-interface ErrorViewProps
-	extends RouteComponentProps<{
-		message?: string;
-		icon?: IconName;
-		actionButtons?: string;
-	}> {
+interface ErrorViewProps {
 	message?: string;
 	icon?: IconName;
 	actionButtons?: Avo.Auth.ErrorActionButton[];
 	children?: ReactNode;
 }
 
-const ErrorView: FunctionComponent<ErrorViewProps> = ({
+const ErrorView: FunctionComponent<ErrorViewProps & RouteComponentProps & UserProps> = ({
 	message,
 	icon,
 	children = null,
 	location,
 	actionButtons = [],
+	user,
 }) => {
 	const [t] = useTranslation();
 
@@ -97,7 +96,11 @@ const ErrorView: FunctionComponent<ErrorViewProps> = ({
 	}
 
 	const goToHome = () => {
-		redirectToLoggedOutHome(location);
+		if (user) {
+			redirectToLoggedInHome(location);
+		} else {
+			redirectToLoggedOutHome(location);
+		}
 	};
 
 	return (
@@ -132,4 +135,4 @@ const ErrorView: FunctionComponent<ErrorViewProps> = ({
 	);
 };
 
-export default withRouter(ErrorView);
+export default compose(withRouter, withUser)(ErrorView) as FunctionComponent<ErrorViewProps>;


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1158

clicking the navigate to homepage button on an error page now takes to to the respective logged in homepage:
![image](https://user-images.githubusercontent.com/1710840/89559606-31868100-d816-11ea-937b-4ccb96a2db5f.png)

![image](https://user-images.githubusercontent.com/1710840/89559610-32b7ae00-d816-11ea-9551-f882cc9a6e09.png)

![image](https://user-images.githubusercontent.com/1710840/89559613-33504480-d816-11ea-8eb2-04c2942b10e3.png)


Also added redirect to logged out startpage so they are redirect to the logged in startpage if the user is logged in:
teachers:
http://localhost:8080/ => http://localhost:8080/start
of
pupils: 
http://localhost:8080/ => http://localhost:8080/werkruimte/opdrachten
