### PR TITLE
fix(klaar-iframe): hide nav bars, zendesk and open links in new tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { Footer, LoadingErrorLoadedComponent, LoadingInfo, Navigation } from './
 import ZendeskWrapper from './shared/components/ZendeskWrapper/ZendeskWrapper';
 import { ROUTE_PARTS } from './shared/constants';
 import { CustomError } from './shared/helpers';
+import { insideIframe } from './shared/helpers/inside-iframe';
 import { dataService } from './shared/services';
 import { waitForTranslations } from './shared/translations/i18n';
 import store from './store';
@@ -54,8 +55,16 @@ const App: FunctionComponent<AppProps> = props => {
 
 	// Render
 	const renderApp = () => {
+		const isInsideIframe = insideIframe();
+		const isLoginRoute = props.location.pathname === APP_PATH.LOGIN.route;
+
 		return (
-			<div className={classnames('o-app', { 'o-app--admin': isAdminRoute })}>
+			<div
+				className={classnames('o-app', {
+					'o-app--admin': isAdminRoute,
+					'o-app--iframe': isInsideIframe,
+				})}
+			>
 				<ToastContainer
 					autoClose={4000}
 					className="c-alert-stack"
@@ -65,17 +74,14 @@ const App: FunctionComponent<AppProps> = props => {
 					position="bottom-left"
 					transition={Slide}
 				/>
-				{/* TODO: Based on current user permissions */}
 				{isAdminRoute ? (
 					<SecuredRoute component={Admin} exact={false} path={ADMIN_PATH.DASHBOARD} />
 				) : (
 					<>
-						{props.location.pathname !== APP_PATH.LOGIN.route && (
-							<Navigation {...props} />
-						)}
+						{!isLoginRoute && !isInsideIframe && <Navigation {...props} />}
 						{renderRoutes()}
-						{props.location.pathname !== APP_PATH.LOGIN.route && <Footer {...props} />}
-						<ZendeskWrapper />
+						{!isLoginRoute && !isInsideIframe && <Footer {...props} />}
+						{!isInsideIframe && <ZendeskWrapper />}
 					</>
 				)}
 			</div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,6 @@ const App: FunctionComponent<AppProps> = props => {
 			<div
 				className={classnames('o-app', {
 					'o-app--admin': isAdminRoute,
-					'o-app--iframe': isInsideIframe,
 				})}
 			>
 				<ToastContainer
@@ -78,7 +77,7 @@ const App: FunctionComponent<AppProps> = props => {
 					<SecuredRoute component={Admin} exact={false} path={ADMIN_PATH.DASHBOARD} />
 				) : (
 					<>
-						{!isLoginRoute && !isInsideIframe && <Navigation {...props} />}
+						{!isLoginRoute && <Navigation {...props} />}
 						{renderRoutes()}
 						{!isLoginRoute && !isInsideIframe && <Footer {...props} />}
 						{!isInsideIframe && <ZendeskWrapper />}

--- a/src/admin/content-block/components/wrappers/MediaPlayerWrapper/MediaPlayerWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/MediaPlayerWrapper/MediaPlayerWrapper.tsx
@@ -104,6 +104,12 @@ const MediaPlayerWrapper: FunctionComponent<MediaPlayerWrapperProps> = ({
 					}
 					src={src}
 					poster={videoStill}
+					organisationName={get(organisation || get(mediaItem, 'organisation'), 'name')}
+					organisationLogo={get(
+						organisation || get(mediaItem, 'organisation'),
+						'logo_url'
+					)}
+					issuedDate={issued || get(mediaItem, 'issued')}
 					autoplay={autoplay}
 					annotationTitle={annotationTitle}
 					annotationText={annotationText}

--- a/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.tsx
+++ b/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.tsx
@@ -23,6 +23,9 @@ type FlowPlayerWrapperProps = {
 	item?: Avo.Item.Item;
 	src?: string;
 	poster?: string;
+	organisationName?: string;
+	organisationLogo?: string;
+	issuedDate?: string;
 	annotationTitle?: string;
 	annotationText?: string;
 	canPlay?: boolean;
@@ -125,14 +128,14 @@ const FlowPlayerWrapper: FunctionComponent<FlowPlayerWrapperProps & UserProps> =
 					subtitles={
 						item
 							? [
-									reorderDate(item.issued || null, '.'),
-									get(item, 'organisation.name', ''),
+									props.issuedDate || reorderDate(item.issued || null, '.'),
+									props.organisationName || get(item, 'organisation.name', ''),
 							  ]
 							: undefined
 					}
 					token={getEnv('FLOW_PLAYER_TOKEN')}
 					dataPlayerId={getEnv('FLOW_PLAYER_ID')}
-					logo={get(item, 'organisation.logo_url')}
+					logo={props.organisationLogo || get(item, 'organisation.logo_url')}
 					{...props.cuePoints}
 					autoplay={(!!item && !!src) || props.autoplay}
 					canPlay={props.canPlay}

--- a/src/shared/components/Navigation/Navigation.tsx
+++ b/src/shared/components/Navigation/Navigation.tsx
@@ -37,6 +37,7 @@ import {
 } from '../../../authentication/store/selectors';
 import { APP_PATH } from '../../../constants';
 import { AppState } from '../../../store';
+import { insideIframe } from '../../helpers/inside-iframe';
 import { getLocation, mapNavElementsToNavigationItems } from '../../helpers/navigation';
 import { ToastService } from '../../services';
 import {
@@ -234,6 +235,31 @@ export const Navigation: FunctionComponent<NavigationParams> = ({
 		}
 	};
 
+	const isInsideIframe = insideIframe();
+
+	if (isInsideIframe) {
+		return (
+			<Navbar background="inverse" position="fixed" placement="top">
+				<Container mode="horizontal">
+					<Toolbar>
+						<ToolbarLeft>
+							<ToolbarItem>
+								<h1 className="c-brand">
+									<img
+										className="c-brand__image"
+										src="/images/avo-logo-i.svg"
+										alt={t(
+											'shared/components/navigation/navigation___archief-voor-onderwijs-logo'
+										)}
+									/>
+								</h1>
+							</ToolbarItem>
+						</ToolbarLeft>
+					</Toolbar>
+				</Container>
+			</Navbar>
+		);
+	}
 	return (
 		<>
 			<Navbar background="inverse" position="fixed" placement="top">

--- a/src/shared/helpers/inside-iframe.ts
+++ b/src/shared/helpers/inside-iframe.ts
@@ -1,0 +1,7 @@
+export function insideIframe(): boolean {
+	try {
+		return window.self !== window.top;
+	} catch (e) {
+		return true;
+	}
+}

--- a/src/shared/helpers/link.tsx
+++ b/src/shared/helpers/link.tsx
@@ -13,6 +13,7 @@ import { ToastService } from '../services';
 import i18n from '../translations/i18n';
 
 import { getEnv } from './env';
+import { insideIframe } from './inside-iframe';
 
 type RouteParams = { [key: string]: string | number | undefined };
 
@@ -107,32 +108,38 @@ export const navigateToContentType = (action: ButtonAction, history: History) =>
 	if (action) {
 		const { type, value, target } = action;
 
+		let resolvedTarget = target;
+		if (insideIframe()) {
+			// Klaar page inside smartschool iframe must open all links in new window: https://meemoo.atlassian.net/browse/AVO-1354
+			resolvedTarget = LinkTarget.Blank;
+		}
+
 		switch (type as Avo.Core.ContentPickerType) {
 			case 'INTERNAL_LINK':
 			case 'CONTENT_PAGE':
 			case 'PROJECTS':
-				navigateToAbsoluteOrRelativeUrl(String(value), history, target);
+				navigateToAbsoluteOrRelativeUrl(String(value), history, resolvedTarget);
 				break;
 
 			case 'COLLECTION':
 				const collectionUrl = buildLink(APP_PATH.COLLECTION_DETAIL.route, {
 					id: value as string,
 				});
-				navigateToAbsoluteOrRelativeUrl(collectionUrl, history, target);
+				navigateToAbsoluteOrRelativeUrl(collectionUrl, history, resolvedTarget);
 				break;
 
 			case 'ITEM':
 				const itemUrl = buildLink(APP_PATH.ITEM_DETAIL.route, {
 					id: value,
 				});
-				navigateToAbsoluteOrRelativeUrl(itemUrl, history, target);
+				navigateToAbsoluteOrRelativeUrl(itemUrl, history, resolvedTarget);
 				break;
 
 			case 'BUNDLE':
 				const bundleUrl = buildLink(BUNDLE_PATH.BUNDLE_DETAIL, {
 					id: value,
 				});
-				navigateToAbsoluteOrRelativeUrl(bundleUrl, history, target);
+				navigateToAbsoluteOrRelativeUrl(bundleUrl, history, resolvedTarget);
 				break;
 
 			case 'EXTERNAL_LINK':
@@ -140,7 +147,7 @@ export const navigateToContentType = (action: ButtonAction, history: History) =>
 					'{{PROXY_URL}}',
 					getEnv('PROXY_URL') || ''
 				);
-				navigateToAbsoluteOrRelativeUrl(externalUrl, history, target);
+				navigateToAbsoluteOrRelativeUrl(externalUrl, history, resolvedTarget);
 				break;
 
 			case 'ANCHOR_LINK':
@@ -148,7 +155,7 @@ export const navigateToContentType = (action: ButtonAction, history: History) =>
 				navigateToAbsoluteOrRelativeUrl(
 					`${urlWithoutQueryOrAnchor}#${value}`,
 					history,
-					target
+					resolvedTarget
 				);
 				break;
 
@@ -168,7 +175,7 @@ export const navigateToContentType = (action: ButtonAction, history: History) =>
 						)
 					),
 					history,
-					target
+					resolvedTarget
 				);
 				break;
 

--- a/src/styles/objects/_app.scss
+++ b/src/styles/objects/_app.scss
@@ -18,3 +18,7 @@
 		height: 100vh;
 	}
 }
+
+.o-app--iframe {
+	padding-top: 0;
+}

--- a/src/styles/objects/_app.scss
+++ b/src/styles/objects/_app.scss
@@ -18,7 +18,3 @@
 		height: 100vh;
 	}
 }
-
-.o-app--iframe {
-	padding-top: 0;
-}


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1354

You can test this by installing live-server globally:
```
npm i -g live-server
```

Then creating a folder with index.html file with this content:
```
<!doctype html>
<html lang="en">
<head>
	<meta charset="UTF-8">
	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
	<meta http-equiv="X-UA-Compatible" content="ie=edge">
	<title>Avo2 iframe</title>
	<style>
	body {
		margin: 0;
		padding: 0;
		border: 0;
		overflow: hidden;
	}
  iframe {
    width: 100vw;
    height: 100vh;
		box-sizing: border-box;
		overflow: hidden;
  }

	</style>
</head>
<body>
<iframe src="http://localhost:8080/projecten/klaar" frameborder="0"></iframe>
</body>
</html>
```

Then start your client and proxy of avo2

Then start the iframe page:
```
live-server --port=8081 .
```

This is what should happen:
* All links on the page should open in a new window
* Header navbar should only show logo and logo should not be clickable
* footer should be hidden
* Zendesk widget should not show up
* logo's on videos should be present

![image](https://user-images.githubusercontent.com/1710840/92588557-75e3c180-f299-11ea-9154-68a682c03de8.png)

![image](https://user-images.githubusercontent.com/1710840/92589780-5e0d3d00-f29b-11ea-8954-c930f8f4cc99.png)



