### PR TITLE
feat(smartlink): trigger analytics events to SmartSchool when inside iframe

### DIFF
--- a/src/admin/content-block/components/wrappers/MediaPlayerTitleTextButtonWrapper/MediaPlayerTitleTextButtonWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/MediaPlayerTitleTextButtonWrapper/MediaPlayerTitleTextButtonWrapper.tsx
@@ -28,8 +28,10 @@ interface MediaPlayerTitleTextButtonWrapperProps {
 	mediaSrc?: string;
 	mediaPoster?: string;
 	mediaTitle: string;
+	mediaExternalId: string;
 	mediaIssued?: string;
 	mediaOrganisation?: Avo.Organization.Organization;
+	mediaDuration?: string;
 	mediaAutoplay?: boolean;
 	headingType: HeadingTypeOption;
 	headingTitle: string;
@@ -48,8 +50,10 @@ export const MediaPlayerTitleTextButtonWrapper: FC<
 	mediaSrc,
 	mediaPoster,
 	mediaTitle,
+	mediaExternalId,
 	mediaIssued,
 	mediaOrganisation,
+	mediaDuration,
 	headingTitle,
 	headingType,
 	content,
@@ -71,6 +75,8 @@ export const MediaPlayerTitleTextButtonWrapper: FC<
 				<MediaPlayerWrapper
 					item={mediaItem}
 					title={mediaTitle}
+					external_id={mediaExternalId}
+					duration={mediaDuration}
 					autoplay={mediaAutoplay}
 					src={mediaSrc}
 					poster={mediaPoster}

--- a/src/admin/content-block/components/wrappers/MediaPlayerWrapper/MediaPlayerWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/MediaPlayerWrapper/MediaPlayerWrapper.tsx
@@ -20,6 +20,8 @@ interface MediaPlayerWrapperProps {
 	src?: string;
 	poster?: string;
 	title: string;
+	external_id?: string;
+	duration?: string;
 	annotationTitle?: string;
 	annotationText?: string;
 	issued?: string;
@@ -33,6 +35,8 @@ const MediaPlayerWrapper: FunctionComponent<MediaPlayerWrapperProps> = ({
 	src,
 	poster,
 	title,
+	external_id,
+	duration,
 	annotationTitle,
 	annotationText,
 	issued,
@@ -104,6 +108,9 @@ const MediaPlayerWrapper: FunctionComponent<MediaPlayerWrapperProps> = ({
 					}
 					src={src}
 					poster={videoStill}
+					external_id={external_id || get(mediaItem, 'external_id')}
+					duration={duration || get(mediaItem, 'duration')}
+					title={title || get(mediaItem, 'title')}
 					organisationName={get(organisation || get(mediaItem, 'organisation'), 'name')}
 					organisationLogo={get(
 						organisation || get(mediaItem, 'organisation'),

--- a/src/authentication/helpers/redirects.ts
+++ b/src/authentication/helpers/redirects.ts
@@ -135,6 +135,16 @@ export function redirectToExternalPage(link: string, target: '_blank' | string |
 	}
 }
 
+export function toAbsoluteUrl(link: string): string {
+	if (link.includes('//')) {
+		return link;
+	}
+	if (link.startsWith('www')) {
+		return `//${link}`;
+	}
+	return `${trimEnd(window.location.origin, '/')}/${trimStart(link, '/')}`;
+}
+
 export function getBaseUrl(location: Location): string {
 	if (location.pathname === '/') {
 		return trimEnd(window.location.href, '/');

--- a/src/collection/components/fragment/FragmentEdit.tsx
+++ b/src/collection/components/fragment/FragmentEdit.tsx
@@ -373,6 +373,9 @@ const FragmentEdit: FunctionComponent<FragmentEditProps & UserProps> = ({
 										poster={
 											fragment.thumbnail_path || itemMetaData.thumbnail_path
 										}
+										external_id={itemMetaData.external_id}
+										duration={itemMetaData.duration}
+										title={itemMetaData.title}
 										cuePoints={{
 											start: fragment.start_oc,
 											end: fragment.end_oc,

--- a/src/collection/components/modals/CutFragmentModal.tsx
+++ b/src/collection/components/modals/CutFragmentModal.tsx
@@ -203,6 +203,9 @@ const CutFragmentModal: FunctionComponent<CutFragmentModalProps> = ({
 						...itemMetaData,
 						thumbnail_path: fragment.thumbnail_path || itemMetaData.thumbnail_path,
 					}}
+					external_id={itemMetaData.external_id}
+					duration={itemMetaData.duration}
+					title={itemMetaData.title}
 					seekTime={fragmentStart}
 					cuePoints={{
 						start: fragmentStart,

--- a/src/item/components/ItemVideoDescription.tsx
+++ b/src/item/components/ItemVideoDescription.tsx
@@ -153,6 +153,9 @@ const ItemVideoDescription: FunctionComponent<ItemVideoDescriptionProps & RouteC
 				cuePoints={cuePoints}
 				seekTime={time}
 				onPlay={onPlay}
+				external_id={itemMetaData.external_id}
+				duration={itemMetaData.duration}
+				title={title}
 			/>
 		);
 	};

--- a/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.tsx
+++ b/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.tsx
@@ -13,6 +13,7 @@ import withUser, { UserProps } from '../../hocs/withUser';
 import { BookmarksViewsPlaysService, ToastService } from '../../services';
 import { trackEvents } from '../../services/event-logging-service';
 import { fetchPlayerTicket } from '../../services/player-ticket-service';
+import { SmartschoolAnalyticsService } from '../../services/smartschool-analytics-service';
 
 import './FlowPlayerWrapper.scss';
 
@@ -25,6 +26,9 @@ type FlowPlayerWrapperProps = {
 	item?: Avo.Item.Item;
 	src?: string;
 	poster?: string;
+	external_id?: string;
+	title?: string;
+	duration?: string;
 	organisationName?: string;
 	organisationLogo?: string;
 	issuedDate?: string;
@@ -110,6 +114,12 @@ const FlowPlayerWrapper: FunctionComponent<FlowPlayerWrapperProps & UserProps> =
 			}
 			setTriggeredForUrl(src || null);
 		}
+
+		SmartschoolAnalyticsService.triggerVideoPlayEvent(
+			props.title || get(item, 'title'),
+			props.external_id || get(item, 'external_id'),
+			toSeconds(props.duration || get(item, 'duration'), true) || undefined
+		);
 	};
 
 	const handlePosterClicked = () => {

--- a/src/shared/components/SmartLink/SmartLink.tsx
+++ b/src/shared/components/SmartLink/SmartLink.tsx
@@ -6,22 +6,30 @@ import { Link } from 'react-router-dom';
 
 import { ButtonAction, ContentPickerType, LinkTarget } from '@viaa/avo2-components';
 
+import { toAbsoluteUrl } from '../../../authentication/helpers/redirects';
 import { BUNDLE_PATH } from '../../../bundle/bundle.const';
 import { APP_PATH } from '../../../constants';
 import { buildLink, getEnv } from '../../helpers';
 import { insideIframe } from '../../helpers/inside-iframe';
+import { SmartschoolAnalyticsService } from '../../services/smartschool-analytics-service';
 
 export interface SmartLinkProps {
 	action?: ButtonAction | null;
 	removeStyles?: boolean;
+	label?: string;
 	children: ReactNode;
 }
 
 const SmartLink: FunctionComponent<SmartLinkProps> = ({
 	action,
 	removeStyles = true,
+	label,
 	children,
 }) => {
+	const handleAdditionalTriggers = (url: string) => {
+		SmartschoolAnalyticsService.triggerUrlEvent(toAbsoluteUrl(url), label);
+	};
+
 	const renderLink = (
 		url: string,
 		target: LinkTarget = LinkTarget.Self
@@ -41,6 +49,7 @@ const SmartLink: FunctionComponent<SmartLinkProps> = ({
 							href={fullUrl}
 							target="_self"
 							className={classnames({ 'a-link__no-styles': removeStyles })}
+							onClick={() => handleAdditionalTriggers(fullUrl)}
 						>
 							{children}
 						</a>
@@ -51,6 +60,7 @@ const SmartLink: FunctionComponent<SmartLinkProps> = ({
 					<Link
 						to={fullUrl}
 						className={classnames({ 'a-link__no-styles': removeStyles })}
+						onClick={() => handleAdditionalTriggers(fullUrl)}
 					>
 						{children}
 					</Link>
@@ -67,6 +77,7 @@ const SmartLink: FunctionComponent<SmartLinkProps> = ({
 							target="_blank"
 							rel="noopener noreferrer"
 							className={classnames({ 'a-link__no-styles': removeStyles })}
+							onClick={() => handleAdditionalTriggers(fullUrl)}
 						>
 							{children}
 						</a>
@@ -79,6 +90,7 @@ const SmartLink: FunctionComponent<SmartLinkProps> = ({
 						target="_blank"
 						rel="noopener noreferrer"
 						className={classnames({ 'a-link__no-styles': removeStyles })}
+						onClick={() => handleAdditionalTriggers(fullUrl)}
 					>
 						{children}
 					</a>

--- a/src/shared/helpers/link.tsx
+++ b/src/shared/helpers/link.tsx
@@ -119,9 +119,14 @@ export function navigateToAbsoluteOrRelativeUrl(
 
 export const generateSmartLink = (
 	action: ButtonAction | null | undefined,
-	children: ReactNode
+	children: ReactNode,
+	label?: string
 ): ReactElement<any, any> | null => {
-	return <SmartLink action={action}>{children}</SmartLink>;
+	return (
+		<SmartLink action={action} label={label}>
+			{children}
+		</SmartLink>
+	);
 };
 
 export const navigateToContentType = (action: ButtonAction, history: History) => {

--- a/src/shared/services/smartschool-analytics-service.ts
+++ b/src/shared/services/smartschool-analytics-service.ts
@@ -1,0 +1,73 @@
+import { CustomError } from '../helpers';
+import { insideIframe } from '../helpers/inside-iframe';
+
+export class SmartschoolAnalyticsService {
+	/**
+	 * Notify parent frame that link was clicked. This is custom code for Smartschool analytics
+	 * https://meemoo.atlassian.net/browse/AVO-1471
+	 * @param url
+	 * @param title
+	 */
+	public static triggerUrlEvent(url: string, title?: string): void {
+		let message: any | undefined;
+		try {
+			if (insideIframe()) {
+				message = {
+					event: 'link',
+					metadata: {
+						click: {
+							title,
+							url,
+							type: 'outbound',
+						},
+					},
+				};
+				window.parent.postMessage(message, '*');
+				console.info('posted message to parent frame: ', message);
+			}
+		} catch (err) {
+			console.error(
+				new CustomError('Failed to notify parent frame of link being clicked', err, {
+					message,
+				})
+			);
+		}
+	}
+
+	/**
+	 * Notify parent frame that movie was played. This is custom code for Smartschool analytics
+	 * https://meemoo.atlassian.net/browse/AVO-1471
+	 * @param title
+	 * @param identifier
+	 * @param duration
+	 */
+	public static triggerVideoPlayEvent(
+		title: string | undefined,
+		identifier: string | undefined,
+		duration: number| undefined
+	): void {
+		let message: any | undefined;
+		try {
+			if (insideIframe()) {
+				message = {
+					event: 'movie',
+					metadata: {
+						click: {
+							title,
+							identifier,
+							duration,
+						},
+					},
+				};
+				window.parent.postMessage(message, '*');
+				console.info('posted message to parent frame: ', message);
+			}
+		} catch (err) {
+			console.error(
+				new CustomError('Failed to notify parent frame of link being clicked', err, {
+					message,
+				})
+			);
+		}
+	}
+}

--- a/src/shared/services/smartschool-analytics-service.ts
+++ b/src/shared/services/smartschool-analytics-service.ts
@@ -1,6 +1,11 @@
 import { CustomError } from '../helpers';
 import { insideIframe } from '../helpers/inside-iframe';
 
+interface SmartschoolEvent {
+	event: string;
+	metadata: Record<string, Record<string, number | boolean | string | undefined | null>>;
+}
+
 export class SmartschoolAnalyticsService {
 	/**
 	 * Notify parent frame that link was clicked. This is custom code for Smartschool analytics
@@ -8,8 +13,8 @@ export class SmartschoolAnalyticsService {
 	 * @param url
 	 * @param title
 	 */
-	public static triggerUrlEvent(url: string, title?: string): void {
-		let message: any | undefined;
+	static triggerUrlEvent(url: string, title?: string): void {
+		let message: SmartschoolEvent | undefined;
 		try {
 			if (insideIframe()) {
 				message = {
@@ -41,12 +46,12 @@ export class SmartschoolAnalyticsService {
 	 * @param identifier
 	 * @param duration
 	 */
-	public static triggerVideoPlayEvent(
+	static triggerVideoPlayEvent(
 		title: string | undefined,
 		identifier: string | undefined,
-		duration: number| undefined
+		duration: number | undefined
 	): void {
-		let message: any | undefined;
+		let message: SmartschoolEvent | undefined;
 		try {
 			if (insideIframe()) {
 				message = {


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1471

i've added console info statements so we can easily debug this once it is on production. During the next deploy we can then remove those console info statements again.

requires proxy PR: https://github.com/viaacode/avo2-proxy/pull/292

![image](https://user-images.githubusercontent.com/1710840/103554210-d46b2600-4eae-11eb-83fe-3fdd28b823d4.png)

![image](https://user-images.githubusercontent.com/1710840/103554219-d8974380-4eae-11eb-96d1-3ea606a5ebcd.png)
