### PR TITLE
fix(zendesk-wrapper): avoid error for resize observer on safari < 13.1

### DIFF
--- a/src/shared/components/ZendeskWrapper/ZendeskWrapper.tsx
+++ b/src/shared/components/ZendeskWrapper/ZendeskWrapper.tsx
@@ -37,6 +37,11 @@ const ZendeskWrapper: FunctionComponent = () => {
 			updateMargin();
 		});
 
+		// Safari < 13.1
+		if (!ResizeObserver) {
+			return;
+		}
+
 		const resizeObserver = new ResizeObserver(() => {
 			updateFooterHeight();
 			updateMargin();


### PR DESCRIPTION
https://caniuse.com/#feat=resizeobserver