### PR TITLE
fix(redirects): output empty string when hash is undefined

### DIFF
--- a/src/authentication/helpers/redirects.ts
+++ b/src/authentication/helpers/redirects.ts
@@ -177,7 +177,7 @@ export function getRedirectAfterLogin(
 	if (from === '/') {
 		return `${base}${defaultPath}`;
 	}
-	return `${base}${from}${location.hash}${queryString.stringify(
+	return `${base}${from}${location.hash || ''}${queryString.stringify(
 		omit(queryStrings, ['returnToUrl'])
 	)}`;
 }


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1391

steps to reproduce:
* open http://localhost:8080/faq-overzicht-2
* leave it open for a night
* log back in


expected result: you should be redirected to http://localhost:8080/faq-overzicht-2 again

current result: you are redirect to: http://localhost:8080/faq-overzicht-2undefined