### PR TITLE
fix(flow-player-wrapper): center play button when adding annotations

### DIFF
--- a/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.scss
+++ b/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.scss
@@ -20,6 +20,8 @@ $c-video-player-progress-inner-bg: $color-teal-bright;
 }
 
 .c-video-player__overlay {
+	position: relative;
+
 	.c-video-player__thumbnail {
 		background-size: cover;
 		background-position: center;


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-944

before:
![image](https://user-images.githubusercontent.com/1710840/90236642-55a01e80-de23-11ea-87bd-7456757a75ea.png)

after:
![image](https://user-images.githubusercontent.com/1710840/90236662-5933a580-de23-11ea-884b-0614d79b3d2e.png)
