### PR TITLE
fix(contentpicker): fetch items on focus

### DIFF
--- a/src/admin/shared/components/ContentPicker/ContentPicker.tsx
+++ b/src/admin/shared/components/ContentPicker/ContentPicker.tsx
@@ -286,6 +286,7 @@ export const ContentPicker: FunctionComponent<ContentPickerProps> = ({
 			aria-label={placeholder}
 			loadOptions={fetchPickerOptions}
 			onChange={onSelectItem}
+			onFocus={() => fetchPickerOptions(null)}
 			value={selectedItem}
 			defaultOptions={itemOptions as any} // TODO: type
 			isClearable


### PR DESCRIPTION
blocks are loaded in order; when the anchor link block is loaded before all blocks with anchor items; these last items are not included in the dropdown list.
This PR (re)fetches these options on focus.

Closes AVO-1597