### PR TITLE
fix(admin): move announcements div to top to remove double scrollbar

### DIFF
--- a/src/styles/generic/_global.scss
+++ b/src/styles/generic/_global.scss
@@ -8,3 +8,8 @@
 .react-datepicker-popper {
 	z-index: $g-c-modal-z;
 }
+
+// Avoid 1px div causing extra scrollbar in admin dashboard
+#announcements {
+	top: 0;
+}


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1710840/91442021-80ea2b00-e871-11ea-9fbe-d60929d2651b.png)

after:
![image](https://user-images.githubusercontent.com/1710840/91442031-847db200-e871-11ea-9937-df4f932124a6.png)
