### PR TITLE
feat(page-overview-wrapper): save labels by id

### DIFF
--- a/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
@@ -1,4 +1,4 @@
-import { cloneDeep, compact, get } from 'lodash-es';
+import { cloneDeep, get, isNumber } from 'lodash-es';
 import React, { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RouteComponentProps, withRouter } from 'react-router';
@@ -23,6 +23,7 @@ import { useDebounce } from '../../../../../shared/hooks';
 import { ToastService } from '../../../../../shared/services';
 import { ContentPageService } from '../../../../../shared/services/content-page-service';
 import i18n from '../../../../../shared/translations/i18n';
+import { ContentPageLabelService } from '../../../../content-page-labels/content-page-label.service';
 import { ContentService } from '../../../../content/content.service';
 import { ContentPageInfo } from '../../../../content/content.types';
 import { convertToContentPageInfos } from '../../../../content/helpers/parsers';
@@ -86,6 +87,7 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteCom
 		item: StringParam,
 		label: CheckboxListParam,
 	};
+	const [labelObjs, setLabelObjs] = useState<LabelObj[]>([]);
 	const [queryParamsState, setQueryParamsState] = useQueryParams(queryParamConfig);
 	const [pages, setPages] = useState<ContentPageInfo[] | null>(null);
 	const [pageCount, setPageCount] = useState<number | null>(null);
@@ -118,21 +120,46 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteCom
 		};
 	};
 
