### PR TITLE
fix(redirects): never redirect a user back to an error page after login

### DIFF
--- a/src/authentication/helpers/redirects.ts
+++ b/src/authentication/helpers/redirects.ts
@@ -176,7 +176,7 @@ export function getRedirectAfterLogin(
 
 	const base = getBaseUrl(location);
 	const from = getFromPath(location, defaultPath);
-	if (from === '/') {
+	if (from === '/' || from.startsWith('/error')) {
 		return `${base}${defaultPath}`;
 	}
 	return `${base}${from}${location.hash || ''}${queryString.stringify(


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1461

proxy PR: https://github.com/viaacode/avo2-proxy/pull/289

This mainly fixes this scenario:
* getest met ineke.vandam+1
* via acm AVO app verwijderd+syncen
* aanmelden lukt niet op avo
* via acm AVO app terug toevoegen + syncen
* aanmelden lukt niet op avo