### PR TITLE
fix(settings): check perms before loading newsletter/notification pages

### DIFF
--- a/src/settings/views/Settings.tsx
+++ b/src/settings/views/Settings.tsx
@@ -110,6 +110,7 @@ const Settings: FunctionComponent<ForPupilsProps & UserProps> = (props) => {
 		PermissionName.VIEW_NOTIFICATIONS_PAGE
 	);
 	if (
+		!Object.keys(tabContents).includes(activeTab) ||
 		(activeTab === EMAIL_ID && !viewNewsletterPage) ||
 		(activeTab === NOTIFICATIONS_ID && !viewNotificationsPage)
 	) {

--- a/src/settings/views/Settings.tsx
+++ b/src/settings/views/Settings.tsx
@@ -18,10 +18,12 @@ import { DefaultSecureRouteProps } from '../../authentication/components/Secured
 import { PermissionName, PermissionService } from '../../authentication/helpers/permission-service';
 import { redirectToClientPage } from '../../authentication/helpers/redirects';
 import { APP_PATH } from '../../constants';
+import { ErrorView } from '../../error/views';
 import { InteractiveTour } from '../../shared/components';
 import { buildLink } from '../../shared/helpers';
 import withUser, { UserProps } from '../../shared/hocs/withUser';
 import { ToastService } from '../../shared/services';
+import { getPageNotFoundError } from '../../shared/translations/page-not-found';
 import { Account, Email, Notifications, Profile } from '../components';
 import { ACCOUNT_ID, EMAIL_ID, NOTIFICATIONS_ID, PROFILE_ID, SettingsTab } from '../settings.const';
 
@@ -98,6 +100,27 @@ const Settings: FunctionComponent<ForPupilsProps & UserProps> = (props) => {
 		}
 		return tab.component;
 	};
+
+	const viewNewsletterPage = PermissionService.hasPerm(
+		props.user,
+		PermissionName.VIEW_NEWSLETTERS_PAGE
+	);
+	const viewNotificationsPage = PermissionService.hasPerm(
+		props.user,
+		PermissionName.VIEW_NOTIFICATIONS_PAGE
+	);
+	if (
+		(activeTab === EMAIL_ID && !viewNewsletterPage) ||
+		(activeTab === NOTIFICATIONS_ID && !viewNotificationsPage)
+	) {
+		return (
+			<ErrorView
+				message={getPageNotFoundError(!!props.user)}
+				icon="search"
+				actionButtons={['home', 'helpdesk']}
+			/>
+		);
+	}
 
 	return (
 		<>


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1605

as a student these are the results when you now load various settings pages:
![image](https://user-images.githubusercontent.com/1710840/125072703-3190a000-e0bb-11eb-8c32-1556dc8a5c34.png)
![image](https://user-images.githubusercontent.com/1710840/125072708-348b9080-e0bb-11eb-828b-eaddfe29ee1d.png)
![image](https://user-images.githubusercontent.com/1710840/125072718-37868100-e0bb-11eb-862e-34b3d3de5d76.png)
![image](https://user-images.githubusercontent.com/1710840/125072724-3a817180-e0bb-11eb-9a0b-ed43a93189a1.png)
![image](https://user-images.githubusercontent.com/1710840/125072738-3d7c6200-e0bb-11eb-9254-1d3b965ee7ad.png)
![image](https://user-images.githubusercontent.com/1710840/125072742-3fdebc00-e0bb-11eb-88aa-02efb6fac3a9.png)