### PR TITLE
feat(admin-layout): make admin layout topbar same width as body

### DIFF
--- a/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
@@ -6,7 +6,6 @@ import MetaTags from 'react-meta-tags';
 import {
 	Button,
 	ButtonToolbar,
-	Container,
 	IconName,
 	TagInfo,
 	TagList,
@@ -855,6 +854,7 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 							'admin/collections-or-bundles/views/collections-or-bundles-overview___bundels'
 					  )
 			}
+			size="full-width"
 		>
 			<AdminLayoutBody>
 				<MetaTags>
@@ -882,15 +882,11 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 						}
 					/>
 				</MetaTags>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal" size="full-width">
-						<LoadingErrorLoadedComponent
-							loadingInfo={loadingInfo}
-							dataObject={collections}
-							render={renderCollectionsOrBundlesOverview}
-						/>
-					</Container>
-				</Container>
+				<LoadingErrorLoadedComponent
+					loadingInfo={loadingInfo}
+					dataObject={collections}
+					render={renderCollectionsOrBundlesOverview}
+				/>
 			</AdminLayoutBody>
 		</AdminLayout>
 	);

--- a/src/admin/content-page-labels/views/ContentPageLabelDetail.tsx
+++ b/src/admin/content-page-labels/views/ContentPageLabelDetail.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, useCallback, useEffect, useState } from 'reac
 import { useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 
-import { Button, ButtonToolbar, Container, Table } from '@viaa/avo2-components';
+import { Button, ButtonToolbar, Table } from '@viaa/avo2-components';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
 import { redirectToClientPage } from '../../../authentication/helpers/redirects';
@@ -164,6 +164,7 @@ const ContentPageLabelEdit: FunctionComponent<ContentPageLabelEditProps> = ({ hi
 				pageTitle={t(
 					'admin/content-page-labels/views/content-page-label-detail___content-pagina-label-details'
 				)}
+				size="large"
 			>
 				<AdminLayoutTopBarRight>
 					<ButtonToolbar>
@@ -182,11 +183,7 @@ const ContentPageLabelEdit: FunctionComponent<ContentPageLabelEditProps> = ({ hi
 						/>
 					</ButtonToolbar>
 				</AdminLayoutTopBarRight>
-				<AdminLayoutBody>
-					<Container mode="vertical" size="small">
-						<Container mode="horizontal">{renderDetailPage()}</Container>
-					</Container>
-				</AdminLayoutBody>
+				<AdminLayoutBody>{renderDetailPage()}</AdminLayoutBody>
 			</AdminLayout>
 		);
 	};

--- a/src/admin/content-page-labels/views/ContentPageLabelEdit.tsx
+++ b/src/admin/content-page-labels/views/ContentPageLabelEdit.tsx
@@ -272,6 +272,7 @@ const ContentPageLabelEdit: FunctionComponent<ContentPageLabelEditProps> = ({
 							'admin/content-page-labels/views/content-page-label-edit___content-pagina-label-aanpassen'
 					  )
 			}
+			size="large"
 		>
 			<AdminLayoutTopBarRight>
 				<ButtonToolbar>
@@ -291,11 +292,7 @@ const ContentPageLabelEdit: FunctionComponent<ContentPageLabelEditProps> = ({
 					/>
 				</ButtonToolbar>
 			</AdminLayoutTopBarRight>
-			<AdminLayoutBody>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal">{renderEditPage()}</Container>
-				</Container>
-			</AdminLayoutBody>
+			<AdminLayoutBody>{renderEditPage()}</AdminLayoutBody>
 		</AdminLayout>
 	);
 

--- a/src/admin/content-page-labels/views/ContentPageLabelOverview.tsx
+++ b/src/admin/content-page-labels/views/ContentPageLabelOverview.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, useCallback, useEffect, useState } from 'reac
 import { Trans, useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 
-import { Button, ButtonToolbar, Container } from '@viaa/avo2-components';
+import { Button, ButtonToolbar } from '@viaa/avo2-components';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
 import { GENERATE_SITE_TITLE } from '../../../constants';
@@ -319,6 +319,7 @@ const ContentPageLabelOverview: FunctionComponent<ContentPageLabelOverviewProps>
 			pageTitle={t(
 				'admin/content-page-labels/views/content-page-label-overview___content-pagina-labels-overzicht'
 			)}
+			size="full-width"
 		>
 			<AdminLayoutTopBarRight>
 				<Button
@@ -344,15 +345,11 @@ const ContentPageLabelOverview: FunctionComponent<ContentPageLabelOverviewProps>
 						)}
 					/>
 				</MetaTags>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal">
-						<LoadingErrorLoadedComponent
-							loadingInfo={loadingInfo}
-							dataObject={contentPageLabel}
-							render={renderContentPageLabelTable}
-						/>
-					</Container>
-				</Container>
+				<LoadingErrorLoadedComponent
+					loadingInfo={loadingInfo}
+					dataObject={contentPageLabel}
+					render={renderContentPageLabelTable}
+				/>
 			</AdminLayoutBody>
 		</AdminLayout>
 	);

--- a/src/admin/content-page-labels/views/ContentPageLabelOverview.tsx
+++ b/src/admin/content-page-labels/views/ContentPageLabelOverview.tsx
@@ -305,7 +305,7 @@ const ContentPageLabelOverview: FunctionComponent<ContentPageLabelOverviewProps>
 					isLoading={isLoading}
 				/>
 				<DeleteObjectModal
-					deleteObjectCallback={() => handleDelete()}
+					deleteObjectCallback={handleDelete}
 					isOpen={isConfirmModalOpen}
 					onClose={() => setIsConfirmModalOpen(false)}
 				/>

--- a/src/admin/content/views/ContentDetail.tsx
+++ b/src/admin/content/views/ContentDetail.tsx
@@ -412,6 +412,7 @@ const ContentDetail: FunctionComponent<ContentDetailProps> = ({ history, match, 
 		<AdminLayout
 			onClickBackButton={() => navigate(history, ADMIN_PATH.CONTENT_PAGE_OVERVIEW)}
 			pageTitle={pageTitle}
+			size="full-width"
 		>
 			<AdminLayoutTopBarRight>{renderContentActions()}</AdminLayoutTopBarRight>
 			<AdminLayoutHeader>

--- a/src/admin/content/views/ContentEdit.tsx
+++ b/src/admin/content/views/ContentEdit.tsx
@@ -57,10 +57,10 @@ import {
 	PageType,
 } from '../content.types';
 import {
+	CONTENT_PAGE_INITIAL_STATE,
 	ContentEditAction,
 	contentEditReducer,
 	ContentPageEditState,
-	CONTENT_PAGE_INITIAL_STATE,
 } from '../helpers/reducers';
 import { useContentTypes } from '../hooks';
 
@@ -543,6 +543,7 @@ const ContentEdit: FunctionComponent<ContentEditProps> = ({ history, match, user
 				<AdminLayout
 					onClickBackButton={() => navigate(history, ADMIN_PATH.CONTENT_PAGE_OVERVIEW)}
 					pageTitle={pageTitle}
+					size="large"
 				>
 					<AdminLayoutTopBarRight>
 						<ButtonToolbar>

--- a/src/admin/content/views/ContentOverview.tsx
+++ b/src/admin/content/views/ContentOverview.tsx
@@ -4,15 +4,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 import { Link } from 'react-router-dom';
 
-import {
-	Button,
-	ButtonToolbar,
-	Container,
-	LinkTarget,
-	Modal,
-	ModalBody,
-	Spacer,
-} from '@viaa/avo2-components';
+import { Button, ButtonToolbar, LinkTarget, Modal, ModalBody, Spacer } from '@viaa/avo2-components';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
 import { getUserGroupLabel } from '../../../authentication/helpers/get-profile-info';
@@ -509,7 +501,10 @@ const ContentOverview: FunctionComponent<ContentOverviewProps> = ({ history, use
 	};
 
 	return (
-		<AdminLayout pageTitle={t('admin/content/views/content-overview___content-overzicht')}>
+		<AdminLayout
+			pageTitle={t('admin/content/views/content-overview___content-overzicht')}
+			size="full-width"
+		>
 			<AdminLayoutTopBarRight>
 				{hasPerm(CREATE_CONTENT_PAGES) && (
 					<Button
@@ -537,15 +532,11 @@ const ContentOverview: FunctionComponent<ContentOverviewProps> = ({ history, use
 						)}
 					/>
 				</MetaTags>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal" size="full-width">
-						<LoadingErrorLoadedComponent
-							loadingInfo={loadingInfo}
-							dataObject={contentPages}
-							render={renderContentOverview}
-						/>
-					</Container>
-				</Container>
+				<LoadingErrorLoadedComponent
+					loadingInfo={loadingInfo}
+					dataObject={contentPages}
+					render={renderContentOverview}
+				/>
 			</AdminLayoutBody>
 		</AdminLayout>
 	);

--- a/src/admin/dashboard/views/Dashboard.tsx
+++ b/src/admin/dashboard/views/Dashboard.tsx
@@ -2,18 +2,16 @@ import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 
-import { Container } from '@viaa/avo2-components';
-
 import { GENERATE_SITE_TITLE } from '../../../constants';
 import i18n from '../../../shared/translations/i18n';
-import { AdminLayout } from '../../shared/layouts';
+import { AdminLayout, AdminLayoutBody } from '../../shared/layouts';
 
 const Dashboard = () => {
 	const [t] = useTranslation();
 
 	return (
-		<AdminLayout pageTitle={i18n.t('admin/dashboard/views/dashboard___dashboard')}>
-			<Container className="u-spacer-top-l" mode="vertical" size="small">
+		<AdminLayout pageTitle={i18n.t('admin/dashboard/views/dashboard___dashboard')} size="large">
+			<AdminLayoutBody>
 				<MetaTags>
 					<title>
 						{GENERATE_SITE_TITLE(
@@ -34,7 +32,7 @@ const Dashboard = () => {
 						aliquid enim dolorum laudantium delectus obcaecati rem. Mollitia?
 					</Trans>
 				</p>
-			</Container>
+			</AdminLayoutBody>
 		</AdminLayout>
 	);
 };

--- a/src/admin/interactive-tour/views/InteractiveTourDetail.tsx
+++ b/src/admin/interactive-tour/views/InteractiveTourDetail.tsx
@@ -174,6 +174,7 @@ const InteractiveTourDetail: FunctionComponent<UserDetailProps> = ({ history, ma
 			pageTitle={t(
 				'admin/interactive-tour/views/interactive-tour-detail___interactive-tour-details'
 			)}
+			size="large"
 		>
 			<AdminLayoutTopBarRight>
 				<HeaderButtons>

--- a/src/admin/interactive-tour/views/InteractiveTourEdit.tsx
+++ b/src/admin/interactive-tour/views/InteractiveTourEdit.tsx
@@ -40,9 +40,9 @@ import { AdminLayout, AdminLayoutBody, AdminLayoutTopBarRight } from '../../shar
 import { PickerItem } from '../../shared/types';
 import InteractiveTourAdd from '../components/InteractiveTourStepAdd';
 import {
+	INTERACTIVE_TOUR_EDIT_INITIAL_STATE,
 	InteractiveTourAction,
 	interactiveTourEditReducer,
-	INTERACTIVE_TOUR_EDIT_INITIAL_STATE,
 } from '../helpers/reducers';
 import {
 	getInitialInteractiveTour,
@@ -477,6 +477,7 @@ const InteractiveTourEdit: FunctionComponent<InteractiveTourEditProps> = ({
 			pageTitle={t(
 				'admin/interactive-tour/views/interactive-tour-edit___interactive-tour-aanpassen'
 			)}
+			size="large"
 		>
 			<AdminLayoutTopBarRight>
 				<ButtonToolbar>
@@ -492,11 +493,7 @@ const InteractiveTourEdit: FunctionComponent<InteractiveTourEditProps> = ({
 					/>
 				</ButtonToolbar>
 			</AdminLayoutTopBarRight>
-			<AdminLayoutBody>
-				<Container mode="vertical" size="small" className="m-interactive-tour-edit-view">
-					<Container mode="horizontal">{renderEditPage()}</Container>
-				</Container>
-			</AdminLayoutBody>
+			<AdminLayoutBody>{renderEditPage()}</AdminLayoutBody>
 		</AdminLayout>
 	);
 

--- a/src/admin/interactive-tour/views/InteractiveTourOverview.tsx
+++ b/src/admin/interactive-tour/views/InteractiveTourOverview.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, useCallback, useEffect, useState } from 'reac
 import { Trans, useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 
-import { Button, ButtonToolbar, Container, Spacer } from '@viaa/avo2-components';
+import { Button, ButtonToolbar, Spacer } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
@@ -288,6 +288,7 @@ const InteractiveTourGroupOverview: FunctionComponent<InteractiveTourOverviewPro
 			pageTitle={t(
 				'admin/interactive-tour/views/interactive-tour-overview___interactieve-tours'
 			)}
+			size="full-width"
 		>
 			<AdminLayoutTopBarRight>
 				<Button
@@ -318,15 +319,11 @@ const InteractiveTourGroupOverview: FunctionComponent<InteractiveTourOverviewPro
 						)}
 					/>
 				</MetaTags>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal">
-						<LoadingErrorLoadedComponent
-							loadingInfo={loadingInfo}
-							dataObject={interactiveTours}
-							render={renderInteractiveTourPageBody}
-						/>
-					</Container>
-				</Container>
+				<LoadingErrorLoadedComponent
+					loadingInfo={loadingInfo}
+					dataObject={interactiveTours}
+					render={renderInteractiveTourPageBody}
+				/>
 			</AdminLayoutBody>
 		</AdminLayout>
 	);

--- a/src/admin/items/views/ItemDetail.tsx
+++ b/src/admin/items/views/ItemDetail.tsx
@@ -471,6 +471,7 @@ const ItemDetail: FunctionComponent<ItemDetailProps> = ({ history, match }) => {
 			<AdminLayout
 				onClickBackButton={() => navigate(history, ADMIN_PATH.ITEMS_OVERVIEW)}
 				pageTitle={`${t('admin/items/views/item-detail___item-details')}: ${item.title}`}
+				size="large"
 			>
 				<AdminLayoutTopBarRight>
 					{!!item && (

--- a/src/admin/items/views/ItemsOverview.tsx
+++ b/src/admin/items/views/ItemsOverview.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, useCallback, useEffect, useState } from 'reac
 import { Trans, useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 
-import { Button, ButtonToolbar, Container } from '@viaa/avo2-components';
+import { Button, ButtonToolbar } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
@@ -344,7 +344,7 @@ const ItemsOverview: FunctionComponent<ItemsOverviewProps> = ({ history, user })
 	};
 
 	return (
-		<AdminLayout pageTitle={t('admin/items/views/items-overview___items')}>
+		<AdminLayout pageTitle={t('admin/items/views/items-overview___items')} size="full-width">
 			<AdminLayoutBody>
 				<MetaTags>
 					<title>
@@ -361,15 +361,11 @@ const ItemsOverview: FunctionComponent<ItemsOverviewProps> = ({ history, user })
 						)}
 					/>
 				</MetaTags>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal" size="full-width">
-						<LoadingErrorLoadedComponent
-							loadingInfo={loadingInfo}
-							dataObject={items}
-							render={renderItemsOverview}
-						/>
-					</Container>
-				</Container>
+				<LoadingErrorLoadedComponent
+					loadingInfo={loadingInfo}
+					dataObject={items}
+					render={renderItemsOverview}
+				/>
 			</AdminLayoutBody>
 		</AdminLayout>
 	);

--- a/src/admin/items/views/PublishItemsOverview.tsx
+++ b/src/admin/items/views/PublishItemsOverview.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, useCallback, useEffect, useState } from 'reac
 import { Trans, useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 
-import { Button, ButtonToolbar, Container } from '@viaa/avo2-components';
+import { Button, ButtonToolbar } from '@viaa/avo2-components';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
 import { redirectToClientPage } from '../../../authentication/helpers/redirects';
@@ -306,7 +306,7 @@ const PublishItemsOverview: FunctionComponent<PublishItemsOverviewProps> = ({ hi
 	};
 
 	return (
-		<AdminLayout pageTitle={t('admin/items/views/items-overview___items')}>
+		<AdminLayout pageTitle={t('admin/items/views/items-overview___items')} size="full-width">
 			<AdminLayoutTopBarRight>
 				<ButtonToolbar>
 					<Button
@@ -344,15 +344,11 @@ const PublishItemsOverview: FunctionComponent<PublishItemsOverviewProps> = ({ hi
 						)}
 					/>
 				</MetaTags>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal" size="full-width">
-						<LoadingErrorLoadedComponent
-							loadingInfo={loadingInfo}
-							dataObject={items}
-							render={renderItemsOverview}
-						/>
-					</Container>
-				</Container>
+				<LoadingErrorLoadedComponent
+					loadingInfo={loadingInfo}
+					dataObject={items}
+					render={renderItemsOverview}
+				/>
 			</AdminLayoutBody>
 		</AdminLayout>
 	);

--- a/src/admin/menu/views/MenuDetail.tsx
+++ b/src/admin/menu/views/MenuDetail.tsx
@@ -306,7 +306,7 @@ const MenuDetail: FunctionComponent<MenuDetailProps> = ({ history, match }) => {
 						</Flex>
 					</Spacer>
 					<DeleteObjectModal
-						deleteObjectCallback={() => handleDelete()}
+						deleteObjectCallback={handleDelete}
 						isOpen={isConfirmModalOpen}
 						onClose={() => setIsConfirmModalOpen(false)}
 					/>

--- a/src/admin/menu/views/MenuDetail.tsx
+++ b/src/admin/menu/views/MenuDetail.tsx
@@ -7,7 +7,6 @@ import {
 	Button,
 	ButtonGroup,
 	ButtonToolbar,
-	Container,
 	Flex,
 	IconName,
 	Spacer,
@@ -217,6 +216,7 @@ const MenuDetail: FunctionComponent<MenuDetailProps> = ({ history, match }) => {
 				onClickBackButton={() => navigate(history, ADMIN_PATH.MENU_OVERVIEW)}
 				className="c-menu-detail"
 				pageTitle={startCase(menuId)}
+				size="full-width"
 			>
 				<AdminLayoutTopBarRight>
 					<ButtonToolbar>
@@ -233,99 +233,88 @@ const MenuDetail: FunctionComponent<MenuDetailProps> = ({ history, match }) => {
 					</ButtonToolbar>
 				</AdminLayoutTopBarRight>
 				<AdminLayoutBody>
-					<Container mode="vertical" size="small">
-						<Container mode="horizontal">
-							<Table align className="c-menu-detail__table" variant="styled">
-								<tbody>
-									{menuItems.map((item, index) => (
-										<tr
-											key={`nav-edit-${item.id}`}
-											className={
-												activeRow === item.id
-													? 'c-menu-detail__table-row--active'
-													: ''
-											}
-										>
-											<td className="o-table-col-1">
-												<ButtonGroup>
-													{renderReorderButton(
-														'up',
-														index,
-														item.id,
-														isFirst(index)
-													)}
-													{renderReorderButton(
-														'down',
-														index,
-														item.id,
-														isLast(index)
-													)}
-												</ButtonGroup>
-											</td>
-											<td>
-												{item.label || item.tooltip || item.content_path}
-											</td>
-											<td>
-												<ButtonToolbar>
-													<Button
-														icon="edit-2"
-														onClick={() =>
-															handleNavigate(
-																MENU_PATH.MENU_ITEM_EDIT,
-																{
-																	menu: menuId,
-																	id: String(item.id),
-																}
-															)
-														}
-														title={t(
-															'admin/menu/views/menu-detail___bewerk-dit-navigatie-item'
-														)}
-														ariaLabel={t(
-															'admin/menu/views/menu-detail___bewerk-dit-navigatie-item'
-														)}
-														type="secondary"
-													/>
-													<Button
-														icon="delete"
-														title={t(
-															'admin/menu/views/menu-detail___verwijder-dit-navigatie-item'
-														)}
-														ariaLabel={t(
-															'admin/menu/views/menu-detail___verwijder-dit-navigatie-item'
-														)}
-														onClick={() => openConfirmModal(item.id)}
-														type="danger-hover"
-													/>
-												</ButtonToolbar>
-											</td>
-										</tr>
-									))}
-								</tbody>
-							</Table>
-							<Spacer margin="top">
-								<Flex center>
-									<Button
-										icon="plus"
-										label={t(
-											'admin/menu/views/menu-detail___voeg-een-item-toe'
-										)}
-										onClick={() =>
-											handleNavigate(MENU_PATH.MENU_ITEM_CREATE, {
-												menu: menuId,
-											})
-										}
-										type="primary"
-									/>
-								</Flex>
-							</Spacer>
-							<DeleteObjectModal
-								deleteObjectCallback={() => handleDelete()}
-								isOpen={isConfirmModalOpen}
-								onClose={() => setIsConfirmModalOpen(false)}
+					<Table align className="c-menu-detail__table" variant="styled">
+						<tbody>
+							{menuItems.map((item, index) => (
+								<tr
+									key={`nav-edit-${item.id}`}
+									className={
+										activeRow === item.id
+											? 'c-menu-detail__table-row--active'
+											: ''
+									}
+								>
+									<td className="o-table-col-1">
+										<ButtonGroup>
+											{renderReorderButton(
+												'up',
+												index,
+												item.id,
+												isFirst(index)
+											)}
+											{renderReorderButton(
+												'down',
+												index,
+												item.id,
+												isLast(index)
+											)}
+										</ButtonGroup>
+									</td>
+									<td>{item.label || item.tooltip || item.content_path}</td>
+									<td>
+										<ButtonToolbar>
+											<Button
+												icon="edit-2"
+												onClick={() =>
+													handleNavigate(MENU_PATH.MENU_ITEM_EDIT, {
+														menu: menuId,
+														id: String(item.id),
+													})
+												}
+												title={t(
+													'admin/menu/views/menu-detail___bewerk-dit-navigatie-item'
+												)}
+												ariaLabel={t(
+													'admin/menu/views/menu-detail___bewerk-dit-navigatie-item'
+												)}
+												type="secondary"
+											/>
+											<Button
+												icon="delete"
+												title={t(
+													'admin/menu/views/menu-detail___verwijder-dit-navigatie-item'
+												)}
+												ariaLabel={t(
+													'admin/menu/views/menu-detail___verwijder-dit-navigatie-item'
+												)}
+												onClick={() => openConfirmModal(item.id)}
+												type="danger-hover"
+											/>
+										</ButtonToolbar>
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</Table>
+					<Spacer margin="top">
+						<Flex center>
+							<Button
+								icon="plus"
+								label={t('admin/menu/views/menu-detail___voeg-een-item-toe')}
+								onClick={() =>
+									handleNavigate(MENU_PATH.MENU_ITEM_CREATE, {
+										menu: menuId,
+									})
+								}
+								type="primary"
 							/>
-						</Container>
-					</Container>
+						</Flex>
+					</Spacer>
+					<DeleteObjectModal
+						deleteObjectCallback={() => handleDelete()}
+						isOpen={isConfirmModalOpen}
+						onClose={() => setIsConfirmModalOpen(false)}
+					/>
 				</AdminLayoutBody>
 			</AdminLayout>
 		);

--- a/src/admin/menu/views/MenuEdit.tsx
+++ b/src/admin/menu/views/MenuEdit.tsx
@@ -8,7 +8,6 @@ import {
 	Badge,
 	Button,
 	ButtonToolbar,
-	Container,
 	Flex,
 	IconName,
 	Spacer,
@@ -355,6 +354,7 @@ const MenuEdit: FunctionComponent<MenuEditProps> = ({ history, match }) => {
 		<AdminLayout
 			onClickBackButton={() => navigate(history, ADMIN_PATH.MENU_OVERVIEW)}
 			pageTitle={pageTitle}
+			size="large"
 		>
 			<AdminLayoutTopBarRight>
 				<ButtonToolbar>
@@ -386,18 +386,14 @@ const MenuEdit: FunctionComponent<MenuEditProps> = ({ history, match }) => {
 					</title>
 					<meta name="description" content={get(menuForm, 'description') || ''} />
 				</MetaTags>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal">
-						<MenuEditForm
-							formErrors={formErrors}
-							formState={menuForm}
-							menuParentId={menuParentId}
-							menuParentOptions={menuParentOptions}
-							onChange={handleChange}
-							permissionWarning={permissionWarning}
-						/>
-					</Container>
-				</Container>
+				<MenuEditForm
+					formErrors={formErrors}
+					formState={menuForm}
+					menuParentId={menuParentId}
+					menuParentOptions={menuParentOptions}
+					onChange={handleChange}
+					permissionWarning={permissionWarning}
+				/>
 			</AdminLayoutBody>
 		</AdminLayout>
 	);

--- a/src/admin/menu/views/MenuOverview.tsx
+++ b/src/admin/menu/views/MenuOverview.tsx
@@ -4,7 +4,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 import { Link } from 'react-router-dom';
 
-import { Button, ButtonToolbar, Container, Spacer, Table } from '@viaa/avo2-components';
+import { Button, ButtonToolbar, Spacer, Table } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
@@ -116,7 +116,10 @@ const MenuOverview: FunctionComponent<MenuOverviewProps> = ({ history }) => {
 	};
 
 	return (
-		<AdminLayout pageTitle={t('admin/menu/views/menu-overview___navigatie-overzicht')}>
+		<AdminLayout
+			pageTitle={t('admin/menu/views/menu-overview___navigatie-overzicht')}
+			size="large"
+		>
 			{!!menus.length && (
 				<AdminLayoutTopBarRight>
 					<Button
@@ -139,15 +142,11 @@ const MenuOverview: FunctionComponent<MenuOverviewProps> = ({ history }) => {
 						)}
 					/>
 				</MetaTags>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal">
-						<DataQueryComponent
-							renderData={renderMenuOverview}
-							resultPath="app_content_nav_elements"
-							query={GET_MENUS}
-						/>
-					</Container>
-				</Container>
+				<DataQueryComponent
+					renderData={renderMenuOverview}
+					resultPath="app_content_nav_elements"
+					query={GET_MENUS}
+				/>
 			</AdminLayoutBody>
 		</AdminLayout>
 	);

--- a/src/admin/permission-groups/views/PermissionGroupDetail.tsx
+++ b/src/admin/permission-groups/views/PermissionGroupDetail.tsx
@@ -6,7 +6,6 @@ import {
 	BlockHeading,
 	Button,
 	ButtonToolbar,
-	Container,
 	Panel,
 	PanelBody,
 	PanelHeader,
@@ -174,6 +173,7 @@ const PermissionGroupEdit: FunctionComponent<PermissionGroupEditProps> = ({ hist
 				pageTitle={t(
 					'admin/permission-groups/views/permission-group-detail___permissie-groep-details'
 				)}
+				size="large"
 			>
 				<AdminLayoutTopBarRight>
 					<ButtonToolbar>
@@ -192,11 +192,7 @@ const PermissionGroupEdit: FunctionComponent<PermissionGroupEditProps> = ({ hist
 						/>
 					</ButtonToolbar>
 				</AdminLayoutTopBarRight>
-				<AdminLayoutBody>
-					<Container mode="vertical" size="small">
-						<Container mode="horizontal">{renderDetailPage()}</Container>
-					</Container>
-				</AdminLayoutBody>
+				<AdminLayoutBody>{renderDetailPage()}</AdminLayoutBody>
 			</AdminLayout>
 		);
 	};

--- a/src/admin/permission-groups/views/PermissionGroupEdit.tsx
+++ b/src/admin/permission-groups/views/PermissionGroupEdit.tsx
@@ -439,6 +439,7 @@ const PermissionGroupEdit: FunctionComponent<PermissionGroupEditProps> = ({
 							'admin/permission-groups/views/permission-group-edit___permissie-groep-aanpassen'
 					  )
 			}
+			size="large"
 		>
 			<AdminLayoutTopBarRight>
 				<ButtonToolbar>
@@ -454,11 +455,7 @@ const PermissionGroupEdit: FunctionComponent<PermissionGroupEditProps> = ({
 					/>
 				</ButtonToolbar>
 			</AdminLayoutTopBarRight>
-			<AdminLayoutBody>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal">{renderEditPage()}</Container>
-				</Container>
-			</AdminLayoutBody>
+			<AdminLayoutBody>{renderEditPage()}</AdminLayoutBody>
 		</AdminLayout>
 	);
 

--- a/src/admin/permission-groups/views/PermissionGroupOverview.tsx
+++ b/src/admin/permission-groups/views/PermissionGroupOverview.tsx
@@ -216,7 +216,7 @@ const PermissionGroupOverview: FunctionComponent<PermissionGroupOverviewProps> =
 					isLoading={isLoading}
 				/>
 				<DeleteObjectModal
-					deleteObjectCallback={() => handleDelete()}
+					deleteObjectCallback={handleDelete}
 					isOpen={isConfirmModalOpen}
 					onClose={() => setIsConfirmModalOpen(false)}
 				/>

--- a/src/admin/permission-groups/views/PermissionGroupOverview.tsx
+++ b/src/admin/permission-groups/views/PermissionGroupOverview.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, useCallback, useEffect, useState } from 'reac
 import { Trans, useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 
-import { Button, ButtonToolbar, Container } from '@viaa/avo2-components';
+import { Button, ButtonToolbar } from '@viaa/avo2-components';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
 import { GENERATE_SITE_TITLE } from '../../../constants';
@@ -230,6 +230,7 @@ const PermissionGroupOverview: FunctionComponent<PermissionGroupOverviewProps> =
 			pageTitle={t(
 				'admin/permission-groups/views/permission-group-overview___permissie-groepen-overzicht'
 			)}
+			size="full-width"
 		>
 			<AdminLayoutTopBarRight>
 				<ButtonToolbar>
@@ -258,15 +259,11 @@ const PermissionGroupOverview: FunctionComponent<PermissionGroupOverviewProps> =
 						)}
 					/>
 				</MetaTags>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal">
-						<LoadingErrorLoadedComponent
-							loadingInfo={loadingInfo}
-							dataObject={permissionGroups}
-							render={renderPermissionGroupTable}
-						/>
-					</Container>
-				</Container>
+				<LoadingErrorLoadedComponent
+					loadingInfo={loadingInfo}
+					dataObject={permissionGroups}
+					render={renderPermissionGroupTable}
+				/>
 			</AdminLayoutBody>
 		</AdminLayout>
 	);

--- a/src/admin/shared/components/TopBar/TopBar.tsx
+++ b/src/admin/shared/components/TopBar/TopBar.tsx
@@ -23,6 +23,7 @@ interface TopbarProps {
 	title?: string;
 	center?: ReactNode;
 	right?: ReactNode;
+	size?: 'small' | 'medium' | 'large' | 'full-width';
 }
 
 export const TopBarComponent: FunctionComponent<TopbarProps & RouteComponentProps> = ({
@@ -30,12 +31,13 @@ export const TopBarComponent: FunctionComponent<TopbarProps & RouteComponentProp
 	title,
 	center,
 	right,
+	size,
 }) => {
 	const [t] = useTranslation();
 
 	return (
 		<Navbar className="c-top-bar">
-			<Container mode="horizontal">
+			<Container mode="horizontal" size={size}>
 				<Toolbar>
 					<ToolbarLeft>
 						<ToolbarItem>

--- a/src/admin/shared/layouts/AdminLayout/AdminLayout.slots.tsx
+++ b/src/admin/shared/layouts/AdminLayout/AdminLayout.slots.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent } from 'react';
 
-export const AdminLayoutActions: FunctionComponent = ({ children }) => <>{children}</>;
 export const AdminLayoutBody: FunctionComponent = ({ children }) => <>{children}</>;
 export const AdminLayoutHeader: FunctionComponent = ({ children }) => <>{children}</>;
 export const AdminLayoutTopBarCenter: FunctionComponent = ({ children }) => <>{children}</>;

--- a/src/admin/shared/layouts/AdminLayout/AdminLayout.tsx
+++ b/src/admin/shared/layouts/AdminLayout/AdminLayout.tsx
@@ -1,13 +1,11 @@
-import classnames from 'classnames';
 import React, { FunctionComponent, ReactNode } from 'react';
 
 import { Container, useSlot } from '@viaa/avo2-components';
 
-import { ActionsBar, TopBar } from '../../components';
+import { TopBar } from '../../components';
 
 import './AdminLayout.scss';
 import {
-	AdminLayoutActions,
 	AdminLayoutBody,
 	AdminLayoutHeader,
 	AdminLayoutTopBarCenter,
@@ -19,6 +17,7 @@ interface AdminLayoutProps {
 	className?: string;
 	pageTitle?: string;
 	onClickBackButton?: () => void;
+	size: 'small' | 'medium' | 'large' | 'full-width'; // TODO move this to a type in the Container component in the components repo
 }
 
 const AdminLayout: FunctionComponent<AdminLayoutProps> = ({
@@ -26,30 +25,29 @@ const AdminLayout: FunctionComponent<AdminLayoutProps> = ({
 	className,
 	pageTitle,
 	onClickBackButton,
+	size,
 }) => {
-	const actions = useSlot(AdminLayoutActions, children);
 	const body = useSlot(AdminLayoutBody, children);
 	const topBarCenter = useSlot(AdminLayoutTopBarCenter, children);
 	const topBarRight = useSlot(AdminLayoutTopBarRight, children);
 	const header = useSlot(AdminLayoutHeader, children);
 
 	return (
-		<div className={classnames('l-admin', { 'l-admin--with-actions': !!actions })}>
+		<div className="l-admin">
 			<TopBar
 				onClickBackButton={onClickBackButton}
 				title={pageTitle}
 				center={topBarCenter}
 				right={topBarRight}
+				size={size}
 			/>
 			<div className="m-admin-layout-content">
 				{header}
-				{children && !body && (
-					<Container className={className} mode="vertical" size="small">
-						<Container mode="horizontal">{!body && children}</Container>
+				<Container className={className} mode="vertical" size="small">
+					<Container mode="horizontal" size={size}>
+						{body || children}
 					</Container>
-				)}
-				{body}
-				{actions && <ActionsBar fixed>{actions}</ActionsBar>}
+				</Container>
 			</div>
 		</div>
 	);

--- a/src/admin/shared/layouts/index.ts
+++ b/src/admin/shared/layouts/index.ts
@@ -1,6 +1,5 @@
 import AdminLayout from './AdminLayout/AdminLayout';
 import {
-	AdminLayoutActions,
 	AdminLayoutBody,
 	AdminLayoutHeader,
 	AdminLayoutTopBarCenter,
@@ -9,7 +8,6 @@ import {
 
 export {
 	AdminLayout,
-	AdminLayoutActions,
 	AdminLayoutBody,
 	AdminLayoutHeader,
 	AdminLayoutTopBarRight,

--- a/src/admin/translations/views/TranslationsOverview.tsx
+++ b/src/admin/translations/views/TranslationsOverview.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, useCallback, useEffect, useState } from 'reac
 import { useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 
-import { Button, Container, KeyValueEditor } from '@viaa/avo2-components';
+import { Button, KeyValueEditor } from '@viaa/avo2-components';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
 import { GENERATE_SITE_TITLE } from '../../../constants';
@@ -148,7 +148,10 @@ const TranslationsOverview: FunctionComponent<TranslationsOverviewProps> = () =>
 	};
 
 	return (
-		<AdminLayout pageTitle={t('admin/translations/views/translations-overview___vertalingen')}>
+		<AdminLayout
+			pageTitle={t('admin/translations/views/translations-overview___vertalingen')}
+			size="full-width"
+		>
 			<AdminLayoutTopBarRight>
 				<Button label="Opslaan" onClick={onSaveTranslations} />
 			</AdminLayoutTopBarRight>
@@ -168,17 +171,13 @@ const TranslationsOverview: FunctionComponent<TranslationsOverviewProps> = () =>
 						)}
 					/>
 				</MetaTags>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal" size="full-width">
-						{!!translations.length && (
-							<KeyValueEditor
-								initialData={initialTranslations}
-								data={translations}
-								onChange={onChangeTranslations}
-							/>
-						)}
-					</Container>
-				</Container>
+				{!!translations.length && (
+					<KeyValueEditor
+						initialData={initialTranslations}
+						data={translations}
+						onChange={onChangeTranslations}
+					/>
+				)}
 			</AdminLayoutBody>
 		</AdminLayout>
 	);

--- a/src/admin/user-groups/views/UserGroupDetail.tsx
+++ b/src/admin/user-groups/views/UserGroupDetail.tsx
@@ -278,6 +278,7 @@ const UserGroupDetail: FunctionComponent<UserDetailProps> = ({ history, match })
 		<AdminLayout
 			onClickBackButton={() => navigate(history, ADMIN_PATH.USER_GROUP_OVERVIEW)}
 			pageTitle={t('admin/user-groups/views/user-group-detail___gebruikersgroep-details')}
+			size="large"
 		>
 			<AdminLayoutTopBarRight>
 				<ButtonToolbar>

--- a/src/admin/user-groups/views/UserGroupEdit.tsx
+++ b/src/admin/user-groups/views/UserGroupEdit.tsx
@@ -498,6 +498,7 @@ const UserGroupEdit: FunctionComponent<UserGroupEditProps> = ({ history, match, 
 			<AdminLayout
 				onClickBackButton={() => navigate(history, ADMIN_PATH.USER_GROUP_OVERVIEW)}
 				pageTitle={t('admin/user-groups/views/user-group-edit___gebruikersgroep-aanpassen')}
+				size="large"
 			>
 				{' '}
 				<AdminLayoutTopBarRight>
@@ -514,11 +515,7 @@ const UserGroupEdit: FunctionComponent<UserGroupEditProps> = ({ history, match, 
 						/>
 					</ButtonToolbar>
 				</AdminLayoutTopBarRight>
-				<AdminLayoutBody>
-					<Container mode="vertical" size="small">
-						<Container mode="horizontal">{renderEditPage()}</Container>
-					</Container>
-				</AdminLayoutBody>
+				<AdminLayoutBody>{renderEditPage()}</AdminLayoutBody>
 			</AdminLayout>
 		);
 	};

--- a/src/admin/user-groups/views/UserGroupOverview.tsx
+++ b/src/admin/user-groups/views/UserGroupOverview.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, useCallback, useEffect, useState } from 'reac
 import { Trans, useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 
-import { Button, ButtonToolbar, Container, Spacer } from '@viaa/avo2-components';
+import { Button, ButtonToolbar, Spacer } from '@viaa/avo2-components';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
 import { redirectToClientPage } from '../../../authentication/helpers/redirects';
@@ -259,6 +259,7 @@ const UserGroupGroupOverview: FunctionComponent<UserGroupOverviewProps> = ({ his
 	return (
 		<AdminLayout
 			pageTitle={t('admin/user-groups/views/user-group-overview___gebruikersgroepen')}
+			size="full-width"
 		>
 			<AdminLayoutTopBarRight>
 				<ButtonToolbar>
@@ -289,15 +290,11 @@ const UserGroupGroupOverview: FunctionComponent<UserGroupOverviewProps> = ({ his
 						)}
 					/>
 				</MetaTags>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal">
-						<LoadingErrorLoadedComponent
-							loadingInfo={loadingInfo}
-							dataObject={userGroups}
-							render={renderUserGroupPageBody}
-						/>
-					</Container>
-				</Container>
+				<LoadingErrorLoadedComponent
+					loadingInfo={loadingInfo}
+					dataObject={userGroups}
+					render={renderUserGroupPageBody}
+				/>
 			</AdminLayoutBody>
 		</AdminLayout>
 	);

--- a/src/admin/users/views/UserDetail.tsx
+++ b/src/admin/users/views/UserDetail.tsx
@@ -369,6 +369,7 @@ const UserDetail: FunctionComponent<UserDetailProps> = ({ history, match, user }
 			<AdminLayout
 				onClickBackButton={() => navigate(history, ADMIN_PATH.USER_OVERVIEW)}
 				pageTitle={t('admin/users/views/user-detail___gebruiker-details')}
+				size="large"
 			>
 				<AdminLayoutTopBarRight>
 					<ButtonToolbar>

--- a/src/admin/users/views/UserOverview.tsx
+++ b/src/admin/users/views/UserOverview.tsx
@@ -3,7 +3,6 @@ import React, { FunctionComponent, useCallback, useEffect, useState } from 'reac
 import { Trans, useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 
-import { Container } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
@@ -231,7 +230,10 @@ const UserOverview: FunctionComponent<UserOverviewProps> = ({ history }) => {
 	};
 
 	return (
-		<AdminLayout pageTitle={t('admin/users/views/user-overview___gebruikers')}>
+		<AdminLayout
+			pageTitle={t('admin/users/views/user-overview___gebruikers')}
+			size="full-width"
+		>
 			<AdminLayoutBody>
 				<MetaTags>
 					<title>
@@ -248,15 +250,11 @@ const UserOverview: FunctionComponent<UserOverviewProps> = ({ history }) => {
 						)}
 					/>
 				</MetaTags>
-				<Container mode="vertical" size="small">
-					<Container mode="horizontal" size="full-width">
-						<LoadingErrorLoadedComponent
-							loadingInfo={loadingInfo}
-							dataObject={profiles}
-							render={renderUserOverview}
-						/>
-					</Container>
-				</Container>
+				<LoadingErrorLoadedComponent
+					loadingInfo={loadingInfo}
+					dataObject={profiles}
+					render={renderUserOverview}
+				/>
 			</AdminLayoutBody>
 		</AdminLayout>
 	);


### PR DESCRIPTION
makes admin layout header width match body and reduces the amount of code at the same time 💪 

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/97422079-9a5d3100-190d-11eb-8225-0c51bd29e280.png)|![image](https://user-images.githubusercontent.com/1710840/97422084-9d582180-190d-11eb-86c3-73b5b562a186.png)|

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/97422120-a9dc7a00-190d-11eb-83c5-153ddaad115a.png)|![image](https://user-images.githubusercontent.com/1710840/97422113-a6e18980-190d-11eb-99aa-6b824292be9f.png)|

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/97422166-b9f45980-190d-11eb-9e58-c1779ccffeb3.png)|![image](https://user-images.githubusercontent.com/1710840/97422153-b791ff80-190d-11eb-8a7d-9ea757218167.png)|