### PR TITLE
feat(error-view): set min height on error view container

### DIFF
--- a/src/error/views/ErrorView.scss
+++ b/src/error/views/ErrorView.scss
@@ -1,3 +1,7 @@
+.m-error-view {
+	min-height: 400px;
+}
+
 .c-error-buttons__mobile {
 	padding-top: 10px;
 

--- a/src/error/views/ErrorView.tsx
+++ b/src/error/views/ErrorView.tsx
@@ -137,7 +137,7 @@ const ErrorView: FunctionComponent<ErrorViewProps & RouteComponentProps & UserPr
 	};
 
 	return (
-		<Container mode="vertical" background="alt">
+		<Container mode="vertical" background="alt" className="m-error-view">
 			<Container size="medium" mode="horizontal">
 				<Blankslate body="" icon={errorIcon} title={errorMessage}>
 					{children}


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1493

since safari otherwise shows some strange render glitch

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/104216851-e878cf80-543a-11eb-8126-2df677fae89e.png)|![image](https://user-images.githubusercontent.com/1710840/104216856-ea429300-543a-11eb-94fc-8b2934be2cd9.png)|