### PR TITLE
fix(media-grid): fix issue with media grid fetching collections

### DIFF
--- a/src/admin/collectionsOrBundles/collections-or-bundles.gql.ts
+++ b/src/admin/collectionsOrBundles/collections-or-bundles.gql.ts
@@ -57,7 +57,7 @@ export const GET_COLLECTIONS = gql`
 `;
 
 export const GET_COLLECTION_IDS = gql`
-	query getCollections($where: app_collections_bool_exp!) {
+	query getCollectionsByIds($where: app_collections_bool_exp!) {
 		app_collections(where: $where) {
 			id
 		}

--- a/src/collection/collection.gql.ts
+++ b/src/collection/collection.gql.ts
@@ -248,7 +248,7 @@ export const GET_COLLECTIONS_BY_OWNER = gql`
 `;
 
 export const GET_PUBLIC_COLLECTIONS = gql`
-	query getCollections($limit: Int!, $typeId: Int!) {
+	query getPublicCollections($limit: Int!, $typeId: Int!) {
 		app_collections(
 			order_by: { title: asc }
 			where: {
@@ -265,7 +265,7 @@ export const GET_PUBLIC_COLLECTIONS = gql`
 `;
 
 export const GET_PUBLIC_COLLECTIONS_BY_ID = gql`
-	query getCollections($id: uuid!, $typeId: Int!, $limit: Int!) {
+	query getPublicCollectionsById($id: uuid!, $typeId: Int!, $limit: Int!) {
 		app_collections(
 			order_by: { title: asc }
 			where: {
@@ -283,7 +283,7 @@ export const GET_PUBLIC_COLLECTIONS_BY_ID = gql`
 `;
 
 export const GET_PUBLIC_COLLECTIONS_BY_TITLE = gql`
-	query getCollections($title: String!, $typeId: Int!, $limit: Int!) {
+	query getPublicCollectionsByTitle($title: String!, $typeId: Int!, $limit: Int!) {
 		app_collections(
 			order_by: { title: asc }
 			where: {

--- a/src/shared/services/content-page-service.ts
+++ b/src/shared/services/content-page-service.ts
@@ -48,7 +48,7 @@ export class ContentPageService {
 	}
 
 	public static async resolveMediaItems(
-		searchQuery: string | undefined,
+		searchQuery: string | null,
 		searchQueryLimit: number | undefined,
 		mediaItems:
 			| {


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1482

proxy PR: https://github.com/viaacode/avo2-proxy/pull/291

This fixes 2 issues with media grids:
* multiple queries had the same name, causing the whitelisting in the proxy to check the wrong permissions
* when manually selecting tiles for the media grid the grid did not re-render, so you wouldn't see your changes until you saved an reloaded.


![image](https://user-images.githubusercontent.com/1710840/103539358-32d8da00-4e98-11eb-973c-dc267f05c370.png)
