### PR TITLE
fix(avo-1910): fix pagination on the teacher search page

### DIFF
--- a/src/search/components/SearchFiltersAndResults.tsx
+++ b/src/search/components/SearchFiltersAndResults.tsx
@@ -331,6 +331,7 @@ const SearchFiltersAndResults: FunctionComponent<SearchFiltersAndResultsProps> =
 					...DEFAULT_FILTER_STATE,
 					collectionLabel: [tagId],
 				},
+				page: 0,
 			},
 			urlUpdateType
 		);

--- a/src/search/views/Search.tsx
+++ b/src/search/views/Search.tsx
@@ -15,7 +15,13 @@ import { useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'redux';
-import { JsonParam, StringParam, UrlUpdateType, useQueryParams } from 'use-query-params';
+import {
+	JsonParam,
+	NumberParam,
+	StringParam,
+	UrlUpdateType,
+	useQueryParams,
+} from 'use-query-params';
 
 import {
 	PermissionGuard,
@@ -45,6 +51,7 @@ const Search: FunctionComponent<UserProps & RouteComponentProps> = ({ user }) =>
 		orderProperty: StringParam,
 		orderDirection: StringParam,
 		tab: StringParam,
+		page: NumberParam,
 	};
 	const [filterState, setFilterState] = useQueryParams(queryParamConfig) as [
 		FilterState,

--- a/src/shared/helpers/formatters/avatar.tsx
+++ b/src/shared/helpers/formatters/avatar.tsx
@@ -1,8 +1,7 @@
-import { get } from 'lodash-es';
-import React, { ReactNode } from 'react';
-
 import { Avatar, AvatarList, AvatarProps } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
+import { get } from 'lodash-es';
+import React, { ReactNode } from 'react';
 
 export const getProfile = (
 	obj: Avo.User.Profile | { profile: Avo.User.Profile } | null | undefined
@@ -11,7 +10,7 @@ export const getProfile = (
 		return null;
 	}
 	if ((obj as Avo.User.Profile).user) {
-		return (obj as unknown) as Avo.User.Profile;
+		return obj as unknown as Avo.User.Profile;
 	}
 	return {
 		...((obj as Avo.User.User).profile || {}),
@@ -19,7 +18,7 @@ export const getProfile = (
 	} as Avo.User.Profile;
 };
 
-export const getInitialChar = (value: string | undefined | null) => (value ? value[0] : '');
+export const getInitialChar = (value: string | undefined | null): string => (value ? value[0] : '');
 
 export const getInitials = (profile: Avo.User.Profile | null) =>
 	getInitialChar(get(profile, 'user.first_name')) +


### PR DESCRIPTION
pagination was broken on the regular search page after avo-1910 which moved the page param to the url params
![image](https://user-images.githubusercontent.com/1710840/177326829-c9d78f41-c8dd-46fd-8d22-bbf51d9c08f4.png)
