### PR TITLE
fix(avo-1908): fix link from workspace to assignment response detail

### DIFF
--- a/src/assignment/views/AssignmentOverview.tsx
+++ b/src/assignment/views/AssignmentOverview.tsx
@@ -24,7 +24,7 @@ import { Avo } from '@viaa/avo2-types';
 import { AssignmentLabelType } from '@viaa/avo2-types/types/assignment';
 import { SearchOrderDirection } from '@viaa/avo2-types/types/search';
 import classnames from 'classnames';
-import { cloneDeep, compact, get, isEqual, isNil } from 'lodash-es';
+import { cloneDeep, compact, get, isEqual, isNil, noop } from 'lodash-es';
 import React, {
 	FunctionComponent,
 	ReactText,
@@ -64,7 +64,10 @@ import { AssignmentLabelsService, ToastService } from '../../shared/services';
 import { trackEvents } from '../../shared/services/event-logging-service';
 import { TableColumnDataType } from '../../shared/types/table-column-data-type';
 import { ITEMS_PER_PAGE } from '../../workspace/workspace.const';
-import { GET_ASSIGNMENT_OVERVIEW_COLUMNS } from '../assignment.const';
+import {
+	ASSIGNMENT_RESPONSE_CREATE_UPDATE_TABS,
+	GET_ASSIGNMENT_OVERVIEW_COLUMNS,
+} from '../assignment.const';
 import { AssignmentService } from '../assignment.service';
 import {
 	AssignmentOverviewTableColumns,
@@ -95,7 +98,7 @@ const defaultFiltersAndSort = {
 };
 
 const AssignmentOverview: FunctionComponent<AssignmentOverviewProps> = ({
-	onUpdate = () => {},
+	onUpdate = noop,
 	history,
 	user,
 }) => {
@@ -146,7 +149,6 @@ const AssignmentOverview: FunctionComponent<AssignmentOverviewProps> = ({
 		if (query.sort_order) {
 			setSortOrder(query.sort_order as SearchOrderDirection);
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const handleQueryChanged = (value: any, id: string) => {
@@ -474,14 +476,18 @@ const AssignmentOverview: FunctionComponent<AssignmentOverviewProps> = ({
 	) => {
 		const cellData: any = (assignment as any)[colKey];
 		const editLink = buildLink(APP_PATH.ASSIGNMENT_EDIT.route, { id: assignment.id });
-		const detailLink = buildLink(APP_PATH.ASSIGNMENT_RESPONSE_DETAIL.route, {
-			id: assignment.id,
-		});
+		const detailLink = buildLink(
+			APP_PATH.ASSIGNMENT_RESPONSE_DETAIL.route,
+			{
+				id: assignment.id,
+			},
+			{ tab: ASSIGNMENT_RESPONSE_CREATE_UPDATE_TABS.ASSIGNMENT }
+		);
 
 		switch (
 			colKey as any // TODO remove cast once assignment_v2 types are fixed (labels, class_room, author)
 		) {
-			case 'title':
+			case 'title': {
 				const renderTitle = () => (
 					<Flex>
 						<Spacer margin="right">
@@ -502,6 +508,7 @@ const AssignmentOverview: FunctionComponent<AssignmentOverviewProps> = ({
 				) : (
 					renderTitle()
 				);
+			}
 
 			case 'labels':
 				return renderLabels(
@@ -517,7 +524,7 @@ const AssignmentOverview: FunctionComponent<AssignmentOverviewProps> = ({
 					) // TODO remove cast once assignment_v2 types are fixed
 				);
 
-			case 'author':
+			case 'author': {
 				const profile = get(assignment, 'profile', null);
 				const avatarOptions = {
 					dark: true,
@@ -530,6 +537,7 @@ const AssignmentOverview: FunctionComponent<AssignmentOverviewProps> = ({
 				) : (
 					renderAvatar(profile, avatarOptions)
 				);
+			}
 
 			case 'deadline_at':
 				return <AssignmentDeadline deadline={assignment.deadline_at} />;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,5 @@
-import { compact } from 'lodash-es';
-
 import { Avo } from '@viaa/avo2-types';
+import { compact } from 'lodash-es';
 
 import { ROUTE_PARTS } from './shared/constants';
 import i18n from './shared/translations/i18n';
@@ -207,12 +206,12 @@ export const APP_PATH: { [routeId in RouteId]: RouteInfo } = {
 		showForInteractiveTour: true,
 	},
 	ASSIGNMENT_RESPONSE_DETAIL: {
-		route: `/${ROUTE_PARTS.assignments}/:id/${ROUTE_PARTS.response}/:responseId`,
+		route: `/${ROUTE_PARTS.assignments}/:id`,
 		showInContentPicker: false,
 		showForInteractiveTour: true,
 	},
 	ASSIGNMENT_RESPONSE_EDIT: {
-		route: `/${ROUTE_PARTS.assignments}/:id/${ROUTE_PARTS.response}/:responseId/${ROUTE_PARTS.edit}`,
+		route: `/${ROUTE_PARTS.assignments}/:id`,
 		showInContentPicker: false,
 		showForInteractiveTour: true,
 	},


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-1908

When clicking a link to an assignment in the workspace as a pupil:
![image](https://user-images.githubusercontent.com/1710840/177297496-f8a9e82d-1d4d-45a8-8d3f-165be03dc0f6.png)

You are now correctly taken to the first tab of the assignment response detail page:
![image](https://user-images.githubusercontent.com/1710840/177297519-3695b86a-2b2e-4d83-a826-683226ea72db.png)
