### PR TITLE
fix(assignment-detail): only create one response entry

### DIFF
--- a/src/assignment/assignment.service.ts
+++ b/src/assignment/assignment.service.ts
@@ -652,6 +652,7 @@ export class AssignmentService {
 					assignmentUuid,
 					pupilUuid: pupilProfileId,
 				},
+				fetchPolicy: 'no-cache',
 			});
 
 			if (response.errors) {
@@ -704,6 +705,7 @@ export class AssignmentService {
 			const response: ApolloQueryResult<Avo.Assignment.Content> = await dataService.query({
 				query: GET_ASSIGNMENT_RESPONSES,
 				variables: { profileId, assignmentUuid },
+				fetchPolicy: 'no-cache',
 			});
 
 			if (response.errors) {

--- a/src/authentication/store/actions.tsx
+++ b/src/authentication/store/actions.tsx
@@ -58,7 +58,7 @@ function checkIfSessionExpires(expiresAt: string) {
 	}
 }
 
-let loading: boolean = false;
+let loading = false;
 
 export const getLoginStateAction = () => {
 	return async (dispatch: Dispatch, getState: any): Promise<Action | null> => {

--- a/src/collection/collection.service.ts
+++ b/src/collection/collection.service.ts
@@ -661,7 +661,7 @@ export class CollectionService {
 			const response = await fetchWithLogout(
 				`${getEnv('PROXY_URL')}/collections/fetch-with-items-by-id?${queryString.stringify({
 					type,
-					assignmentId: assignmentUuid,
+					assignmentUuid,
 					id: collectionId,
 				})}`,
 				{


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1371

fix issue where assignmentUuid isn't correctly passed to the proxy, causing the collection content of an assignment to not show up

make sure only one assignment_response entry is created by removing the caching for the request to check if a response already exists and fixing the issue where the user object is stored twice in the redux store.