### PR TITLE
fix(dropdown): replace some controlled dropdown with dropdowns

### DIFF
--- a/src/admin/content/views/ContentDetail.tsx
+++ b/src/admin/content/views/ContentDetail.tsx
@@ -16,6 +16,7 @@ import {
 	Button,
 	ButtonToolbar,
 	Container,
+	Dropdown,
 	DropdownButton,
 	DropdownContent,
 	LinkTarget,
@@ -35,7 +36,6 @@ import { redirectToClientPage } from '../../../authentication/helpers/redirects'
 import { GENERATE_SITE_TITLE } from '../../../constants';
 import { ContentPage } from '../../../content-page/views';
 import {
-	ControlledDropdown,
 	DeleteObjectModal,
 	LoadingErrorLoadedComponent,
 	LoadingInfo,
@@ -372,7 +372,7 @@ const ContentDetail: FunctionComponent<ContentDetailProps> = ({ history, match, 
 					/>
 				)}
 				{!!CONTENT_DROPDOWN_ITEMS && !!CONTENT_DROPDOWN_ITEMS.length && (
-					<ControlledDropdown
+					<Dropdown
 						isOpen={isOptionsMenuOpen}
 						menuWidth="fit-content"
 						onOpen={() => setIsOptionsMenuOpen(true)}
@@ -393,7 +393,7 @@ const ContentDetail: FunctionComponent<ContentDetailProps> = ({ history, match, 
 								onClick={executeAction}
 							/>
 						</DropdownContent>
-					</ControlledDropdown>
+					</Dropdown>
 				)}
 			</ButtonToolbar>
 		);

--- a/src/bundle/views/BundleDetail.tsx
+++ b/src/bundle/views/BundleDetail.tsx
@@ -11,6 +11,7 @@ import {
 	ButtonToolbar,
 	Column,
 	Container,
+	Dropdown,
 	DropdownButton,
 	DropdownContent,
 	Flex,
@@ -44,7 +45,6 @@ import { PublishCollectionModal } from '../../collection/components';
 import { COLLECTION_COPY, COLLECTION_COPY_REGEX } from '../../collection/views/CollectionDetail';
 import { APP_PATH, GENERATE_SITE_TITLE } from '../../constants';
 import {
-	ControlledDropdown,
 	DeleteObjectModal,
 	InteractiveTour,
 	LoadingErrorLoadedComponent,
@@ -555,7 +555,7 @@ const BundleDetail: FunctionComponent<BundleDetailProps> = ({ history, location,
 		}
 
 		return (
-			<ControlledDropdown
+			<Dropdown
 				isOpen={isOptionsMenuOpen}
 				menuWidth="fit-content"
 				onOpen={() => setIsOptionsMenuOpen(true)}
@@ -573,7 +573,7 @@ const BundleDetail: FunctionComponent<BundleDetailProps> = ({ history, location,
 				<DropdownContent>
 					<MenuContent menuItems={BUNDLE_DROPDOWN_ITEMS} onClick={executeAction} />
 				</DropdownContent>
-			</ControlledDropdown>
+			</Dropdown>
 		);
 	};
 
@@ -633,7 +633,7 @@ const BundleDetail: FunctionComponent<BundleDetailProps> = ({ history, location,
 					: []),
 			];
 			return (
-				<ControlledDropdown
+				<Dropdown
 					isOpen={isOptionsMenuOpen}
 					menuWidth="fit-content"
 					onOpen={() => setIsOptionsMenuOpen(true)}
@@ -651,7 +651,7 @@ const BundleDetail: FunctionComponent<BundleDetailProps> = ({ history, location,
 					<DropdownContent>
 						<MenuContent menuItems={BUNDLE_DROPDOWN_ITEMS} onClick={executeAction} />
 					</DropdownContent>
-				</ControlledDropdown>
+				</Dropdown>
 			);
 		}
 		const isPublic = bundle && bundle.is_public;

--- a/src/collection/components/CollectionOrBundleEdit.tsx
+++ b/src/collection/components/CollectionOrBundleEdit.tsx
@@ -18,6 +18,7 @@ import {
 	Button,
 	ButtonToolbar,
 	Container,
+	Dropdown,
 	DropdownButton,
 	DropdownContent,
 	Flex,
@@ -43,7 +44,6 @@ import { PermissionName, PermissionService } from '../../authentication/helpers/
 import { redirectToClientPage } from '../../authentication/helpers/redirects';
 import { APP_PATH, GENERATE_SITE_TITLE } from '../../constants';
 import {
-	ControlledDropdown,
 	DraggableListModal,
 	InputModal,
 	InteractiveTour,
@@ -976,7 +976,7 @@ const CollectionOrBundleEdit: FunctionComponent<CollectionOrBundleEditProps &
 					)}
 					onClick={() => setIsReorderModalOpen(true)}
 				/>
-				<ControlledDropdown
+				<Dropdown
 					isOpen={isOptionsMenuOpen}
 					menuWidth="fit-content"
 					onOpen={() => setIsOptionsMenuOpen(true)}
@@ -1001,7 +1001,7 @@ const CollectionOrBundleEdit: FunctionComponent<CollectionOrBundleEditProps &
 							onClick={executeAction}
 						/>
 					</DropdownContent>
-				</ControlledDropdown>
+				</Dropdown>
 				<Spacer margin="left-small">{renderSaveButton()}</Spacer>
 				<InteractiveTour showButton />
 			</ButtonToolbar>
@@ -1036,7 +1036,7 @@ const CollectionOrBundleEdit: FunctionComponent<CollectionOrBundleEditProps &
 		];
 		return (
 			<ButtonToolbar>
-				<ControlledDropdown
+				<Dropdown
 					isOpen={isOptionsMenuOpen}
 					menuWidth="fit-content"
 					onOpen={() => setIsOptionsMenuOpen(true)}
@@ -1058,7 +1058,7 @@ const CollectionOrBundleEdit: FunctionComponent<CollectionOrBundleEditProps &
 							onClick={executeAction}
 						/>
 					</DropdownContent>
-				</ControlledDropdown>
+				</Dropdown>
 			</ButtonToolbar>
 		);
 	};

--- a/src/collection/components/fragment/FragmentEdit.tsx
+++ b/src/collection/components/fragment/FragmentEdit.tsx
@@ -13,6 +13,7 @@ import {
 	Button,
 	Column,
 	convertToHtml,
+	Dropdown,
 	DropdownButton,
 	DropdownContent,
 	Form,
@@ -32,11 +33,7 @@ import {
 import { Avo } from '@viaa/avo2-types';
 
 import { getProfileName } from '../../../authentication/helpers/get-profile-info';
-import {
-	ControlledDropdown,
-	DeleteObjectModal,
-	FlowPlayerWrapper,
-} from '../../../shared/components';
+import { DeleteObjectModal, FlowPlayerWrapper } from '../../../shared/components';
 import WYSIWYGWrapper from '../../../shared/components/WYSIWYGWrapper/WYSIWYGWrapper';
 import { WYSIWYG_OPTIONS_AUTHOR, WYSIWYG_OPTIONS_DEFAULT } from '../../../shared/constants';
 import { createDropdownMenuItem } from '../../../shared/helpers';
@@ -356,7 +353,7 @@ const FragmentEdit: FunctionComponent<FragmentEditProps & UserProps> = ({
 						</ToolbarLeft>
 						<ToolbarRight>
 							<ToolbarItem>
-								<ControlledDropdown
+								<Dropdown
 									isOpen={openOptionsId === fragment.id}
 									menuWidth="fit-content"
 									onOpen={() => setOpenOptionsId(fragment.id)}
@@ -381,7 +378,7 @@ const FragmentEdit: FunctionComponent<FragmentEditProps & UserProps> = ({
 											onClick={onClickDropdownItem}
 										/>
 									</DropdownContent>
-								</ControlledDropdown>
+								</Dropdown>
 							</ToolbarItem>
 						</ToolbarRight>
 					</Toolbar>

--- a/src/collection/views/CollectionDetail.tsx
+++ b/src/collection/views/CollectionDetail.tsx
@@ -12,6 +12,7 @@ import {
 	ButtonToolbar,
 	Column,
 	Container,
+	Dropdown,
 	DropdownButton,
 	DropdownContent,
 	Grid,
@@ -37,7 +38,6 @@ import { redirectToClientPage } from '../../authentication/helpers/redirects';
 import RegisterOrRegisterOrLogin from '../../authentication/views/RegisterOrLogin';
 import { APP_PATH, GENERATE_SITE_TITLE } from '../../constants';
 import {
-	ControlledDropdown,
 	InteractiveTour,
 	LoadingErrorLoadedComponent,
 	LoadingInfo,
@@ -637,7 +637,7 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 						onClick={() => executeAction('openShareThroughEmail')}
 					/>
 				)}
-				<ControlledDropdown
+				<Dropdown
 					isOpen={isOptionsMenuOpen}
 					menuWidth="fit-content"
 					onOpen={() => setIsOptionsMenuOpen(true)}
@@ -658,7 +658,7 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 							onClick={executeAction}
 						/>
 					</DropdownContent>
-				</ControlledDropdown>
+				</Dropdown>
 				{permissions.canEditCollection && (
 					<Spacer margin="left-small">
 						<Button
@@ -750,7 +750,7 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 		];
 		return (
 			<ButtonToolbar>
-				<ControlledDropdown
+				<Dropdown
 					isOpen={isOptionsMenuOpen}
 					menuWidth="fit-content"
 					onOpen={() => setIsOptionsMenuOpen(true)}
@@ -771,7 +771,7 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 							onClick={executeAction}
 						/>
 					</DropdownContent>
-				</ControlledDropdown>
+				</Dropdown>
 			</ButtonToolbar>
 		);
 	};


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1326

So we can close them from the parent component when one of their options is clicked

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/91751834-b66e7b80-ebc5-11ea-8782-fb99daf9106e.png)|![image](https://user-images.githubusercontent.com/1710840/91751840-b79fa880-ebc5-11ea-9a61-c13c8934c714.png)|