### PR TITLE
fix(date-range-dropdown): use moment for parsing instead of date obj

### DIFF
--- a/src/shared/components/DateRangeDropdown/DateRangeDropdown.tsx
+++ b/src/shared/components/DateRangeDropdown/DateRangeDropdown.tsx
@@ -187,8 +187,8 @@ const DateRangeDropdown: FunctionComponent<DateRangeDropdownProps> = ({
 		tillYear = (till || yearInputLte || '').split('-')[0];
 	}
 
-	const fromDate: Date | null = from ? new Date(from) : null;
-	const tillDate: Date | null = till ? new Date(till) : null;
+	const fromDate: Date | null = from ? moment(from, 'YYYY-MM-DD HH:mm:ss').toDate() : null;
+	const tillDate: Date | null = till ? moment(till, 'YYYY-MM-DD HH:mm:ss').toDate() : null;
 
 	return (
 		<Dropdown


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1406

safari fails on this code:
```
new Date('2020-11-10 00:00:00') // => Invalid time value
```

so changed it to:
```
moment('2020-11-10 00:00:00', 'YYYY-MM-DD HH:mm:ss').toDate()
```