### PR TITLE
feat(page-overview-wrapper): use links instead of buttons for SEO

### DIFF
--- a/src/admin/content-block/components/wrappers/MediaPlayerTitleTextButtonWrapper/MediaPlayerTitleTextButtonWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/MediaPlayerTitleTextButtonWrapper/MediaPlayerTitleTextButtonWrapper.tsx
@@ -1,6 +1,4 @@
 import React, { FC, FunctionComponent } from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { compose } from 'redux';
 
 import {
 	BlockHeading,
@@ -17,7 +15,7 @@ import {
 	PermissionName,
 	PermissionService,
 } from '../../../../../authentication/helpers/permission-service';
-import { navigateToContentType } from '../../../../../shared/helpers';
+import { generateSmartLink } from '../../../../../shared/helpers';
 import withUser, { UserProps } from '../../../../../shared/hocs/withUser';
 import { AlignOption, HeadingTypeOption } from '../../../../shared/types';
 import MediaPlayerWrapper from '../MediaPlayerWrapper/MediaPlayerWrapper';
@@ -44,7 +42,7 @@ interface MediaPlayerTitleTextButtonWrapperProps {
 }
 
 export const MediaPlayerTitleTextButtonWrapper: FC<
-	MediaPlayerTitleTextButtonWrapperProps & RouteComponentProps & UserProps
+	MediaPlayerTitleTextButtonWrapperProps & UserProps
 > = ({
 	mediaItem,
 	mediaSrc,
@@ -61,7 +59,6 @@ export const MediaPlayerTitleTextButtonWrapper: FC<
 	buttonLabel,
 	buttonType,
 	buttonAction,
-	history,
 	align,
 	mediaAutoplay,
 	user,
@@ -85,34 +82,26 @@ export const MediaPlayerTitleTextButtonWrapper: FC<
 				/>
 			</Column>
 			<Column size="2-5" className={`u-text-${align}`}>
-				<BlockHeading
-					type={headingType}
-					onClick={
-						shouldTitleLink
-							? () => navigateToContentType(mediaItem, history)
-							: undefined
-					}
-					className={shouldTitleLink ? 'u-clickable' : ''}
-				>
-					{headingTitle}
-				</BlockHeading>
-				<RichTextWrapper elements={{ content }} />
-				{buttonAction && (
-					<Button
-						icon={buttonIcon}
-						label={buttonLabel}
-						type={buttonType}
-						onClick={() => {
-							navigateToContentType(buttonAction, history);
-						}}
-					/>
+				{generateSmartLink(
+					mediaItem,
+					<BlockHeading
+						type={headingType}
+						className={shouldTitleLink ? 'u-clickable' : ''}
+					>
+						{headingTitle}
+					</BlockHeading>
 				)}
+				<RichTextWrapper elements={{ content }} />
+				{buttonAction &&
+					generateSmartLink(
+						buttonAction,
+						<Button icon={buttonIcon} label={buttonLabel} type={buttonType} />
+					)}
 			</Column>
 		</Grid>
 	);
 };
 
-export default compose(
-	withRouter,
-	withUser
-)(MediaPlayerTitleTextButtonWrapper) as FunctionComponent<MediaPlayerTitleTextButtonWrapperProps>;
+export default withUser(MediaPlayerTitleTextButtonWrapper) as FunctionComponent<
+	MediaPlayerTitleTextButtonWrapperProps
+>;

--- a/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
@@ -1,7 +1,6 @@
 import { cloneDeep, get, isNumber } from 'lodash-es';
 import React, { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { RouteComponentProps, withRouter } from 'react-router';
 import { NumberParam, QueryParamConfig, StringParam, useQueryParams } from 'use-query-params';
 
 import {
@@ -17,7 +16,7 @@ import { Avo } from '@viaa/avo2-types';
 import { ContentPage } from '../../../../../content-page/views';
 import { LoadingErrorLoadedComponent, LoadingInfo } from '../../../../../shared/components';
 import { ROUTE_PARTS } from '../../../../../shared/constants';
-import { CustomError, getEnv, navigate } from '../../../../../shared/helpers';
+import { CustomError, getEnv } from '../../../../../shared/helpers';
 import { fetchWithLogout } from '../../../../../shared/helpers/fetch-with-logout';
 import { useDebounce } from '../../../../../shared/hooks';
 import { ToastService } from '../../../../../shared/services';
@@ -64,7 +63,7 @@ interface PageOverviewWrapperProps {
 	renderLink: RenderLinkFunction;
 }
 
-const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteComponentProps> = ({
+const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps> = ({
 	contentTypeAndTabs = {
 		selectedContentType: 'PROJECT',
 		selectedLabels: null,
@@ -83,7 +82,6 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteCom
 	sortOrder = 'published_at__desc',
 	headerBackgroundColor,
 	renderLink,
-	history,
 }) => {
 	const [t] = useTranslation();
 
@@ -330,14 +328,9 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteCom
 				)}
 				buttonLabel={buttonLabel}
 				focusedPage={focusedPage}
-				onLabelClicked={(label: string) =>
-					navigate(
-						history,
-						`/${ROUTE_PARTS.news}`,
-						{},
-						`label=${encodeURIComponent(label)}`
-					)
-				}
+				getLabelLink={(label: string) => {
+					return `/${ROUTE_PARTS.news}?label=${encodeURIComponent(label)}`;
+				}}
 				renderLink={renderLink}
 			/>
 		);
@@ -352,4 +345,4 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps & RouteCom
 	);
 };
 
-export default withRouter(PageOverviewWrapper);
+export default PageOverviewWrapper;


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1660

requires components PR: https://github.com/viaacode/avo2-components/pull/452

Replaces button with onClick by a href where possible:
* page overview block labels
* media player buttons

![image](https://user-images.githubusercontent.com/1710840/126160708-e04889e2-634c-46b8-ab13-d3b30c263047.png)

![image](https://user-images.githubusercontent.com/1710840/126160721-02672d1c-b454-4f95-a18c-bc1f385df6d6.png)

