### PR TITLE
fix(columns): hide organisations column by default

### DIFF
--- a/src/admin/collectionsOrBundles/collections-or-bundles.const.ts
+++ b/src/admin/collectionsOrBundles/collections-or-bundles.const.ts
@@ -365,7 +365,7 @@ const getCollectionOrganisationColumn = (
 	id: 'organisation',
 	label: i18n.t('admin/collections-or-bundles/collections-or-bundles___organisatie'),
 	sortable: false,
-	visibleByDefault: true,
+	visibleByDefault: false,
 	filterType: 'CheckboxDropdownModal',
 	filterProps: {
 		options: organisationOptions,


### PR DESCRIPTION
AVO-1455 hide organisations column by default