### PR TITLE
fix(zendesk): remove zendesk widget when switching to admin dashboard

### DIFF
--- a/src/admin/Admin.tsx
+++ b/src/admin/Admin.tsx
@@ -54,6 +54,13 @@ const Admin: FunctionComponent<{ user: Avo.User.User }> = ({ user }) => {
 		}
 	}, [userPermissions, navigationItems, setLoadingInfo]);
 
+	useEffect(() => {
+		const widget = document.querySelector('iframe#launcher');
+		if (widget) {
+			widget.remove();
+		}
+	}, []);
+
 	const renderAdminPage = () => {
 		if (!navigationItems || !userPermissions) {
 			return null;


### PR DESCRIPTION
steps:
* go to http://localhost:8080
* click "beheer" in the menu bar

expected result: zendesk widget is not visible in the admin dashboard

current result: zendesk widget is visible

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/89762190-38501500-daf0-11ea-92cf-57a3832203b9.png)|![image](https://user-images.githubusercontent.com/1710840/89762191-3a19d880-daf0-11ea-85b6-ee58bbee570a.png)|