### PR TITLE
fix(collection-detail): replace history when redirecting from old id

### DIFF
--- a/src/collection/views/CollectionDetail.tsx
+++ b/src/collection/views/CollectionDetail.tsx
@@ -160,10 +160,7 @@ const CollectionDetail: FunctionComponent<CollectionDetailProps> = ({
 			if (collectionId !== uuid) {
 				// Redirect to new url that uses the collection uuid instead of the collection avo1 id
 				// and continue loading the collection
-				redirectToClientPage(
-					buildLink(APP_PATH.COLLECTION_DETAIL.route, { id: uuid }),
-					history
-				);
+				history.replace(buildLink(APP_PATH.COLLECTION_DETAIL.route, { id: uuid }));
 
 				return;
 			}


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1446

how to test:
* ga naar: http://localhost:8080/item/cv4bp1t14v
* edit de link naast de video to point to: http://localhost:8080/collecties/2255881 ipv https://onderwijs.hetarchief.be/collecties/2255881
* use the back button once

expected result: you go back to the item page

result before this PR: you would stay on the collection page