### PR TITLE
fix(collection-edit): default to fragment description for drag item

### DIFF
--- a/src/collection/components/CollectionOrBundleEdit.tsx
+++ b/src/collection/components/CollectionOrBundleEdit.tsx
@@ -58,6 +58,7 @@ import {
 	navigate,
 	renderAvatar,
 	sanitizeHtml,
+	stripHtml,
 } from '../../shared/helpers';
 import withUser from '../../shared/hocs/withUser';
 import { BookmarksViewsPlaysService, ToastService } from '../../shared/services';
@@ -825,7 +826,15 @@ const CollectionOrBundleEdit: FunctionComponent<CollectionOrBundleEditProps &
 								fragment,
 								fragment.use_custom_fields,
 								'title'
-							),
+							) ||
+								stripHtml(
+									getFragmentProperty(
+										fragment.item_meta,
+										fragment,
+										fragment.use_custom_fields,
+										'description'
+									) || ''
+								),
 							{ length: 50 }
 						)}
 					</BlockHeading>


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1289

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/90503123-3a991b80-e14f-11ea-8992-9a3ef6875aa5.png)|![image](https://user-images.githubusercontent.com/1710840/90503108-34a33a80-e14f-11ea-85bd-46f9fd3c4117.png)|