### PR TITLE
fix(content-labels): show content label link in admin dashboard

### DIFF
--- a/src/admin/content/content.gql.ts
+++ b/src/admin/content/content.gql.ts
@@ -47,6 +47,7 @@ export const GET_CONTENT_PAGES = gql`
 				content_label {
 					label
 					id
+					link_to
 				}
 			}
 		}
@@ -149,6 +150,7 @@ export const GET_CONTENT_BY_ID = gql`
 				content_label {
 					label
 					id
+					link_to
 				}
 			}
 			contentBlockssBycontentId(order_by: { position: asc }) {


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1091

enable content page tag links in admin dashboard

![image](https://user-images.githubusercontent.com/1710840/95875158-01a5ad80-0d72-11eb-8011-48ca04ffeaae.png)
