### PR TITLE
fix(media-player-wrapper): do not pass item obj if mediaitem is undef

### DIFF
--- a/src/admin/content-block/components/wrappers/MediaPlayerWrapper/MediaPlayerWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/MediaPlayerWrapper/MediaPlayerWrapper.tsx
@@ -88,12 +88,15 @@ const MediaPlayerWrapper: FunctionComponent<MediaPlayerWrapperProps> = ({
 			>
 				<FlowPlayerWrapper
 					item={
-						{
-							...(mediaItem || {}),
-							title: title || get(mediaItem, 'title') || '',
-							issued: issued || get(mediaItem, 'issued') || '',
-							organisation: organisation || get(mediaItem, 'organisation') || '',
-						} as any
+						mediaItem
+							? ({
+									...(mediaItem || {}),
+									title: title || get(mediaItem, 'title') || '',
+									issued: issued || get(mediaItem, 'issued') || '',
+									organisation:
+										organisation || get(mediaItem, 'organisation') || '',
+							  } as any)
+							: undefined
 					}
 					src={src}
 					poster={videoStill}


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1273

test page: http://localhost:8080/test-cp-inekes

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/89885400-4888f280-dbcb-11ea-8f30-809bc84b6f77.png)|![image](https://user-images.githubusercontent.com/1710840/89885405-4aeb4c80-dbcb-11ea-80e6-f2605e3862aa.png)|