### PR TITLE
fix(page-overview-wrapper): encode labels in the url query params

### DIFF
--- a/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
@@ -331,7 +331,12 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteCom
 				buttonLabel={buttonLabel}
 				focusedPage={focusedPage}
 				onLabelClicked={(label: string) =>
-					navigate(history, `/${ROUTE_PARTS.news}`, {}, `label=${label}`)
+					navigate(
+						history,
+						`/${ROUTE_PARTS.news}`,
+						{},
+						`label=${encodeURIComponent(label)}`
+					)
 				}
 				renderLink={renderLink}
 			/>


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1619

to test on page: http://localhost:8080/nieuws

![image](https://user-images.githubusercontent.com/1710840/125058218-5a5c6980-e0aa-11eb-8927-20b31efdeba4.png)

![image](https://user-images.githubusercontent.com/1710840/125058228-5cbec380-e0aa-11eb-897a-296bb9e53dd4.png)
