### PR TITLE
feat(dynamic-route-resolver): custom error message for depublished pages

### DIFF
--- a/src/dynamic-route-resolver/dynamic-route-resolver.const.ts
+++ b/src/dynamic-route-resolver/dynamic-route-resolver.const.ts
@@ -1,4 +1,5 @@
 import { getEnv } from '../shared/helpers';
+import i18n from '../shared/translations/i18n';
 
 export const DYNAMIC_ROUTE_RESOLVER_PATH = Object.freeze({
 	ALL_ROUTES: `*`,
@@ -30,4 +31,9 @@ export const GET_REDIRECTS: () => { [avo1Path: string]: string } = () => ({
 		'/nieuws/barend-van-heusden-aan-het-woord-over-cultuur-de-spiegel',
 
 	'/klaar.json': `${getEnv('PROXY_URL')}/klaar/klaar.json`,
+});
+
+export const GET_ERROR_MESSAGES: () => { [key: string]: string } = () => ({
+	DEPUBLISHED_PAGINA: i18n.t('Deze pagina is niet meer beschikbaar'),
+	DEPUBLISHED_EVENT_DETAIL: i18n.t('Dit event is reeds afgelopen'),
 });

--- a/src/shared/services/content-page-service.ts
+++ b/src/shared/services/content-page-service.ts
@@ -27,18 +27,23 @@ export class ContentPageService {
 					credentials: 'include',
 				}
 			);
-			if (response.status === 404) {
-				return null;
-			}
+			let responseContent: any;
+			try {
+				responseContent = await response.json();
+			} catch (err) {}
 			if (response.status < 200 || response.status >= 400) {
 				throw new CustomError('Failed to get content page from /content-pages', null, {
 					path,
 					response,
+					responseContent,
 				});
 			}
-			return convertToContentPageInfo(await response.json());
+			if (responseContent.error) {
+				return responseContent.error;
+			}
+			return convertToContentPageInfo(responseContent);
 		} catch (err) {
-			throw new CustomError('Failed to get all user groups', err);
+			throw new CustomError('Failed to get content page by path', err);
 		}
 	}
 


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1421

Requires proxy PR: https://github.com/viaacode/avo2-proxy/pull/270

example url of a depublished event content page:
http://localhost:8080/depublished-event-page

example url of a depublished regular content page:
http://localhost:8080/depublished-content-page

![image](https://user-images.githubusercontent.com/1710840/98942828-e2c04580-24ee-11eb-801d-df33e5208905.png)

![image](https://user-images.githubusercontent.com/1710840/98942898-01264100-24ef-11eb-90c8-a2de73746768.png)

![image](https://user-images.githubusercontent.com/1710840/98942899-02576e00-24ef-11eb-9a16-08250afa4873.png)
