### PR TITLE
fix(page-overview-wrapper): reset focused page when changing pages

### DIFF
--- a/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
@@ -278,6 +278,7 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteCom
 				item: undefined,
 			};
 		});
+		setFocusedPage(null);
 	};
 
 	const handleSelectedTabsChanged = (tabs: LabelObj[]) => {


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1226

http://localhost:8080/faq-focus-test?item=/faq-leerling/waarom-lerarenkaart-of-stamboeknummer

![image](https://user-images.githubusercontent.com/1710840/103797340-a6b9e480-5048-11eb-8b90-f052b6e454aa.png)

![image](https://user-images.githubusercontent.com/1710840/103797346-a7eb1180-5048-11eb-94b1-b740772847d6.png)

