### PR TITLE
fix(flowplayer): rewrite flowplayer m3u8 urls to mp4 on ios

### DIFF
--- a/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.scss
+++ b/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.scss
@@ -13,6 +13,7 @@ $c-video-player-progress-inner-bg: $color-teal-bright;
 	position: relative;
 	border-radius: 0.4rem;
 	overflow: hidden;
+	max-width: 100%;
 
 	.a-flowplayer__text {
 		color: $color-gray-200;

--- a/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.tsx
+++ b/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.tsx
@@ -118,11 +118,33 @@ const FlowPlayerWrapper: FunctionComponent<FlowPlayerWrapperProps & UserProps> =
 		}
 	};
 
+	const hasHlsSupport = (): boolean => {
+		try {
+			new MediaSource();
+			return true;
+		} catch (err) {
+			return false;
+		}
+	};
+
+	const getBrowserSafeUrl = (src: string): string => {
+		if (hasHlsSupport()) {
+			return src;
+		} else if (src.includes('flowplayer')) {
+			return src.replace('/hls/', '/v-').replace('/playlist.m3u8', '_original.mp4');
+		} else {
+			ToastService.danger(
+				t('Deze video kan niet worden afgespeeld. Probeer een andere browser.')
+			);
+			return src;
+		}
+	};
+
 	return (
 		<div className="c-video-player t-player-skin--dark">
 			{src && (props.autoplay || clickedThumbnail || !item) ? (
 				<FlowPlayer
-					src={src}
+					src={getBrowserSafeUrl(src)}
 					seekTime={props.seekTime}
 					poster={poster}
 					title={get(item, 'title')}


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1414

ios doesn't support hls playlists

@benjaminnaesen als je deze eens kan testen op je iphone, of had jij er geen?

deze video zou moeten kunnen afspelen op ios safari:
http://localhost:8080/flowplayer-met-m-3-u-8-url