+	const getSelectedLabelIds = (): number[] => {
+		if (!contentTypeAndTabs.selectedLabels) {
+			return [];
+		}
+		if (isNumber(contentTypeAndTabs.selectedLabels[0])) {
+			// new format where we save the ids of the labels instead of the full label object
+			// https://meemoo.atlassian.net/browse/AVO-1410
+			return contentTypeAndTabs.selectedLabels || [];
+		} else {
+			// Old format where we save the whole label object
+			// TODO deprecated remove when all content pages with type overview have been resaved
+			return (((contentTypeAndTabs.selectedLabels || []) as unknown) as LabelObj[]).map(
+				(label) => label.id
+			);
+		}
+	};
+
 	const fetchPages = useCallback(async () => {
 		try {
+			if (contentTypeAndTabs.selectedLabels && contentTypeAndTabs.selectedLabels.length) {
+				setLabelObjs(
+					await ContentPageLabelService.getContentPageLabelsByTypeAndIds(
+						contentTypeAndTabs.selectedContentType,
+						getSelectedLabelIds()
+					)
+				);
+			}
+
 			// Map labels in query params to label objects
 			let selectedTabs: LabelObj[] = [];
 			if (queryParamsState.label) {
-				if (queryParamsState.label.length) {
-					selectedTabs = compact(
-						(queryParamsState.label || []).map((labelName: string) => {
-							return (contentTypeAndTabs.selectedLabels || []).find((labelObj) => {
-								return labelObj.label === labelName;
-							});
-						})
+				const queryLabels = queryParamsState.label || [];
+				if (queryLabels.length) {
+					selectedTabs = await ContentPageLabelService.getContentPageLabelsByTypeAndLabels(
+						contentTypeAndTabs.selectedContentType,
+						queryLabels
 					);
 					setSelectedTabObjects(selectedTabs);
 				} else {
+					selectedTabs = [];
 					setSelectedTabObjects([]);
 				}
 			}
@@ -162,15 +189,14 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteCom
 				}
 			}
 
-			const selectedLabelIds = selectedTabs.map((labelObj) => labelObj.id);
-			const blockLabelIds = ((contentTypeAndTabs.selectedLabels ||
-				[]) as Avo.ContentPage.Label[]).map((labelObj) => labelObj.id);
 			const body: ContentPageOverviewParams = {
 				withBlock: itemStyle === 'ACCORDION',
 				contentType: contentTypeAndTabs.selectedContentType,
-				labelIds: (contentTypeAndTabs.selectedLabels || []).map((labelObj) => labelObj.id),
+				labelIds: getSelectedLabelIds(),
 				selectedLabelIds:
-					selectedLabelIds && selectedLabelIds.length ? selectedLabelIds : blockLabelIds,
+					selectedTabs && selectedTabs.length
+						? selectedTabs.map((tab) => tab.id)
+						: getSelectedLabelIds(),
 				orderByProp: 'published_at',
 				orderByDirection: 'desc',
 				offset: queryParamsState.page * debouncedItemsPerPage,
@@ -259,8 +285,8 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteCom
 	};
 
 	const getLabelsWithContent = () => {
-		return (contentTypeAndTabs.selectedLabels || []).filter(
-			(labelInfo: Avo.ContentPage.Label) => (labelPageCounts || {})[labelInfo.id] > 0
+		return (labelObjs || []).filter(
+			(labelObj: LabelObj) => (labelPageCounts || {})[labelObj.id] > 0
 		);
 	};
 

--- a/src/admin/content-page-labels/content-page-label.gql.ts
+++ b/src/admin/content-page-labels/content-page-label.gql.ts
@@ -44,6 +44,26 @@ export const GET_CONTENT_PAGE_LABEL_BY_ID = gql`
 	}
 `;
 
+export const GET_CONTENT_PAGE_LABELS_BY_TYPE_AND_LABEL = gql`
+	query getContentPageLabelsByTypeAndLabels($contentType: String!, $labels: [String!]!) {
+		app_content_labels(
+			where: { label: { _in: $labels }, content_type: { _eq: $contentType } }
+		) {
+			label
+			id
+		}
+	}
+`;
+
+export const GET_CONTENT_PAGE_LABELS_BY_TYPE_AND_ID = gql`
+	query getContentPageLabelsByTypeAndIds($contentType: String!, $labelIds: [Int!]!) {
+		app_content_labels(where: { id: { _in: $labelIds }, content_type: { _eq: $contentType } }) {
+			label
+			id
+		}
+	}
+`;
+
 export const INSERT_CONTENT_PAGE_LABEL = gql`
 	mutation insertContentPageLabel($contentPageLabel: app_content_labels_insert_input!) {
 		insert_app_content_labels(objects: [$contentPageLabel]) {

--- a/src/admin/content-page-labels/content-page-label.service.ts
+++ b/src/admin/content-page-labels/content-page-label.service.ts
@@ -1,5 +1,6 @@
 import { get, isNil } from 'lodash-es';
 
+import { LabelObj } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
 import { CustomError } from '../../shared/helpers';
@@ -9,8 +10,9 @@ import i18n from '../../shared/translations/i18n';
 import { ITEMS_PER_PAGE } from './content-page-label.const';
 import {
 	DELETE_CONTENT_PAGE_LABEL,
-	GET_CONTENT_PAGE_LABELS,
 	GET_CONTENT_PAGE_LABEL_BY_ID,
+	GET_CONTENT_PAGE_LABELS, GET_CONTENT_PAGE_LABELS_BY_TYPE_AND_ID,
+	GET_CONTENT_PAGE_LABELS_BY_TYPE_AND_LABEL,
 	INSERT_CONTENT_PAGE_LABEL,
 	UPDATE_CONTENT_PAGE_LABEL,
 } from './content-page-label.gql';
@@ -194,6 +196,60 @@ export class ContentPageLabelService {
 				i18n.t(
 					'admin/content-page-labels/content-page-label___het-verwijderen-van-de-content-pagina-label-is-mislukt'
 				)
+			);
+		}
+	}
+
+	static async getContentPageLabelsByTypeAndLabels(
+		contentType: Avo.ContentPage.Type,
+		labels: string[]
+	): Promise<LabelObj[]> {
+		try {
+			const response = await dataService.query({
+				query: GET_CONTENT_PAGE_LABELS_BY_TYPE_AND_LABEL,
+				variables: { contentType, labels },
+			});
+
+			if (response.errors) {
+				throw new CustomError('graphql response contains errors', null, { response });
+			}
+
+			return get(response, 'data.app_content_labels') || [];
+		} catch (err) {
+			throw new CustomError(
+				'Failed to get content page label objects by type and label',
+				err,
+				{
+					query: 'GET_CONTENT_PAGE_LABELS_BY_TYPE_AND_LABEL',
+					variables: { contentType, labels },
+				}
+			);
+		}
+	}
+
+	static async getContentPageLabelsByTypeAndIds(
+		contentType: Avo.ContentPage.Type,
+		labelIds: number[]
+	): Promise<LabelObj[]> {
+		try {
+			const response = await dataService.query({
+				query: GET_CONTENT_PAGE_LABELS_BY_TYPE_AND_ID,
+				variables: { contentType, labelIds },
+			});
+
+			if (response.errors) {
+				throw new CustomError('graphql response contains errors', null, { response });
+			}
+
+			return get(response, 'data.app_content_labels') || [];
+		} catch (err) {
+			throw new CustomError(
+				'Failed to get content page label objects by type and label',
+				err,
+				{
+					query: 'GET_CONTENT_PAGE_LABELS_BY_TYPE_AND_ID',
+					variables: { contentType, labelIds },
+				}
 			);
 		}
 	}

--- a/src/admin/content/content.gql.ts
+++ b/src/admin/content/content.gql.ts
@@ -213,7 +213,7 @@ export const GET_PERMISSIONS_FROM_CONTENT_PAGE_BY_PATH = gql`
 `;
 
 export const GET_CONTENT_LABELS_BY_CONTENT_TYPE = gql`
-	query getContentLabls($contentType: String!) {
+	query getContentLabels($contentType: String!) {
 		app_content_labels(where: { content_type: { _eq: $contentType } }) {
 			id
 			label

--- a/src/admin/content/views/ContentOverview.tsx
+++ b/src/admin/content/views/ContentOverview.tsx
@@ -95,7 +95,18 @@ const ContentOverview: FunctionComponent<ContentOverviewProps> = ({ history, use
 							{ path: { _ilike: queryWordWildcard } },
 							{
 								profile: {
-									usersByuserId: { full_name: { _ilike: queryWordWildcard } },
+									_or: [
+										{
+											usersByuserId: {
+												first_name: { _ilike: queryWordWildcard },
+											},
+										},
+										{
+											usersByuserId: {
+												last_name: { _ilike: queryWordWildcard },
+											},
+										},
+									],
 								},
 							},
 							{
@@ -273,9 +284,7 @@ const ContentOverview: FunctionComponent<ContentOverviewProps> = ({ history, use
 			await ContentService.deleteContentPage(contentToDelete.id);
 			fetchContentPages();
 			ToastService.success(
-				t(
-					'admin/content/views/content-overview___het-content-item-is-succesvol-verwijderd'
-				)
+				t('admin/content/views/content-overview___het-content-item-is-succesvol-verwijderd')
 			);
 		} catch (err) {
 			console.error(


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1410

This should allow users to rename page labels without breaking overview pages.
links to specific labels on overview pages will still break. not much we can do about that.

overview pagina met label:
![image](https://user-images.githubusercontent.com/1710840/98017031-fee12a00-1dfe-11eb-9306-bd77d995fd21.png)

rename the label:
![image](https://user-images.githubusercontent.com/1710840/98017134-20421600-1dff-11eb-9558-2bd8caab6417.png)

overview page loads with changed label:
![image](https://user-images.githubusercontent.com/1710840/98017158-27692400-1dff-11eb-95eb-2abacb7e1eff.png)
