### PR TITLE
feat(publish-content-page-modal): add input to set published_at date

### DIFF
--- a/src/admin/content/components/PublishContentPageModal.scss
+++ b/src/admin/content/components/PublishContentPageModal.scss
@@ -1,0 +1,22 @@
+.c-content-page-publish-modal__display-date {
+	margin-top: 3.2rem;
+
+	.o-form-group__label {
+		font-weight: 500;
+	}
+
+	.u-spacer {
+		position: relative;
+		display: inline-block;
+
+		.c-tooltip-trigger {
+			position: absolute;
+			right: 10px;
+			top: 6px;
+		}
+
+		.c-tooltip[data-popper-placement^=right] > .c-tooltip__arrow {
+			left: -4px;
+		}
+	}
+}

--- a/src/admin/content/components/PublishContentPageModal.tsx
+++ b/src/admin/content/components/PublishContentPageModal.tsx
@@ -8,6 +8,7 @@ import {
 	DatePicker,
 	Form,
 	FormGroup,
+	Icon,
 	Modal,
 	ModalBody,
 	RadioButtonGroup,
@@ -15,11 +16,17 @@ import {
 	Toolbar,
 	ToolbarItem,
 	ToolbarRight,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
 } from '@viaa/avo2-components';
 
+import Html from '../../../shared/components/Html/Html';
 import { ToastService } from '../../../shared/services';
 import { ContentPageInfo } from '../content.types';
 import { getPublishedState } from '../helpers/get-published-state';
+
+import './PublishContentPageModal.scss';
 
 type publishOption = 'private' | 'public' | 'timebound';
 
@@ -40,6 +47,7 @@ const PublishContentPageModal: FunctionComponent<PublishContentPageModalProps> =
 	const [selectedOption, setSelectedOption] = useState<publishOption>(
 		getPublishedState(contentPage)
 	);
+	const [publishedAt, setPublishedAt] = useState<string | null>(contentPage.published_at);
 	const [publishAt, setPublishAt] = useState<string | null>(contentPage.publish_at);
 	const [depublishAt, setDepublishAt] = useState<string | null>(contentPage.depublish_at);
 
@@ -47,7 +55,8 @@ const PublishContentPageModal: FunctionComponent<PublishContentPageModalProps> =
 		try {
 			const newContent: Partial<ContentPageInfo> = {
 				is_public: selectedOption === 'public',
-				published_at: selectedOption === 'public' ? new Date().toISOString() : null,
+				published_at:
+					publishedAt || (selectedOption === 'public' ? new Date().toISOString() : null),
 				publish_at: selectedOption === 'timebound' ? publishAt : null,
 				depublish_at: selectedOption === 'timebound' ? depublishAt : null,
 			} as Partial<ContentPageInfo>;
@@ -154,6 +163,31 @@ const PublishContentPageModal: FunctionComponent<PublishContentPageModalProps> =
 						</FormGroup>
 					</Form>
 				</Spacer>
+
+				<FormGroup
+					label={t('Display datum (optioneel)')}
+					className="c-content-page-publish-modal__display-date"
+				>
+					<Spacer>
+						<DatePicker
+							value={publishedAt ? new Date(publishedAt) : null}
+							onChange={(date) => setPublishedAt(date ? date.toISOString() : null)}
+						/>
+						<Tooltip position="right">
+							<TooltipTrigger>
+								<Icon className="a-info-icon" name="info" size="small" />
+							</TooltipTrigger>
+							<TooltipContent>
+								<Html
+									content={t(
+										"Dit is de datum die getoond wordt als publiceer datum.<br/>Op deze datum worden de pagina's in een overzicht gesorteerd."
+									)}
+									sanitizePreset={'basic'}
+								/>
+							</TooltipContent>
+						</Tooltip>
+					</Spacer>
+				</FormGroup>
 
 				<Toolbar spaced>
 					<ToolbarRight>


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1445

requires proxy PR: https://github.com/viaacode/avo2-proxy/pull/285

![image](https://user-images.githubusercontent.com/1710840/101802693-07b8d000-3b10-11eb-85de-eeaf0188c0b3.png)

initial news page:
![image](https://user-images.githubusercontent.com/1710840/101802559-df30d600-3b0f-11eb-9be0-95bf5ad2ddb3.png)

Suppose you want the first article to show up below the second. Change the display date:
![image](https://user-images.githubusercontent.com/1710840/101802632-f4a60000-3b0f-11eb-8d7c-2dbcfb65dcc3.png)

Now the ordering is different:
![image](https://user-images.githubusercontent.com/1710840/101802658-fbcd0e00-3b0f-11eb-88fb-4e2601080fbd.png)


Tooltip:
![image](https://user-images.githubusercontent.com/1710840/101802675-012a5880-3b10-11eb-8d79-e4ae01273b2e.png)
