### PR TITLE
feat: filter on no-role for collections and bundles

### DIFF
--- a/src/admin/collectionsOrBundles/views/CollectionOrBundleActualisationOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionOrBundleActualisationOverview.tsx
@@ -73,8 +73,15 @@ const CollectionOrBundleActualisationOverview: FunctionComponent<CollectionOrBun
 	// computed
 
 	const userGroupOptions = useMemo(
-		() =>
-			userGroups.map(
+		() => [
+			{
+				id: NULL_FILTER,
+				label: t('Geen rol'),
+				checked: get(tableState, 'author.user_groups', [] as string[]).includes(
+					NULL_FILTER
+				),
+			},
+			...userGroups.map(
 				(option): CheckboxOption => ({
 					id: String(option.id),
 					label: option.label as string,
@@ -83,7 +90,8 @@ const CollectionOrBundleActualisationOverview: FunctionComponent<CollectionOrBun
 					),
 				})
 			),
-		[tableState, userGroups]
+		],
+		[tableState, userGroups, t]
 	);
 
 	const collectionLabelOptions = useMemo(

--- a/src/admin/collectionsOrBundles/views/CollectionOrBundleMarcomOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionOrBundleMarcomOverview.tsx
@@ -71,8 +71,15 @@ const CollectionOrBundleMarcomOverview: FunctionComponent<CollectionOrBundleMarc
 
 	// computed
 	const userGroupOptions = useMemo(
-		() =>
-			userGroups.map(
+		() => [
+			{
+				id: NULL_FILTER,
+				label: t('Geen rol'),
+				checked: get(tableState, 'author.user_groups', [] as string[]).includes(
+					NULL_FILTER
+				),
+			},
+			...userGroups.map(
 				(option): CheckboxOption => ({
 					id: String(option.id),
 					label: option.label as string,
@@ -81,7 +88,8 @@ const CollectionOrBundleMarcomOverview: FunctionComponent<CollectionOrBundleMarc
 					),
 				})
 			),
-		[tableState, userGroups]
+		],
+		[tableState, userGroups, t]
 	);
 
 	const collectionLabelOptions = useMemo(

--- a/src/admin/collectionsOrBundles/views/CollectionOrBundleQualityCheckOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionOrBundleQualityCheckOverview.tsx
@@ -72,8 +72,15 @@ const CollectionOrBundleQualityCheckOverview: FunctionComponent<CollectionOrBund
 
 	// computed
 	const userGroupOptions = useMemo(
-		() =>
-			userGroups.map(
+		() => [
+			{
+				id: NULL_FILTER,
+				label: t('Geen rol'),
+				checked: get(tableState, 'author.user_groups', [] as string[]).includes(
+					NULL_FILTER
+				),
+			},
+			...userGroups.map(
 				(option): CheckboxOption => ({
 					id: String(option.id),
 					label: option.label as string,
@@ -82,7 +89,8 @@ const CollectionOrBundleQualityCheckOverview: FunctionComponent<CollectionOrBund
 					),
 				})
 			),
-		[tableState, userGroups]
+		],
+		[tableState, userGroups, t]
 	);
 
 	const collectionLabelOptions = useMemo(

--- a/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
@@ -84,8 +84,15 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 
 	// computed
 	const userGroupOptions = useMemo(
-		() =>
-			userGroups.map(
+		() => [
+			{
+				id: NULL_FILTER,
+				label: t('Geen rol'),
+				checked: get(tableState, 'author.user_groups', [] as string[]).includes(
+					NULL_FILTER
+				),
+			},
+			...userGroups.map(
 				(option): CheckboxOption => ({
 					id: String(option.id),
 					label: option.label as string,
@@ -94,7 +101,8 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 					),
 				})
 			),
-		[tableState, userGroups]
+		],
+		[tableState, userGroups, t]
 	);
 	const collectionLabelOptions = useMemo(
 		() => [


### PR DESCRIPTION
Optie 'no role' toegevoegd bij filteren in collecties en bundles
Queries geupdate