### PR TITLE
fix(user-overview): set default sort to last_name asc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "avo2-client",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "avo2-client",
-	"version": "1.2.7",
+	"version": "1.2.8",
 	"private": true,
 	"scripts": {
 		"preinstall": "npx npm-force-resolutions",

--- a/src/admin/users/views/UserOverview.tsx
+++ b/src/admin/users/views/UserOverview.tsx
@@ -94,8 +94,8 @@ const UserOverview: FunctionComponent<UserOverviewProps> = ({ history }) => {
 		try {
 			const [profilesTemp, profileCountTemp] = await UserService.getProfiles(
 				tableState.page || 0,
-				(tableState.sort_column || 'last_access_at') as UserOverviewTableCol,
-				tableState.sort_order || 'desc',
+				(tableState.sort_column || 'last_name') as UserOverviewTableCol,
+				tableState.sort_order || 'asc',
 				generateWhereObject(getFilters(tableState))
 			);
 			setProfiles(profilesTemp);


### PR DESCRIPTION
since the sort causes the query to time out
This is a hotfix until we can fix this issue more thoroughly