### PR TITLE
fix(package.json): add start-with-env script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,6 +241,8 @@ node_modules
 .DS_Store
 .env
 .env.local
+.env.dev
+.env.qas
 .env.development.local
 .env.test.local
 .env.production.local

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"preinstall": "npx npm-force-resolutions",
 		"prestart": "npm run env",
 		"start": "react-scripts start",
+		"start-with-env": "dotenv -e .env.qas npm run start",
 		"env": "node ./scripts/env.js && cp env-config.js ./public",
 		"build": "react-scripts build",
 		"postbuild": "ts-node --transpile-only --project ./scripts/tsconfig.json -- scripts/add-cookiebot-ignore-attributes.ts",

--- a/scripts/env.js
+++ b/scripts/env.js
@@ -20,12 +20,13 @@ if (fs.existsSync('.env')) {
 	const lines = envFile.split('\n').map(line => line.trim());
 
 	lines.forEach(line => {
-		const lineParts = line.split('=');
+		const [envKey, ...envValueParts] = line.split('=');
+		const envValue = envValueParts.join('=')
 
-		if (!CI_ENV_VARIABLES[lineParts[0]] || CI_ENV_VARIABLES[lineParts[0]][0] === '$') {
-			envVariables[lineParts[0]] = lineParts[1];
+		if (!CI_ENV_VARIABLES[envKey] || CI_ENV_VARIABLES[envKey][0] === '$') {
+			envVariables[envKey] = envValue;
 		} else {
-			envVariables[lineParts[0]] = CI_ENV_VARIABLES[lineParts[0]];
+			envVariables[envKey] = CI_ENV_VARIABLES[envKey];
 		}
 	});
 } else {


### PR DESCRIPTION
We hebben dit aangepast om support te voorzien voor .env variables met `=` in de url.