### PR TITLE
feat(profile): change profile fields for exception accounts

### DIFF
--- a/src/authentication/helpers/get-profile-info.ts
+++ b/src/authentication/helpers/get-profile-info.ts
@@ -135,6 +135,10 @@ export function isProfileComplete(user: Avo.User.User): boolean {
 		return true;
 	}
 
+	if (!!profile && profile.is_exception) {
+		return true;
+	}
+
 	return (
 		!!profile &&
 		!!profile.organizations &&

--- a/src/settings/components/Profile.tsx
+++ b/src/settings/components/Profile.tsx
@@ -133,43 +133,50 @@ const Profile: FunctionComponent<ProfileProps & {
 	);
 	const [permissions, setPermissions] = useState<FieldPermissions | null>(null);
 
+	const isExceptionAccount = get(user, 'profile.is_exception', false);
+
 	useEffect(() => {
 		setPermissions({
 			SUBJECTS: {
 				VIEW: PermissionService.hasPerm(user, PermissionName.VIEW_SUBJECTS_ON_PROFILE_PAGE),
 				EDIT: PermissionService.hasPerm(user, PermissionName.EDIT_SUBJECTS_ON_PROFILE_PAGE),
-				REQUIRED: PermissionService.hasPerm(
-					user,
-					PermissionName.REQUIRED_SUBJECTS_ON_PROFILE_PAGE
-				),
+				REQUIRED:
+					PermissionService.hasPerm(
+						user,
+						PermissionName.REQUIRED_SUBJECTS_ON_PROFILE_PAGE
+					) && !isExceptionAccount,
 			},
 			EDUCATION_LEVEL: {
 				VIEW: PermissionService.hasPerm(
 					user,
 					PermissionName.VIEW_EDUCATION_LEVEL_ON_PROFILE_PAGE
 				),
-				EDIT: PermissionService.hasPerm(
-					user,
-					PermissionName.EDIT_EDUCATION_LEVEL_ON_PROFILE_PAGE
-				),
-				REQUIRED: PermissionService.hasPerm(
-					user,
-					PermissionName.REQUIRED_EDUCATION_LEVEL_ON_PROFILE_PAGE
-				),
+				EDIT:
+					PermissionService.hasPerm(
+						user,
+						PermissionName.EDIT_EDUCATION_LEVEL_ON_PROFILE_PAGE
+					) && !isExceptionAccount,
+				REQUIRED:
+					PermissionService.hasPerm(
+						user,
+						PermissionName.REQUIRED_EDUCATION_LEVEL_ON_PROFILE_PAGE
+					) && !isExceptionAccount,
 			},
 			EDUCATIONAL_ORGANISATION: {
 				VIEW: PermissionService.hasPerm(
 					user,
 					PermissionName.VIEW_EDUCATIONAL_ORGANISATION_ON_PROFILE_PAGE
 				),
-				EDIT: PermissionService.hasPerm(
-					user,
-					PermissionName.EDIT_EDUCATIONAL_ORGANISATION_ON_PROFILE_PAGE
-				),
-				REQUIRED: PermissionService.hasPerm(
-					user,
-					PermissionName.REQUIRED_EDUCATIONAL_ORGANISATION_ON_PROFILE_PAGE
-				),
+				EDIT:
+					PermissionService.hasPerm(
+						user,
+						PermissionName.EDIT_EDUCATIONAL_ORGANISATION_ON_PROFILE_PAGE
+					) && !isExceptionAccount,
+				REQUIRED:
+					PermissionService.hasPerm(
+						user,
+						PermissionName.REQUIRED_EDUCATIONAL_ORGANISATION_ON_PROFILE_PAGE
+					) && !isExceptionAccount,
 			},
 			ORGANISATION: {
 				VIEW: PermissionService.hasPerm(
@@ -487,7 +494,7 @@ const Profile: FunctionComponent<ProfileProps & {
 						value={selectedSubjects}
 						onChange={selectedValues => setSelectedSubjects(selectedValues || [])}
 					/>
-				) : (
+				) : selectedSubjects.length ? (
 					<TagList
 						tags={selectedSubjects.map(
 							(subject): TagOption => ({ id: subject.value, label: subject.label })
@@ -495,12 +502,18 @@ const Profile: FunctionComponent<ProfileProps & {
 						swatches={false}
 						closable={false}
 					/>
+				) : (
+					'-'
 				)}
 			</FormGroup>
 		);
 	};
 
 	const renderEducationLevelsField = (editable: boolean, required: boolean) => {
+		if (!selectedEducationLevels.length && !editable) {
+			return null;
+		}
+
 		return (
 			<FormGroup
 				label={t('settings/components/profile___onderwijsniveau')}


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-977

* hide complete profile step
* make subjects optional
* make education levels read only + hide if undefined
* make educational organisation readonly and remove required asterix

create account:
![image](https://user-images.githubusercontent.com/1710840/89899322-657cf000-dbe2-11ea-8af1-b5e152abc9a6.png)

complete profile step is not show

profile page looks like this:
![image](https://user-images.githubusercontent.com/1710840/89899351-7168b200-dbe2-11ea-83a7-7d09ad3299ab.png)


create second account:
![image](https://user-images.githubusercontent.com/1710840/89899362-76c5fc80-dbe2-11ea-8788-4ee72ddcd0b2.png)

complete profile step is not show

profile page looks like this:
![image](https://user-images.githubusercontent.com/1710840/89899376-7ded0a80-dbe2-11ea-8ad1-d41ef6f0f03a.png)
