### PR TITLE
fix(redirects): decode url before trying to split it by the path

### DIFF
--- a/src/authentication/helpers/redirects.ts
+++ b/src/authentication/helpers/redirects.ts
@@ -139,7 +139,7 @@ export function getBaseUrl(location: Location): string {
 	if (location.pathname === '/') {
 		return trimEnd(window.location.href, '/');
 	}
-	return trimEnd(window.location.href.split(location.pathname)[0], '/');
+	return trimEnd(decodeURIComponent(window.location.href).split(location.pathname)[0], '/');
 }
 
 export function getFromPath(


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1430