### PR TITLE
fix: fetch unblocked_at property from database

### DIFF
--- a/src/admin/users/user.gql.ts
+++ b/src/admin/users/user.gql.ts
@@ -87,6 +87,9 @@ export const GET_USER_BY_ID = gql`
 			blocked_at {
 				max
 			}
+			unblocked_at {
+				max
+			}
 			classifications {
 				id
 				key


### PR DESCRIPTION
Fixes issue where the unblocked date on a user detail page was undefined.
Proxy fix: https://github.com/viaacode/avo2-proxy/pull/380