### PR TITLE
fix(items-service): await response json from proxy for mediamosa resolve

### DIFF
--- a/src/admin/items/items.service.ts
+++ b/src/admin/items/items.service.ts
@@ -214,7 +214,7 @@ export class ItemsService {
 					}
 				);
 			}
-			return get(response.json(), 'externalId') || null;
+			return get(await response.json(), 'externalId') || null;
 		} catch (err) {
 			throw new CustomError('Failed to get external_id by mediamosa id (avo1 id)', err, {
 				mediamosaId,


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1262

test page: http://localhost:8080/media/de-teloorgang-van-de-regie-maritiem-transport/lTKGYYUfrRN9RZkkdM7Cyqgp
should redirect to: http://localhost:8080/item/db7vm5bb7r

before:
![image](https://user-images.githubusercontent.com/1710840/89887658-f9dd5780-dbce-11ea-85c2-58f61fe20949.png)


after:
![image](https://user-images.githubusercontent.com/1710840/89887665-fc3fb180-dbce-11ea-9145-865616284c82.png)


