### PR TITLE
fix(i18n): improve display of untranslated strings

### DIFF
--- a/src/shared/translations/i18n.ts
+++ b/src/shared/translations/i18n.ts
@@ -35,7 +35,10 @@ I18n.use(XHR)
 			useSuspense: false,
 		},
 		parseMissingKeyHandler: (key) => {
-			return `${upperFirst(lowerCase(key.split('___').pop()))} ***`;
+			if (key.includes('___')) {
+				return `${upperFirst(lowerCase(key.split('___').pop()))} ***`;
+			}
+			return `${key} ***`;
 		},
 	});
 


### PR DESCRIPTION
only delete any none alphanumeric characters if the key contains "___", otherwise just render the untranslated string with a " ***" suffix

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/97292210-3ffb9c00-184b-11eb-9679-7ff422ad3242.png)|![image](https://user-images.githubusercontent.com/1710840/97292220-41c55f80-184b-11eb-959f-d6523dcfddda.png)|