### PR TITLE
feat(user-service): link delete users ui to backend route

### DIFF
--- a/src/admin/collectionsOrBundles/collections-or-bundles.gql.ts
+++ b/src/admin/collectionsOrBundles/collections-or-bundles.gql.ts
@@ -56,15 +56,6 @@ export const GET_COLLECTIONS = gql`
 	}
 `;
 
-// TODO add relations back into the collections query to show which collections are a copy of which collection
-// We first want to test how fast the query is, before we make it heavier again:
-//
-// relations(where: { predicate: { _eq: "IS_COPY_OF" } }) {
-// 	subject
-// 	predicate
-// 	object
-// }
-
 export const GET_COLLECTION_IDS = gql`
 	query getCollections($where: app_collections_bool_exp!) {
 		app_collections(where: $where) {
@@ -81,7 +72,7 @@ export const BULK_UPDATE_PUBLISH_STATE_FOR_COLLECTIONS = gql`
 		$updatedByProfileId: uuid!
 	) {
 		update_app_collections(
-			where: { id: { _in: $collectionIds } }
+			where: { id: { _in: $collectionIds }, is_deleted: { _eq: false } }
 			_set: {
 				is_public: $isPublic
 				updated_at: $now
@@ -101,7 +92,7 @@ export const BULK_UPDATE_AUTHOR_FOR_COLLECTIONS = gql`
 		$updatedByProfileId: uuid!
 	) {
 		update_app_collections(
-			where: { id: { _in: $collectionIds } }
+			where: { id: { _in: $collectionIds }, is_deleted: { _eq: false } }
 			_set: {
 				owner_profile_id: $authorId
 				updated_at: $now
@@ -120,7 +111,7 @@ export const BULK_DELETE_COLLECTIONS = gql`
 		$updatedByProfileId: uuid!
 	) {
 		update_app_collections(
-			where: { id: { _in: $collectionIds } }
+			where: { id: { _in: $collectionIds }, is_deleted: { _eq: false } }
 			_set: { is_deleted: true, updated_at: $now, updated_by_profile_id: $updatedByProfileId }
 		) {
 			affected_rows
@@ -153,7 +144,7 @@ export const BULK_UPDATE_DATE_AND_LAST_AUTHOR_COLLECTIONS = gql`
 		$updatedByProfileId: uuid!
 	) {
 		update_app_collections(
-			where: { id: { _in: $collectionIds } }
+			where: { id: { _in: $collectionIds }, is_deleted: { _eq: false } }
 			_set: { updated_at: $now, updated_by_profile_id: $updatedByProfileId }
 		) {
 			affected_rows

--- a/src/admin/collectionsOrBundles/collections-or-bundles.service.ts
+++ b/src/admin/collectionsOrBundles/collections-or-bundles.service.ts
@@ -19,8 +19,8 @@ import {
 	BULK_UPDATE_AUTHOR_FOR_COLLECTIONS,
 	BULK_UPDATE_DATE_AND_LAST_AUTHOR_COLLECTIONS,
 	BULK_UPDATE_PUBLISH_STATE_FOR_COLLECTIONS,
-	GET_COLLECTIONS,
 	GET_COLLECTION_IDS,
+	GET_COLLECTIONS,
 } from './collections-or-bundles.gql';
 import { CollectionsOrBundlesOverviewTableCols } from './collections-or-bundles.types';
 

--- a/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
@@ -177,6 +177,8 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 				}
 			}
 
+			andFilters.push({ is_deleted: { _eq: false } });
+
 			return { _and: andFilters };
 		},
 		[isCollection, user]

--- a/src/admin/content/content.gql.ts
+++ b/src/admin/content/content.gql.ts
@@ -64,7 +64,11 @@ export const GET_PUBLIC_PROJECT_CONTENT_PAGES = gql`
 		app_content(
 			limit: $limit
 			order_by: $orderBy
-			where: { content_type: { _eq: PROJECT }, is_public: { _eq: true } }
+			where: {
+				content_type: { _eq: PROJECT }
+				is_public: { _eq: true }
+				is_deleted: { _eq: false }
+			}
 		) {
 			path
 			title
@@ -96,6 +100,7 @@ export const GET_PUBLIC_PROJECT_CONTENT_PAGES_BY_TITLE = gql`
 				title: { _ilike: $title }
 				content_type: { _eq: PROJECT }
 				is_public: { _eq: true }
+				is_deleted: { _eq: false }
 			}
 			limit: $limit
 			order_by: $orderBy
@@ -108,7 +113,7 @@ export const GET_PUBLIC_PROJECT_CONTENT_PAGES_BY_TITLE = gql`
 
 export const GET_CONTENT_BY_ID = gql`
 	query getContentById($id: Int!) {
-		app_content(where: { id: { _eq: $id } }) {
+		app_content(where: { id: { _eq: $id }, is_deleted: { _eq: false } }) {
 			content_type
 			content_width
 			created_at
@@ -181,7 +186,10 @@ export const GET_CONTENT_TYPES = gql`
 
 export const UPDATE_CONTENT_BY_ID = gql`
 	mutation updateContentById($id: Int!, $contentPage: app_content_set_input!) {
-		update_app_content(where: { id: { _eq: $id } }, _set: $contentPage) {
+		update_app_content(
+			where: { id: { _eq: $id }, is_deleted: { _eq: false } }
+			_set: $contentPage
+		) {
 			affected_rows
 		}
 	}
@@ -197,9 +205,9 @@ export const INSERT_CONTENT = gql`
 	}
 `;
 
-export const DELETE_CONTENT = gql`
-	mutation deleteContent($id: Int!) {
-		delete_app_content(where: { id: { _eq: $id } }) {
+export const SOFT_DELETE_CONTENT = gql`
+	mutation softDeleteContent($id: Int!) {
+		update_app_content(where: { id: { _eq: $id } }, _set: { is_deleted: true }) {
 			affected_rows
 		}
 	}
@@ -207,7 +215,7 @@ export const DELETE_CONTENT = gql`
 
 export const GET_PERMISSIONS_FROM_CONTENT_PAGE_BY_PATH = gql`
 	query GetPermissionsFromContentPageByPath($path: String!) {
-		app_content(where: { path: { _eq: $path } }) {
+		app_content(where: { path: { _eq: $path }, is_deleted: { _eq: false } }) {
 			user_group_ids
 		}
 	}

--- a/src/admin/content/content.service.ts
+++ b/src/admin/content/content.service.ts
@@ -20,7 +20,7 @@ import {
 	TABLE_COLUMN_TO_DATABASE_ORDER_OBJECT,
 } from './content.const';
 import {
-	DELETE_CONTENT,
+	SOFT_DELETE_CONTENT,
 	DELETE_CONTENT_LABEL_LINKS,
 	GET_CONTENT_BY_ID,
 	GET_CONTENT_LABELS_BY_CONTENT_TYPE,
@@ -47,7 +47,7 @@ export class ContentService {
 			variables: {
 				limit,
 				orderBy: { title: 'asc' },
-				where: { is_public: { _eq: true } },
+				where: { is_public: { _eq: true }, is_deleted: { _eq: false } },
 			},
 		};
 
@@ -89,7 +89,11 @@ export class ContentService {
 			variables: {
 				limit: limit || null,
 				orderBy: { title: 'asc' },
-				where: { title: { _ilike: `%${title}%` }, is_public: { _eq: true } },
+				where: {
+					title: { _ilike: `%${title}%` },
+					is_public: { _eq: true },
+					is_deleted: { _eq: false },
+				},
 			},
 		};
 
@@ -584,7 +588,7 @@ export class ContentService {
 		try {
 			const response = await dataService.mutate({
 				variables: { id },
-				mutation: DELETE_CONTENT,
+				mutation: SOFT_DELETE_CONTENT,
 				update: ApolloCacheManager.clearContentCache,
 			});
 
@@ -594,7 +598,7 @@ export class ContentService {
 		} catch (err) {
 			throw new CustomError('Failed to delete content page from the database', err, {
 				id,
-				query: 'DELETE_CONTENT',
+				query: 'SOFT_DELETE_CONTENT',
 			});
 		}
 	}

--- a/src/admin/content/views/ContentDetail.tsx
+++ b/src/admin/content/views/ContentDetail.tsx
@@ -57,7 +57,7 @@ import {
 import { SpecialUserGroup } from '../../user-groups/user-group.const';
 import PublishContentPageModal from '../components/PublishContentPageModal';
 import { CONTENT_PATH, GET_CONTENT_DETAIL_TABS } from '../content.const';
-import { DELETE_CONTENT } from '../content.gql';
+import { SOFT_DELETE_CONTENT } from '../content.gql';
 import { ContentService } from '../content.service';
 import { ContentDetailParams, ContentPageInfo } from '../content.types';
 import { isPublic } from '../helpers/get-published-state';
@@ -89,7 +89,7 @@ const ContentDetail: FunctionComponent<ContentDetailProps> = ({ history, match, 
 	const [isPublishModalOpen, setIsPublishModalOpen] = useState<boolean>(false);
 	const [isOptionsMenuOpen, setIsOptionsMenuOpen] = useState<boolean>(false);
 
-	const [triggerContentDelete] = useMutation(DELETE_CONTENT);
+	const [triggerContentDelete] = useMutation(SOFT_DELETE_CONTENT);
 
 	const [currentTab, setCurrentTab, tabs] = useTabs(
 		GET_CONTENT_DETAIL_TABS(),

--- a/src/admin/content/views/ContentOverview.tsx
+++ b/src/admin/content/views/ContentOverview.tsx
@@ -158,6 +158,9 @@ const ContentOverview: FunctionComponent<ContentOverviewProps> = ({ history, use
 					// Add filter to only allow the content pages for which the user is the author
 					andFilters.push({ user_profile_id: { _eq: get(user, 'profile.id') } });
 				}
+
+				andFilters.push({ is_deleted: { _eq: false } });
+
 				return { _and: andFilters };
 			};
 

--- a/src/admin/users/user.gql.ts
+++ b/src/admin/users/user.gql.ts
@@ -2,7 +2,11 @@ import { gql } from 'apollo-boost';
 
 export const GET_USER_BY_ID = gql`
 	query getUserById($id: uuid!) {
-		users_profiles(offset: 0, limit: 1, where: { id: { _eq: $id } }) {
+		users_profiles(
+			offset: 0
+			limit: 1
+			where: { id: { _eq: $id }, is_deleted: { _eq: false } }
+		) {
 			id
 			user: usersByuserId {
 				uid
@@ -124,7 +128,7 @@ export const GET_PROFILE_IDS = gql`
 
 export const GET_PROFILE_NAMES = gql`
 	query getProfileNames($profileIds: [uuid!]!) {
-		users_profiles(where: { id: { _in: $profileIds } }) {
+		users_profiles(where: { id: { _in: $profileIds }, is_deleted: { _eq: false } }) {
 			id
 			user: usersByuserId {
 				id
@@ -157,7 +161,7 @@ export const GET_DISTINCT_BUSINESS_CATEGORIES = gql`
 	query getDistinctBusinessCategories {
 		users_profiles(
 			distinct_on: business_category
-			where: { business_category: { _is_null: false } }
+			where: { business_category: { _is_null: false }, is_deleted: { _eq: false } }
 		) {
 			business_category
 		}
@@ -175,27 +179,41 @@ export const GET_IDPS = gql`
 export const GET_CONTENT_COUNTS_FOR_USERS = gql`
 	query getContentCountsForUsers($profileIds: [uuid!]!) {
 		publicCollections: app_collections_aggregate(
-			where: { profile: { id: { _in: $profileIds } }, is_public: { _eq: true } }
+			where: {
+				profile: { id: { _in: $profileIds } }
+				is_public: { _eq: true }
+				is_deleted: { _eq: false }
+			}
 		) {
 			aggregate {
 				count
 			}
 		}
 		publicContentPages: app_content_aggregate(
-			where: { user_profile_id: { _in: $profileIds }, is_public: { _eq: true } }
+			where: {
+				user_profile_id: { _in: $profileIds }
+				is_public: { _eq: true }
+				is_deleted: { _eq: false }
+			}
 		) {
 			aggregate {
 				count
 			}
 		}
 		privateCollections: app_collections_aggregate(
-			where: { profile: { id: { _in: $profileIds } }, is_public: { _eq: false } }
+			where: {
+				profile: { id: { _in: $profileIds } }
+				is_public: { _eq: false }
+				is_deleted: { _eq: false }
+			}
 		) {
 			aggregate {
 				count
 			}
 		}
-		assignments: app_assignments_aggregate(where: { owner_profile_id: { _in: $profileIds } }) {
+		assignments: app_assignments_aggregate(
+			where: { owner_profile_id: { _in: $profileIds }, is_deleted: { _eq: false } }
+		) {
 			aggregate {
 				count
 			}
@@ -213,7 +231,11 @@ export const GET_CONTENT_COUNTS_FOR_USERS = gql`
 			}
 		}
 		privateContentPages: app_content_aggregate(
-			where: { user_profile_id: { _in: $profileIds }, is_public: { _eq: false } }
+			where: {
+				user_profile_id: { _in: $profileIds }
+				is_public: { _eq: false }
+				is_deleted: { _eq: false }
+			}
 		) {
 			aggregate {
 				count

--- a/src/admin/users/user.service.ts
+++ b/src/admin/users/user.service.ts
@@ -254,7 +254,7 @@ export class UserService {
 				transferToProfileId,
 			};
 			const response = await fetchWithLogout(url, {
-				method: 'POST',
+				method: 'DELETE',
 				headers: {
 					'Content-Type': 'application/json',
 				},

--- a/src/admin/users/user.service.ts
+++ b/src/admin/users/user.service.ts
@@ -19,12 +19,15 @@ import {
 	GET_IDPS,
 	GET_PROFILE_IDS,
 	GET_PROFILE_NAMES,
-	GET_USERS,
 	GET_USER_BY_ID,
+	GET_USERS,
 } from './user.gql';
 import {
+	BulkBlockUsersBody,
+	BulkDeleteUsersBody,
 	DeleteContentCounts,
 	DeleteContentCountsRaw,
+	UserDeleteOption,
 	UserOverviewTableCol,
 	UserSummeryView,
 } from './user.types';
@@ -206,16 +209,17 @@ export class UserService {
 		let url: string | undefined;
 		try {
 			url = `${getEnv('PROXY_URL')}/user/bulk-block`;
+			const body: BulkBlockUsersBody = {
+				profileIds,
+				isBlocked,
+			};
 			const response = await fetchWithLogout(url, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
 				},
 				credentials: 'include',
-				body: JSON.stringify({
-					profileIds,
-					isBlocked,
-				}),
+				body: JSON.stringify(body),
 			});
 
 			if (response.status < 200 || response.status >= 400) {
@@ -233,6 +237,43 @@ export class UserService {
 					isBlocked,
 				}
 			);
+		}
+	}
+
+	static async bulkDeleteUsers(
+		profileIds: string[],
+		deleteOption: UserDeleteOption,
+		transferToProfileId?: string
+	): Promise<void> {
+		let url: string | undefined;
+		try {
+			url = `${getEnv('PROXY_URL')}/user/bulk-delete`;
+			const body: BulkDeleteUsersBody = {
+				profileIds,
+				deleteOption,
+				transferToProfileId,
+			};
+			const response = await fetchWithLogout(url, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify(body),
+			});
+
+			if (response.status < 200 || response.status >= 400) {
+				throw new CustomError('Status code was unexpected', null, {
+					response,
+				});
+			}
+		} catch (err) {
+			throw new CustomError('Failed to bulk delete users from the database', err, {
+				url,
+				profileIds,
+				deleteOption,
+				transferToProfileId,
+			});
 		}
 	}
 

--- a/src/admin/users/user.types.ts
+++ b/src/admin/users/user.types.ts
@@ -61,12 +61,26 @@ export interface RawPermission {
 
 export type UserBulkAction = 'block' | 'unblock' | 'delete' | 'change_subjects' | 'export';
 
+// TODO use types from typings library after update to v2.27.0
 export type UserDeleteOption =
 	| 'DELETE_PRIVATE_KEEP_NAME'
 	| 'TRANSFER_PUBLIC'
 	| 'TRANSFER_ALL'
 	| 'ANONYMIZE_PUBLIC'
 	| 'DELETE_ALL';
+
+// TODO use types from typings library after update to v2.27.0
+export interface BulkDeleteUsersBody {
+	profileIds: string[];
+	deleteOption: UserDeleteOption;
+	transferToProfileId?: string;
+}
+
+// TODO use types from typings library after update to v2.27.0
+export interface BulkBlockUsersBody {
+	profileIds: string[];
+	isBlocked: boolean;
+}
 
 export interface DeleteContentCounts {
 	publicCollections: number;

--- a/src/admin/users/views/UserDetail.tsx
+++ b/src/admin/users/views/UserDetail.tsx
@@ -242,7 +242,7 @@ const UserDetail: FunctionComponent<UserDetailProps> = ({ history, match, user }
 			return;
 		}
 
-		const userGroup: RawUserGroup = get(storedProfile, 'profile_user_group.group', []);
+		const userGroup: RawUserGroup = get(storedProfile, 'profile_user_group.group');
 
 		return (
 			<Container mode="vertical" size="small">
@@ -270,13 +270,17 @@ const UserDetail: FunctionComponent<UserDetailProps> = ({ history, match, user }
 								],
 							])}
 							{renderDetailRow(
-								<Link
-									to={buildLink(ADMIN_PATH.USER_GROUP_DETAIL, {
-										id: userGroup.id,
-									})}
-								>
-									{userGroup.label}
-								</Link>,
+								!!userGroup ? (
+									<Link
+										to={buildLink(ADMIN_PATH.USER_GROUP_DETAIL, {
+											id: userGroup.id,
+										})}
+									>
+										{userGroup.label}
+									</Link>
+								) : (
+									'-'
+								),
 								t('admin/users/views/user-detail___gebruikersgroep')
 							)}
 							{renderDateDetailRows(storedProfile, [
@@ -309,42 +313,55 @@ const UserDetail: FunctionComponent<UserDetailProps> = ({ history, match, user }
 								],
 							])}
 							{renderDetailRow(
-								idpMapsToTagList(user.idpmaps, 'idps'),
+								idpMapsToTagList(get(storedProfile, 'user.idpmaps', []), 'idps') ||
+									'-',
 								t('admin/users/views/user-detail___gelinked-aan')
 							)}
 							{renderDetailRow(
 								stringsToTagList(
 									get(storedProfile, 'profile_classifications', [] as any[]),
 									'key'
-								),
+								) || '-',
 								t('admin/users/views/user-detail___vakken')
 							)}
 							{renderDetailRow(
-								<TagList
-									tags={get(storedProfile, 'profile_contexts', [] as any[]).map(
-										(educationLevel: { key: string }): TagOption => ({
-											id: educationLevel.key,
-											label: educationLevel.key,
-										})
-									)}
-									swatches={false}
-									closable={false}
-								/>,
+								get(storedProfile, 'profile_contexts', [] as any[]).length ? (
+									<TagList
+										tags={get(
+											storedProfile,
+											'profile_contexts',
+											[] as any[]
+										).map(
+											(educationLevel: { key: string }): TagOption => ({
+												id: educationLevel.key,
+												label: educationLevel.key,
+											})
+										)}
+										swatches={false}
+										closable={false}
+									/>
+								) : (
+									'-'
+								),
 								t('admin/users/views/user-detail___opleidingsniveaus')
 							)}
 							{renderDetailRow(
-								<TagList
-									closable={false}
-									swatches={false}
-									tags={eduOrgNames.map((eduOrgName) => ({
-										label: eduOrgName,
-										id: eduOrgName,
-									}))}
-								/>,
+								!!eduOrgNames.length ? (
+									<TagList
+										closable={false}
+										swatches={false}
+										tags={eduOrgNames.map((eduOrgName) => ({
+											label: eduOrgName,
+											id: eduOrgName,
+										}))}
+									/>
+								) : (
+									''
+								),
 								t('admin/users/views/user-detail___educatieve-organisaties')
 							)}
 							{renderDetailRow(
-								get(storedProfile, 'organisation.name'),
+								get(storedProfile, 'organisation.name', '-'),
 								t('admin/users/views/user-detail___bedrijf')
 							)}
 						</tbody>

--- a/src/admin/users/views/UserOverview.tsx
+++ b/src/admin/users/views/UserOverview.tsx
@@ -770,9 +770,7 @@ const UserOverview: FunctionComponent<UserOverviewProps & RouteComponentProps & 
 					isLoading={isLoading}
 					showCheckboxes
 					selectedItems={selectedProfileIds}
-					onSelectionChanged={(newSelectedProfileIds) => {
-						setSelectedProfileIds(newSelectedProfileIds);
-					}}
+					onSelectionChanged={setSelectedProfileIds}
 					onSelectAll={setAllProfilesAsSelected}
 					onSelectBulkAction={handleBulkAction as any}
 					bulkActions={GET_USER_BULK_ACTIONS(user)}

--- a/src/admin/users/views/UserOverview.tsx
+++ b/src/admin/users/views/UserOverview.tsx
@@ -213,6 +213,8 @@ const UserOverview: FunctionComponent<UserOverviewProps & RouteComponentProps & 
 			if (!isNil(filters.stamboek)) {
 				andFilters.push({ stamboek: { _is_null: !filters.stamboek } });
 			}
+			// TODO wait for is_deleted to be added to the users_summary_view
+			// andFilters.push({ profile: { is_deleted: { _eq: false } } });
 
 			return { _and: andFilters };
 		},
@@ -464,8 +466,20 @@ const UserOverview: FunctionComponent<UserOverviewProps & RouteComponentProps & 
 		setTransferToUser(null);
 	};
 
-	const handleDeleteUsers = () => {
-		ToastService.info('Nog niet geïmplementeerd');
+	const handleDeleteUsers = async () => {
+		try {
+			setDeleteConfirmModalOpen(false);
+			await UserService.bulkDeleteUsers(
+				selectedProfileIds,
+				selectedDeleteOption,
+				transferToUser?.value
+			);
+			await fetchProfiles();
+			ToastService.success(t('De geselecteerde gebruikers zijn verwijderd'));
+		} catch (err) {
+			console.error(new CustomError('Failed to remove users', err));
+			ToastService.danger(t('Het verwijderen van de geselecteerde gebruikers is mislukt'));
+		}
 	};
 
 	const validateOptionModalAndOpenConfirm = async () => {
@@ -749,12 +763,16 @@ const UserOverview: FunctionComponent<UserOverviewProps & RouteComponentProps & 
 						'admin/users/views/user-overview___er-zijn-geen-gebruikers-doe-voldoen-aan-de-opgegeven-filters'
 					)}
 					itemsPerPage={ITEMS_PER_PAGE}
-					onTableStateChanged={setTableState}
+					onTableStateChanged={(newTableState) => {
+						setTableState(newTableState);
+					}}
 					renderNoResults={renderNoResults}
 					isLoading={isLoading}
 					showCheckboxes
 					selectedItems={selectedProfileIds}
-					onSelectionChanged={setSelectedProfileIds}
+					onSelectionChanged={(newSelectedProfileIds) => {
+						setSelectedProfileIds(newSelectedProfileIds);
+					}}
 					onSelectAll={setAllProfilesAsSelected}
 					onSelectBulkAction={handleBulkAction as any}
 					bulkActions={GET_USER_BULK_ACTIONS(user)}

--- a/src/collection/collection.gql.ts
+++ b/src/collection/collection.gql.ts
@@ -3,7 +3,7 @@ import { gql } from 'apollo-boost';
 // TODO: Reduce to only what we need.
 export const GET_COLLECTION_BY_ID = gql`
 	query getCollectionById($id: uuid!) {
-		app_collections(where: { id: { _eq: $id } }) {
+		app_collections(where: { id: { _eq: $id }, is_deleted: { _eq: false } }) {
 			id
 			description
 			description_long
@@ -109,7 +109,10 @@ export const GET_COLLECTION_BY_ID = gql`
 
 export const UPDATE_COLLECTION = gql`
 	mutation updateCollectionById($id: uuid!, $collection: app_collections_set_input!) {
-		update_app_collections(where: { id: { _eq: $id } }, _set: $collection) {
+		update_app_collections(
+			where: { id: { _eq: $id }, is_deleted: { _eq: false } }
+			_set: $collection
+		) {
 			affected_rows
 		}
 	}
@@ -130,9 +133,9 @@ export const INSERT_COLLECTION = gql`
 	}
 `;
 
-export const DELETE_COLLECTION = gql`
-	mutation deleteCollectionById($id: uuid!) {
-		delete_app_collections(where: { id: { _eq: $id } }) {
+export const SOFT_DELETE_COLLECTION = gql`
+	mutation softDeleteCollectionById($id: uuid!) {
+		update_app_collections(where: { id: { _eq: $id } }, _set: { is_deleted: true }) {
 			affected_rows
 		}
 	}
@@ -180,7 +183,11 @@ export const GET_COLLECTIONS_BY_OWNER = gql`
 		$order: [app_collections_order_by!] = { updated_at: desc }
 	) {
 		app_collections(
-			where: { type_id: { _eq: $type_id }, owner_profile_id: { _eq: $owner_profile_id } }
+			where: {
+				type_id: { _eq: $type_id }
+				owner_profile_id: { _eq: $owner_profile_id }
+				is_deleted: { _eq: false }
+			}
 			offset: $offset
 			limit: $limit
 			order_by: $order
@@ -244,7 +251,11 @@ export const GET_PUBLIC_COLLECTIONS = gql`
 	query getCollections($limit: Int!, $typeId: Int!) {
 		app_collections(
 			order_by: { title: asc }
-			where: { type_id: { _eq: $typeId }, is_public: { _eq: true } }
+			where: {
+				type_id: { _eq: $typeId }
+				is_public: { _eq: true }
+				is_deleted: { _eq: false }
+			}
 			limit: $limit
 		) {
 			id
@@ -257,7 +268,12 @@ export const GET_PUBLIC_COLLECTIONS_BY_ID = gql`
 	query getCollections($id: uuid!, $typeId: Int!, $limit: Int!) {
 		app_collections(
 			order_by: { title: asc }
-			where: { type_id: { _eq: $typeId }, id: { _eq: $id }, is_public: { _eq: true } }
+			where: {
+				type_id: { _eq: $typeId }
+				id: { _eq: $id }
+				is_public: { _eq: true }
+				is_deleted: { _eq: false }
+			}
 			limit: $limit
 		) {
 			id
@@ -274,6 +290,7 @@ export const GET_PUBLIC_COLLECTIONS_BY_TITLE = gql`
 				type_id: { _eq: $typeId }
 				title: { _ilike: $title }
 				is_public: { _eq: true }
+				is_deleted: { _eq: false }
 			}
 			limit: $limit
 		) {
@@ -286,7 +303,11 @@ export const GET_PUBLIC_COLLECTIONS_BY_TITLE = gql`
 export const GET_COLLECTION_TITLES_BY_OWNER = gql`
 	query getCollectionNamesByOwner($owner_profile_id: uuid) {
 		app_collections(
-			where: { type_id: { _eq: 3 }, owner_profile_id: { _eq: $owner_profile_id } }
+			where: {
+				type_id: { _eq: 3 }
+				owner_profile_id: { _eq: $owner_profile_id }
+				is_deleted: { _eq: false }
+			}
 			order_by: { updated_at: desc }
 		) {
 			id
@@ -298,7 +319,11 @@ export const GET_COLLECTION_TITLES_BY_OWNER = gql`
 export const GET_BUNDLE_TITLES_BY_OWNER = gql`
 	query getCollectionNamesByOwner($owner_profile_id: uuid) {
 		app_collections(
-			where: { type_id: { _eq: 4 }, owner_profile_id: { _eq: $owner_profile_id } }
+			where: {
+				type_id: { _eq: 4 }
+				owner_profile_id: { _eq: $owner_profile_id }
+				is_deleted: { _eq: false }
+			}
 			order_by: { updated_at: desc }
 		) {
 			id
@@ -310,7 +335,11 @@ export const GET_BUNDLE_TITLES_BY_OWNER = gql`
 export const GET_BUNDLES_CONTAINING_COLLECTION = gql`
 	query getPublishedBundlesContainingCollection($id: String!) {
 		app_collections(
-			where: { is_public: { _eq: true }, collection_fragments: { external_id: { _eq: $id } } }
+			where: {
+				is_public: { _eq: true }
+				collection_fragments: { external_id: { _eq: $id } }
+				is_deleted: { _eq: false }
+			}
 		) {
 			id
 			title
@@ -381,7 +410,12 @@ export const GET_COLLECTION_BY_TITLE_OR_DESCRIPTION = gql`
 
 export const GET_COLLECTIONS_BY_FRAGMENT_ID = gql`
 	query getCollectionsByItemUuid($fragmentId: String!) {
-		app_collections(where: { collection_fragments: { external_id: { _eq: $fragmentId } } }) {
+		app_collections(
+			where: {
+				collection_fragments: { external_id: { _eq: $fragmentId } }
+				is_deleted: { _eq: false }
+			}
+		) {
 			id
 			title
 			is_public

--- a/src/collection/collection.service.ts
+++ b/src/collection/collection.service.ts
@@ -16,7 +16,7 @@ import { VideoStillService } from '../shared/services/video-stills-service';
 import i18n from '../shared/translations/i18n';
 
 import {
-	DELETE_COLLECTION,
+	SOFT_DELETE_COLLECTION,
 	DELETE_COLLECTION_FRAGMENT,
 	DELETE_COLLECTION_LABELS,
 	GET_BUNDLE_TITLES_BY_OWNER,
@@ -358,7 +358,7 @@ export class CollectionService {
 		try {
 			// delete collection by id
 			await dataService.mutate({
-				mutation: DELETE_COLLECTION,
+				mutation: SOFT_DELETE_COLLECTION,
 				variables: {
 					id: collectionId,
 				},

--- a/src/collection/components/CollectionOrBundleEdit.tsx
+++ b/src/collection/components/CollectionOrBundleEdit.tsx
@@ -455,7 +455,8 @@ const CollectionOrBundleEdit: FunctionComponent<
 		if (collectionState.currentCollection) {
 			const newCollection = await CollectionService.updateCollection(
 				collectionState.initialCollection,
-				updatedCollection as Partial<Avo.Collection.Collection>
+				updatedCollection as Partial<Avo.Collection.Collection>,
+				user
 			);
 
 			if (newCollection) {
@@ -511,7 +512,8 @@ const CollectionOrBundleEdit: FunctionComponent<
 			// Immediately store the new name, without the user having to click the save button twice
 			const newCollection = await CollectionService.updateCollection(
 				collectionState.initialCollection,
-				collectionWithNewName
+				collectionWithNewName,
+				user
 			);
 
 			if (newCollection) {

--- a/src/collection/components/CollectionOrBundleOverview.tsx
+++ b/src/collection/components/CollectionOrBundleOverview.tsx
@@ -43,7 +43,7 @@ import { truncateTableValue } from '../../shared/helpers/truncate';
 import { ApolloCacheManager, ToastService } from '../../shared/services';
 import { trackEvents } from '../../shared/services/event-logging-service';
 import { ITEMS_PER_PAGE } from '../../workspace/workspace.const';
-import { DELETE_COLLECTION } from '../collection.gql';
+import { SOFT_DELETE_COLLECTION } from '../collection.gql';
 import { CollectionService } from '../collection.service';
 import { ContentTypeNumber, toDutchContentType } from '../collection.types';
 
@@ -79,7 +79,7 @@ const CollectionOrBundleOverview: FunctionComponent<CollectionOrBundleOverviewPr
 	const [page, setPage] = useState<number>(0);
 
 	// Mutations
-	const [triggerCollectionDelete] = useMutation(DELETE_COLLECTION);
+	const [triggerCollectionDelete] = useMutation(SOFT_DELETE_COLLECTION);
 
 	// Listeners
 	const onClickDelete = (collectionId: string) => {

--- a/src/shared/helpers/idps-to-taglist.tsx
+++ b/src/shared/helpers/idps-to-taglist.tsx
@@ -14,13 +14,16 @@ export const IDP_COLORS: { [idp in Avo.Auth.IdpType]: string } = {
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 export function idpMapsToTagList(
-	ipdMaps: Avo.Auth.IdpType[],
+	idpMaps: Avo.Auth.IdpType[],
 	key: string,
 	onTagClicked: (tagId: ReactText) => void = noop
 ) {
+	if (!idpMaps || !idpMaps.length) {
+		return null;
+	}
 	return (
 		<TagList
-			tags={ipdMaps.map(
+			tags={idpMaps.map(
 				(idpMap: Avo.Auth.IdpType): TagOption => {
 					return {
 						color: IDP_COLORS[idpMap],

--- a/src/shared/services/organizations-service.gql.ts
+++ b/src/shared/services/organizations-service.gql.ts
@@ -28,7 +28,7 @@ export const GET_USERS_IN_COMPANY = gql`
 	query getUsersByCompanyId($companyId: String!) {
 		users_profiles(
 			order_by: { usersByuserId: { first_name: asc } }
-			where: { company_id: { _eq: $companyId } }
+			where: { company_id: { _eq: $companyId }, is_deleted: { _eq: false } }
 		) {
 			id
 			user: usersByuserId {

--- a/src/workspace/workspace.gql.ts
+++ b/src/workspace/workspace.gql.ts
@@ -3,21 +3,33 @@ import { gql } from 'apollo-boost';
 export const GET_WORKSPACE_TAB_COUNTS = gql`
 	query getWorkspaceTabCounts($owner_profile_id: uuid) {
 		collection_counts: app_collections_aggregate(
-			where: { owner_profile_id: { _eq: $owner_profile_id }, type_id: { _eq: 3 } }
+			where: {
+				owner_profile_id: { _eq: $owner_profile_id }
+				type_id: { _eq: 3 }
+				is_deleted: { _eq: false }
+			}
 		) {
 			aggregate {
 				count
 			}
 		}
 		bundle_counts: app_collections_aggregate(
-			where: { owner_profile_id: { _eq: $owner_profile_id }, type_id: { _eq: 4 } }
+			where: {
+				owner_profile_id: { _eq: $owner_profile_id }
+				type_id: { _eq: 4 }
+				is_deleted: { _eq: false }
+			}
 		) {
 			aggregate {
 				count
 			}
 		}
 		assignment_counts: app_assignments_aggregate(
-			where: { owner_profile_id: { _eq: $owner_profile_id }, is_archived: { _eq: false } }
+			where: {
+				owner_profile_id: { _eq: $owner_profile_id }
+				is_archived: { _eq: false }
+				is_deleted: { _eq: false }
+			}
 		) {
 			aggregate {
 				count


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1343

proxy PR: https://github.com/viaacode/avo2-proxy/pull/286

De gebruiker verdwijnt momenteel nog niet uit de lijst aangezien bart maandag nog de is_deleted property toevoegt aan de benodigde view:
https://github.com/viaacode/avo2-client/pull/1143/files#diff-68ccf6700a4dc412197a969c1948398a5fa4d5efe144198644eb21b82dc714f1R216-R217

Link delete ui to backend route
add soft delete where clause to all content queries:
is_deleted: false

for tables:
* users_profiles
* shared_users
* app_collections
* app_assignments
* app_content

![image](https://user-images.githubusercontent.com/1710840/101932075-92fe9800-3bda-11eb-8c68-cf843d1855fd.png)
