### PR TITLE
fix(data-service): fetch graphql data without types

### DIFF
--- a/src/shared/services/data-service.ts
+++ b/src/shared/services/data-service.ts
@@ -6,7 +6,9 @@ import { get } from 'lodash-es';
 import { getEnv } from '../helpers';
 import { goToLoginBecauseOfUnauthorizedError } from '../helpers/fetch-with-logout';
 
-const cache = new InMemoryCache();
+const cache = new InMemoryCache({
+	addTypename: false,
+});
 const httpLink = new HttpLink({ uri: `${getEnv('PROXY_URL')}/data`, credentials: 'include' });
 
 const logoutMiddleware = onError(({ networkError }) => {


### PR DESCRIPTION
so we can replace these queries with the same query from the whitelist. This way we avoid any tampering with the query on the client or during transit to the server