### PR TITLE
fix(fragment): show replacement warning on edit, redirect item detail

### DIFF
--- a/src/admin/items/items.service.ts
+++ b/src/admin/items/items.service.ts
@@ -15,10 +15,10 @@ import {
 	DELETE_ITEM_FROM_COLLECTIONS_BOOKMARKS,
 	FETCH_ITEM_UUID_BY_EXTERNAL_ID,
 	GET_DISTINCT_SERIES,
-	GET_ITEMS_WITH_FILTERS,
 	GET_ITEM_BY_EXTERNAL_ID,
 	GET_ITEM_BY_UUID,
 	GET_ITEM_DEPUBLISH_REASON,
+	GET_ITEMS_WITH_FILTERS,
 	GET_PUBLIC_ITEMS,
 	GET_PUBLIC_ITEMS_BY_TITLE_OR_EXTERNAL_ID,
 	GET_UNPUBLISHED_ITEMS_WITH_FILTERS,
@@ -253,7 +253,9 @@ export class ItemsService {
 		);
 	}
 
-	public static async fetchItemByExternalId(externalId: string): Promise<Avo.Item.Item | null> {
+	public static async fetchItemByExternalId(
+		externalId: string
+	): Promise<(Avo.Item.Item & { replacement_for?: string }) | null> {
 		try {
 			const response = await dataService.query({
 				query: GET_ITEM_BY_EXTERNAL_ID,
@@ -283,7 +285,9 @@ export class ItemsService {
 				);
 				const replacedByItemUid = get(relations, '[0].object', null);
 				if (replacedByItemUid) {
-					return await ItemsService.fetchItemByUuid(replacedByItemUid);
+					const replacementItem = await ItemsService.fetchItemByUuid(replacedByItemUid);
+					(replacementItem as any).replacement_for = externalId;
+					return replacementItem;
 				}
 			}
 

--- a/src/collection/components/CollectionOrBundleEdit.tsx
+++ b/src/collection/components/CollectionOrBundleEdit.tsx
@@ -851,10 +851,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 					return (
 						<CollectionOrBundleEditContent
 							type={type}
-							collectionId={collectionState.currentCollection.id}
-							collectionFragments={
-								collectionState.currentCollection.collection_fragments
-							}
+							collection={collectionState.currentCollection}
 							changeCollectionState={changeCollectionState}
 							history={history}
 							location={location}

--- a/src/collection/components/CollectionOrBundleEditContent.tsx
+++ b/src/collection/components/CollectionOrBundleEditContent.tsx
@@ -2,28 +2,27 @@ import { get, isNil } from 'lodash-es';
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Container } from '@viaa/avo2-components';
+import { Alert, Container, Spacer } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
 import { DefaultSecureRouteProps } from '../../authentication/components/SecuredRoute';
 import { PermissionName, PermissionService } from '../../authentication/helpers/permission-service';
 import { ToastService } from '../../shared/services';
 import { FragmentAdd, FragmentEdit } from '../components';
+import { showReplacementWarning } from '../helpers/fragment';
 
 import { CollectionAction } from './CollectionOrBundleEdit';
 import './CollectionOrBundleEditContent.scss';
 
 interface CollectionOrBundleEditContentProps extends DefaultSecureRouteProps {
 	type: 'collection' | 'bundle';
-	collectionId: string;
-	collectionFragments: Avo.Collection.Fragment[];
+	collection: Avo.Collection.Collection;
 	changeCollectionState: (action: CollectionAction) => void;
 }
 
 const CollectionOrBundleEditContent: FunctionComponent<CollectionOrBundleEditContentProps> = ({
 	type,
-	collectionId,
-	collectionFragments,
+	collection,
 	changeCollectionState,
 	user,
 }) => {
@@ -64,6 +63,7 @@ const CollectionOrBundleEditContent: FunctionComponent<CollectionOrBundleEditCon
 	if (isNil(allowedToAddLinks)) {
 		return null;
 	}
+	const collectionFragments = collection.collection_fragments || [];
 	return (
 		<Container mode="vertical" className="m-collection-or-bundle-edit-content">
 			<Container mode="horizontal" key={collectionFragments.map(getFragmentKey).join('_')}>
@@ -74,20 +74,34 @@ const CollectionOrBundleEditContent: FunctionComponent<CollectionOrBundleEditCon
 						type={isCollection ? 'itemOrText' : 'collection'}
 						key={getFragmentKey(fragment)}
 						index={index}
-						collectionId={collectionId}
+						collectionId={collection.id}
 						numberOfFragments={collectionFragments.length}
 						changeCollectionState={changeCollectionState}
 						openOptionsId={openOptionsId}
 						setOpenOptionsId={setOpenOptionsId}
 						fragment={fragment}
 						allowedToAddLinks={allowedToAddLinks as boolean}
+						renderWarning={() => {
+							if (showReplacementWarning(collection, fragment, user)) {
+								return (
+									<Spacer margin="bottom">
+										<Alert type="danger">
+											{t(
+												'collection/components/fragment/fragment-list___dit-item-is-recent-vervangen-door-een-nieuwe-versie-je-controleert-best-of-je-knippunten-nog-correct-zijn'
+											)}
+										</Alert>
+									</Spacer>
+								);
+							}
+							return null;
+						}}
 					/>
 				))}
 			</Container>
 			{!collectionFragments.length && isCollection && (
 				<FragmentAdd
 					index={0}
-					collectionId={collectionId}
+					collectionId={collection.id}
 					numberOfFragments={collectionFragments.length}
 					changeCollectionState={changeCollectionState}
 				/>

--- a/src/collection/components/fragment/FragmentEdit.tsx
+++ b/src/collection/components/fragment/FragmentEdit.tsx
@@ -1,5 +1,12 @@
 import { get, isEqual, isNil, isString } from 'lodash-es';
-import React, { FunctionComponent, ReactText, useCallback, useEffect, useState } from 'react';
+import React, {
+	FunctionComponent,
+	ReactNode,
+	ReactText,
+	useCallback,
+	useEffect,
+	useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -46,6 +53,7 @@ interface FragmentEditProps {
 	setOpenOptionsId: (id: number | null) => void;
 	fragment: Avo.Collection.Fragment;
 	allowedToAddLinks: boolean;
+	renderWarning?: () => ReactNode | null;
 }
 
 const FragmentEdit: FunctionComponent<FragmentEditProps & UserProps> = ({
@@ -58,6 +66,7 @@ const FragmentEdit: FunctionComponent<FragmentEditProps & UserProps> = ({
 	setOpenOptionsId,
 	fragment,
 	allowedToAddLinks,
+	renderWarning = () => null,
 	user,
 }) => {
 	const [t] = useTranslation();
@@ -353,6 +362,7 @@ const FragmentEdit: FunctionComponent<FragmentEditProps & UserProps> = ({
 						</ToolbarRight>
 					</Toolbar>
 				</div>
+				{renderWarning()}
 				<div className="c-panel__body">
 					{fragment.type !== 'TEXT' && itemMetaData ? (
 						<Grid>

--- a/src/collection/components/fragment/FragmentList.tsx
+++ b/src/collection/components/fragment/FragmentList.tsx
@@ -1,5 +1,4 @@
-import { get, sortBy } from 'lodash-es';
-import moment from 'moment';
+import { sortBy } from 'lodash-es';
 import React, { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -7,8 +6,7 @@ import { Alert, Spacer } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
-import { getProfileId } from '../../../authentication/helpers/get-profile-id';
-import { RelationEntry } from '../../../shared/services/relation-service/relation.types';
+import { showReplacementWarning } from '../../helpers/fragment';
 
 import FragmentDetail from './FragmentDetail';
 
@@ -38,24 +36,6 @@ const FragmentList: FunctionComponent<FragmentListDetailProps> = ({
 }) => {
 	const [t] = useTranslation();
 
-	const showReplacementWarning = (collectionFragment: Avo.Collection.Fragment): boolean => {
-		const item = collectionFragment.item_meta as Avo.Item.Item;
-		const replacedRelation: RelationEntry<Avo.Item.Item> | undefined = get(
-			item,
-			'relations[0]'
-		);
-		const ownsCollection: boolean = collection.owner_profile_id === getProfileId(user);
-
-		// Show the warning of replaced items only
-		// * to owners and
-		// * only if the collection has not been updated since the replacement happend
-		return (
-			ownsCollection &&
-			!!replacedRelation &&
-			moment(replacedRelation.created_at) > moment(collection.updated_at)
-		);
-	};
-
 	const renderCollectionFragments = () =>
 		sortBy(collectionFragments, 'position').map(
 			(collectionFragment: Avo.Collection.Fragment) => {
@@ -64,7 +44,7 @@ const FragmentList: FunctionComponent<FragmentListDetailProps> = ({
 						className="c-collection-list__item"
 						key={`collection-fragment-${collectionFragment.id}`}
 					>
-						{showReplacementWarning(collectionFragment) && (
+						{showReplacementWarning(collection, collectionFragment, user) && (
 							<Spacer margin="bottom-large">
 								<Alert type="danger">
 									{t(

--- a/src/collection/helpers/fragment.ts
+++ b/src/collection/helpers/fragment.ts
@@ -1,6 +1,10 @@
 import { get } from 'lodash-es';
+import moment from 'moment';
 
 import { Avo } from '@viaa/avo2-types';
+
+import { getProfileId } from '../../authentication/helpers/get-profile-id';
+import { RelationEntry } from '../../shared/services/relation-service/relation.types';
 
 export const getFragmentProperty = (
 	itemMetaData: Avo.Item.Item | Avo.Collection.Collection | undefined,
@@ -11,4 +15,30 @@ export const getFragmentProperty = (
 	return useCustomFields || !itemMetaData
 		? get(fragment, `custom_${prop}`, '')
 		: get(itemMetaData, prop, '');
+};
+
+/**
+ * Show warning to users if
+ * - They are owner of the collection
+ * - And the item was replaced and the collection has not been edited since the replacement
+ * - And the fragment that was replaced was added to the collection before it was replaced
+ * @param collection
+ * @param collectionFragment
+ * @param user
+ */
+export const showReplacementWarning = (
+	collection: Avo.Collection.Collection,
+	collectionFragment: Avo.Collection.Fragment,
+	user: Avo.User.User
+): boolean => {
+	const item = collectionFragment.item_meta as Avo.Item.Item;
+	const replacedRelation: RelationEntry<Avo.Item.Item> | undefined = get(item, 'relations[0]');
+	const ownsCollection: boolean = collection.owner_profile_id === getProfileId(user);
+
+	return (
+		ownsCollection &&
+		!!replacedRelation &&
+		moment(replacedRelation.created_at) > moment(collection.updated_at) &&
+		moment(replacedRelation.created_at) > moment(collectionFragment.created_at)
+	);
 };

--- a/src/item/views/ItemDetail.tsx
+++ b/src/item/views/ItemDetail.tsx
@@ -40,7 +40,7 @@ import {
 	ContentTypeString,
 	toEnglishContentType,
 } from '../../collection/collection.types';
-import { GENERATE_SITE_TITLE } from '../../constants';
+import { APP_PATH, GENERATE_SITE_TITLE } from '../../constants';
 import {
 	InteractiveTour,
 	LoadingErrorLoadedComponent,
@@ -49,6 +49,7 @@ import {
 } from '../../shared/components';
 import { LANGUAGES } from '../../shared/constants';
 import {
+	buildLink,
 	CustomError,
 	generateAssignmentCreateLink,
 	generateSearchLink,
@@ -123,9 +124,9 @@ const ItemDetail: FunctionComponent<ItemDetailProps> = ({ history, match, locati
 					return;
 				}
 
-				const itemObj: Avo.Item.Item | null = await ItemsService.fetchItemByExternalId(
-					match.params.id
-				);
+				const itemObj:
+					| (Avo.Item.Item & { replacement_for?: string })
+					| null = await ItemsService.fetchItemByExternalId(match.params.id);
 				if (!itemObj) {
 					setLoadingInfo({
 						state: 'error',
@@ -144,6 +145,15 @@ const ItemDetail: FunctionComponent<ItemDetailProps> = ({ history, match, locati
 							) + itemObj.depublish_reason,
 						icon: 'camera-off',
 					});
+					return;
+				}
+
+				if (itemObj.replacement_for) {
+					// Item was replaced by another item
+					// We should reload the page, to update the url
+					history.replace(
+						buildLink(APP_PATH.ITEM_DETAIL.route, { id: itemObj.external_id })
+					);
 					return;
 				}
 


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-700

show warning on collection edit screen as well as the collection detail screen:

![image](https://user-images.githubusercontent.com/1710840/95062063-bb5ea780-06fc-11eb-8129-b8587b73e525.png)

also: replace url for replaced items, so we don't have any issues with replaced items being added to a collection/assignment.
