### PR TITLE
feat(image-grid): add new image format: 400x150

### DIFF
--- a/src/admin/content-block/components/wrappers/ImageGridWrapper/ImageGridWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/ImageGridWrapper/ImageGridWrapper.tsx
@@ -27,6 +27,7 @@ const formatLookup: {
 	'4:3': { imageWidth: 400, imageHeight: 300, itemWidth: 400 },
 	'2:1': { imageWidth: 200, imageHeight: 100, itemWidth: 200 },
 	'6:9': { imageWidth: 400, imageHeight: 225, itemWidth: 400 },
+	'400x150': { imageWidth: 400, imageHeight: 150, itemWidth: 400 },
 };
 
 const BlockGridWrapper: FunctionComponent<BlockGridWrapperProps> = ({

--- a/src/admin/content-block/content-block.const.ts
+++ b/src/admin/content-block/content-block.const.ts
@@ -520,6 +520,10 @@ export const GET_IMAGE_GRID_FORMAT_OPTIONS: () => SelectOption<BlockGridFormatOp
 		label: i18n.t('admin/content-block/content-block___6-x-9-400-x-225'),
 		value: '6:9',
 	},
+	{
+		label: i18n.t('400x150'),
+		value: '400x150',
+	},
 ];
 
 export const GET_PAGE_OVERVIEW_TAB_STYLE_OPTIONS: () => SelectOption<ContentTabStyle>[] = () => [

--- a/src/admin/shared/types/content-block.ts
+++ b/src/admin/shared/types/content-block.ts
@@ -18,7 +18,13 @@ export type AlignOption = 'left' | 'right' | 'center';
 
 export type FillOption = 'cover' | 'contain' | 'auto';
 
-export type BlockGridFormatOption = 'squareSmall' | 'squareLarge' | '4:3' | '2:1' | '6:9';
+export type BlockGridFormatOption =
+	| 'squareSmall'
+	| 'squareLarge'
+	| '4:3'
+	| '2:1'
+	| '6:9'
+	| '400x150';
 
 export type WidthOption = 'full-width' | 'page-header' | string; // CSS width string: eg: 100%; 400px, 500px
 


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1060

het afknippen van de logos is een gevolg van het rare image formaat die geupload is:
![image](https://user-images.githubusercontent.com/1710840/96580982-695f7980-12d9-11eb-92ff-a8d47d1c344b.png)

before:
![image](https://user-images.githubusercontent.com/1710840/96580907-4cc34180-12d9-11eb-86de-fd8be5f03cef.png)

after:
![image](https://user-images.githubusercontent.com/1710840/96580915-4df46e80-12d9-11eb-841b-c8674a6b7c37.png)
