### PR TITLE
feat(bookmark-views-plays-service): remove init count code and queries

### DIFF
--- a/src/shared/services/bookmarks-views-plays-service/bookmarks-views-plays-service.const.ts
+++ b/src/shared/services/bookmarks-views-plays-service/bookmarks-views-plays-service.const.ts
@@ -12,10 +12,6 @@ import {
 	INCREMENT_COLLECTION_VIEWS,
 	INCREMENT_ITEM_PLAYS,
 	INCREMENT_ITEM_VIEWS,
-	INIT_COLLECTION_PLAYS,
-	INIT_COLLECTION_VIEWS,
-	INIT_ITEM_PLAYS,
-	INIT_ITEM_VIEWS,
 	INSERT_COLLECTION_BOOKMARK,
 	INSERT_ITEM_BOOKMARK,
 	REMOVE_COLLECTION_BOOKMARK,
@@ -38,7 +34,6 @@ export const DEFAULT_BOOKMARK_VIEW_PLAY_COUNTS: BookmarkViewPlayCounts = {
 export interface QueryDefinition {
 	query?: DocumentNode;
 	get?: DocumentNode;
-	init?: DocumentNode;
 	increment?: DocumentNode;
 	variables: (uuid: string, user?: Avo.User.User) => any;
 	responsePath?: string;
@@ -90,7 +85,6 @@ export const EVENT_QUERIES: {
 	view: {
 		item: {
 			get: GET_ITEM_VIEWS,
-			init: INIT_ITEM_VIEWS,
 			increment: INCREMENT_ITEM_VIEWS,
 			variables: (itemUuid: string) => ({
 				itemUuid,
@@ -99,7 +93,6 @@ export const EVENT_QUERIES: {
 		},
 		collection: {
 			get: GET_COLLECTION_VIEWS,
-			init: INIT_COLLECTION_VIEWS,
 			increment: INCREMENT_COLLECTION_VIEWS,
 			variables: (collectionUuid: string) => ({
 				collectionUuid,
@@ -110,7 +103,6 @@ export const EVENT_QUERIES: {
 	play: {
 		item: {
 			get: GET_ITEM_PLAYS,
-			init: INIT_ITEM_PLAYS,
 			increment: INCREMENT_ITEM_PLAYS,
 			variables: (itemUuid: string) => ({
 				itemUuid,
@@ -119,7 +111,6 @@ export const EVENT_QUERIES: {
 		},
 		collection: {
 			get: GET_COLLECTION_PLAYS,
-			init: INIT_COLLECTION_PLAYS,
 			increment: INCREMENT_COLLECTION_PLAYS,
 			variables: (collectionUuid: string) => ({
 				collectionUuid,

--- a/src/shared/services/bookmarks-views-plays-service/bookmarks-views-plays-service.gql.ts
+++ b/src/shared/services/bookmarks-views-plays-service/bookmarks-views-plays-service.gql.ts
@@ -55,22 +55,6 @@ export const INCREMENT_COLLECTION_VIEWS = gql`
 	}
 `;
 
-export const INIT_ITEM_VIEWS = gql`
-	mutation insertInitialItemViewCount($itemUuid: uuid!) {
-		insert_app_item_views(objects: [{ count: 1, item_id: $itemUuid }]) {
-			affected_rows
-		}
-	}
-`;
-
-export const INIT_COLLECTION_VIEWS = gql`
-	mutation insertInitialCollectionViewCount($collectionUuid: uuid!) {
-		insert_app_collection_views(objects: [{ count: 1, collection_uuid: $collectionUuid }]) {
-			affected_rows
-		}
-	}
-`;
-
 export const INCREMENT_ITEM_PLAYS = gql`
 	mutation increaseItemPlays($itemUuid: uuid!) {
 		update_app_item_plays(where: { item_id: { _eq: $itemUuid } }, _inc: { count: 1 }) {
@@ -130,22 +114,6 @@ export const GET_COLLECTION_PLAYS = gql`
 			play_counts {
 				count
 			}
-		}
-	}
-`;
-
-export const INIT_ITEM_PLAYS = gql`
-	mutation insertInitialItemPlayCount($itemUuid: uuid!) {
-		insert_app_item_plays(objects: [{ count: 1, item_id: $itemUuid }]) {
-			affected_rows
-		}
-	}
-`;
-
-export const INIT_COLLECTION_PLAYS = gql`
-	mutation insertInitialCollectionPlayCount($collectionUuid: uuid!) {
-		insert_app_collection_plays(objects: [{ count: 1, collection_uuid: $collectionUuid }]) {
-			affected_rows
 		}
 	}
 `;

--- a/src/shared/services/bookmarks-views-plays-service/bookmarks-views-plays-service.types.ts
+++ b/src/shared/services/bookmarks-views-plays-service/bookmarks-views-plays-service.types.ts
@@ -70,6 +70,6 @@ export interface AppCollectionBookmark {
 }
 
 export type EventAction = 'bookmark' | 'unbookmark' | 'view' | 'play';
-export type QueryType = 'query' | 'get' | 'init' | 'increment';
+export type QueryType = 'query' | 'get' | 'increment';
 export type EventContentTypeSimplified = 'item' | 'collection';
 export type EventContentType = EventContentTypeSimplified | 'bundle';


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1531

The syncrator will ensure a row is created for each item/collection/bundle with count 0, so we do not need to initialise this count when a user views the page. All we have to do is increment.

You can test this on any item/collection/bundle detail page. The view count should increment on page reload.
http://localhost:8080/item/sx64487s06

![image](https://user-images.githubusercontent.com/1710840/126176548-65927e92-8e9b-4bd0-ad0d-d61b3783ff8d.png)


