### PR TITLE
fix(content-picker): order profiles by last name for efficiency

### DIFF
--- a/src/admin/shared/components/ContentPicker/item-providers/profile.ts
+++ b/src/admin/shared/components/ContentPicker/item-providers/profile.ts
@@ -13,8 +13,8 @@ export const retrieveProfiles = async (
 	try {
 		const response: [Avo.User.Profile[], number] = await UserService.getProfiles(
 			0,
-			'last_access_at',
-			'desc',
+			'last_name',
+			'asc',
 			!!name
 				? {
 						_or: [


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1325

This bug can only be reproduced on production since there are a lot of users in the prd database

Otherwise the query times out if we sort by last_access_at date