### PR TITLE
feat(avo-1908): adjust BlockList to pass configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2517,6 +2517,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -2535,6 +2536,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "4.0.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -2560,6 +2562,7 @@
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.0",
@@ -3997,7 +4000,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/experimental-utils": "4.33.0",
@@ -4028,7 +4031,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
       "version": "7.3.7",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4042,7 +4045,7 @@
     },
     "node_modules/@typescript-eslint/experimental-utils": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
@@ -4065,7 +4068,7 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/scope-manager": "4.33.0",
@@ -4091,7 +4094,7 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "4.33.0",
@@ -4131,7 +4134,7 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -4143,7 +4146,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/types": "4.33.0",
@@ -4169,7 +4172,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.3.7",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4291,7 +4294,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "4.33.0",
@@ -4731,6 +4734,7 @@
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5349,6 +5353,7 @@
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8359,6 +8364,7 @@
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1"
@@ -8656,6 +8662,7 @@
     },
     "node_modules/eslint": {
       "version": "7.32.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -9074,6 +9081,7 @@
     },
     "node_modules/eslint/node_modules/eslint-utils": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
@@ -9087,6 +9095,7 @@
     },
     "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
@@ -9094,6 +9103,7 @@
     },
     "node_modules/eslint/node_modules/ignore": {
       "version": "4.0.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -9101,6 +9111,7 @@
     },
     "node_modules/espree": {
       "version": "7.3.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^7.4.0",
@@ -9113,6 +9124,7 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
@@ -13851,6 +13863,7 @@
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
@@ -16858,6 +16871,7 @@
     },
     "node_modules/progress": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -22362,6 +22376,7 @@
     },
     "node_modules/table": {
       "version": "6.8.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^8.0.1",
@@ -22376,6 +22391,7 @@
     },
     "node_modules/table/node_modules/ajv": {
       "version": "8.11.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -22390,6 +22406,7 @@
     },
     "node_modules/table/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -22397,10 +22414,12 @@
     },
     "node_modules/table/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/table/node_modules/slice-ansi": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -22416,6 +22435,7 @@
     },
     "node_modules/table/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -23247,6 +23267,7 @@
     },
     "node_modules/typescript": {
       "version": "4.7.4",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -26293,12 +26314,10 @@
       }
     },
     "@csstools/postcss-unset-value": {
-      "version": "1.0.1",
-      "requires": {}
+      "version": "1.0.1"
     },
     "@csstools/selector-specificity": {
-      "version": "2.0.1",
-      "requires": {}
+      "version": "2.0.1"
     },
     "@emotion/cache": {
       "version": "10.0.29",
@@ -26366,6 +26385,7 @@
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
+      "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
@@ -26379,7 +26399,8 @@
       },
       "dependencies": {
         "ignore": {
-          "version": "4.0.6"
+          "version": "4.0.6",
+          "dev": true
         }
       }
     },
@@ -26387,15 +26408,14 @@
       "version": "0.1.1"
     },
     "@graphql-typed-document-node/core": {
-      "version": "3.1.1",
-      "requires": {}
+      "version": "3.1.1"
     },
     "@hookform/resolvers": {
-      "version": "2.9.3",
-      "requires": {}
+      "version": "2.9.3"
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
+      "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.0",
         "debug": "^4.1.1",
@@ -26575,12 +26595,10 @@
       "version": "2.11.5"
     },
     "@react-hook/latest": {
-      "version": "1.0.3",
-      "requires": {}
+      "version": "1.0.3"
     },
     "@react-hook/passive-layout-effect": {
-      "version": "1.2.1",
-      "requires": {}
+      "version": "1.2.1"
     },
     "@react-hook/resize-observer": {
       "version": "1.2.5",
@@ -27346,7 +27364,7 @@
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "4.33.0",
         "@typescript-eslint/scope-manager": "4.33.0",
@@ -27360,7 +27378,7 @@
       "dependencies": {
         "semver": {
           "version": "7.3.7",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -27369,7 +27387,7 @@
     },
     "@typescript-eslint/experimental-utils": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
         "@typescript-eslint/scope-manager": "4.33.0",
@@ -27381,7 +27399,7 @@
     },
     "@typescript-eslint/parser": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@typescript-eslint/scope-manager": "4.33.0",
         "@typescript-eslint/types": "4.33.0",
@@ -27391,7 +27409,7 @@
     },
     "@typescript-eslint/scope-manager": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@typescript-eslint/types": "4.33.0",
         "@typescript-eslint/visitor-keys": "4.33.0"
@@ -27407,11 +27425,11 @@
     },
     "@typescript-eslint/types": {
       "version": "4.33.0",
-      "devOptional": true
+      "dev": true
     },
     "@typescript-eslint/typescript-estree": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@typescript-eslint/types": "4.33.0",
         "@typescript-eslint/visitor-keys": "4.33.0",
@@ -27424,7 +27442,7 @@
       "dependencies": {
         "semver": {
           "version": "7.3.7",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -27484,7 +27502,7 @@
     },
     "@typescript-eslint/visitor-keys": {
       "version": "4.33.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
@@ -27729,8 +27747,7 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.3.2",
-      "requires": {}
+      "version": "5.3.2"
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -27784,8 +27801,7 @@
       }
     },
     "ajv-errors": {
-      "version": "1.0.1",
-      "requires": {}
+      "version": "1.0.1"
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -27808,11 +27824,11 @@
       }
     },
     "ajv-keywords": {
-      "version": "3.5.2",
-      "requires": {}
+      "version": "3.5.2"
     },
     "ansi-colors": {
-      "version": "4.1.3"
+      "version": "4.1.3",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -28268,7 +28284,8 @@
       "version": "0.0.7"
     },
     "astral-regex": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "async": {
       "version": "3.2.4"
@@ -28398,8 +28415,7 @@
       }
     },
     "babel-plugin-named-asset-import": {
-      "version": "0.3.8",
-      "requires": {}
+      "version": "0.3.8"
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
@@ -28608,8 +28624,7 @@
       },
       "dependencies": {
         "braft-utils": {
-          "version": "3.0.12",
-          "requires": {}
+          "version": "3.0.12"
         },
         "immutable": {
           "version": "3.7.6"
@@ -28625,14 +28640,12 @@
       },
       "dependencies": {
         "braft-utils": {
-          "version": "3.0.12",
-          "requires": {}
+          "version": "3.0.12"
         }
       }
     },
     "braft-finder": {
-      "version": "0.0.19",
-      "requires": {}
+      "version": "0.0.19"
     },
     "brorand": {
       "version": "1.1.0"
@@ -29526,8 +29539,7 @@
       }
     },
     "css-declaration-sorter": {
-      "version": "6.3.0",
-      "requires": {}
+      "version": "6.3.0"
     },
     "css-has-pseudo": {
       "version": "3.0.4",
@@ -29536,8 +29548,7 @@
       }
     },
     "css-prefers-color-scheme": {
-      "version": "6.0.3",
-      "requires": {}
+      "version": "6.0.3"
     },
     "css-select": {
       "version": "5.1.0",
@@ -29612,8 +29623,7 @@
       }
     },
     "cssnano-utils": {
-      "version": "3.1.0",
-      "requires": {}
+      "version": "3.1.0"
     },
     "csso": {
       "version": "4.2.0",
@@ -30086,8 +30096,7 @@
       }
     },
     "draftjs-utils": {
-      "version": "0.9.4",
-      "requires": {}
+      "version": "0.9.4"
     },
     "duplexer": {
       "version": "0.1.2"
@@ -30199,6 +30208,7 @@
     },
     "enquirer": {
       "version": "2.3.6",
+      "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }
@@ -30399,6 +30409,7 @@
     },
     "eslint": {
       "version": "7.32.0",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -30444,24 +30455,26 @@
       "dependencies": {
         "eslint-utils": {
           "version": "2.1.0",
+          "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
           },
           "dependencies": {
             "eslint-visitor-keys": {
-              "version": "1.3.0"
+              "version": "1.3.0",
+              "dev": true
             }
           }
         },
         "ignore": {
-          "version": "4.0.6"
+          "version": "4.0.6",
+          "dev": true
         }
       }
     },
     "eslint-config-prettier": {
       "version": "8.3.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -30645,8 +30658,7 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.6.0",
-      "requires": {}
+      "version": "4.6.0"
     },
     "eslint-plugin-testing-library": {
       "version": "5.5.1",
@@ -30677,6 +30689,7 @@
     },
     "espree": {
       "version": "7.3.1",
+      "dev": true,
       "requires": {
         "acorn": "^7.4.0",
         "acorn-jsx": "^5.3.1",
@@ -30684,7 +30697,8 @@
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "1.3.0"
+          "version": "1.3.0",
+          "dev": true
         }
       }
     },
@@ -31937,8 +31951,7 @@
       }
     },
     "icss-utils": {
-      "version": "5.1.0",
-      "requires": {}
+      "version": "5.1.0"
     },
     "idb": {
       "version": "6.1.5"
@@ -32990,8 +33003,7 @@
       }
     },
     "jest-pnp-resolver": {
-      "version": "1.2.2",
-      "requires": {}
+      "version": "1.2.2"
     },
     "jest-regex-util": {
       "version": "28.0.2"
@@ -33150,8 +33162,7 @@
           }
         },
         "ws": {
-          "version": "7.5.8",
-          "requires": {}
+          "version": "7.5.8"
         }
       }
     },
@@ -33731,7 +33742,8 @@
       "version": "4.7.0"
     },
     "lodash.truncate": {
-      "version": "4.4.2"
+      "version": "4.4.2",
+      "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0"
@@ -34927,8 +34939,7 @@
       }
     },
     "postcss-browser-comments": {
-      "version": "4.0.0",
-      "requires": {}
+      "version": "4.0.0"
     },
     "postcss-calc": {
       "version": "8.2.4",
@@ -35002,20 +35013,16 @@
       }
     },
     "postcss-discard-comments": {
-      "version": "5.1.2",
-      "requires": {}
+      "version": "5.1.2"
     },
     "postcss-discard-duplicates": {
-      "version": "5.1.0",
-      "requires": {}
+      "version": "5.1.0"
     },
     "postcss-discard-empty": {
-      "version": "5.1.1",
-      "requires": {}
+      "version": "5.1.1"
     },
     "postcss-discard-overridden": {
-      "version": "5.1.0",
-      "requires": {}
+      "version": "5.1.0"
     },
     "postcss-double-position-gradients": {
       "version": "3.1.1",
@@ -35031,8 +35038,7 @@
       }
     },
     "postcss-flexbugs-fixes": {
-      "version": "5.0.2",
-      "requires": {}
+      "version": "5.0.2"
     },
     "postcss-focus-visible": {
       "version": "6.0.4",
@@ -35047,12 +35053,10 @@
       }
     },
     "postcss-font-variant": {
-      "version": "5.0.0",
-      "requires": {}
+      "version": "5.0.0"
     },
     "postcss-gap-properties": {
-      "version": "3.0.3",
-      "requires": {}
+      "version": "3.0.3"
     },
     "postcss-image-set-function": {
       "version": "4.0.6",
@@ -35069,8 +35073,7 @@
       }
     },
     "postcss-initial": {
-      "version": "4.0.1",
-      "requires": {}
+      "version": "4.0.1"
     },
     "postcss-js": {
       "version": "4.0.0",
@@ -35093,12 +35096,10 @@
       }
     },
     "postcss-logical": {
-      "version": "5.0.4",
-      "requires": {}
+      "version": "5.0.4"
     },
     "postcss-media-minmax": {
-      "version": "5.0.0",
-      "requires": {}
+      "version": "5.0.0"
     },
     "postcss-merge-longhand": {
       "version": "5.1.6",
@@ -35145,8 +35146,7 @@
       }
     },
     "postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "requires": {}
+      "version": "3.0.0"
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -35190,8 +35190,7 @@
       }
     },
     "postcss-normalize-charset": {
-      "version": "5.1.0",
-      "requires": {}
+      "version": "5.1.0"
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -35254,12 +35253,10 @@
       }
     },
     "postcss-overflow-shorthand": {
-      "version": "3.0.3",
-      "requires": {}
+      "version": "3.0.3"
     },
     "postcss-page-break": {
-      "version": "3.0.4",
-      "requires": {}
+      "version": "3.0.4"
     },
     "postcss-place": {
       "version": "7.0.4",
@@ -35339,8 +35336,7 @@
       }
     },
     "postcss-replace-overflow-wrap": {
-      "version": "4.0.0",
-      "requires": {}
+      "version": "4.0.0"
     },
     "postcss-selector-not": {
       "version": "6.0.0",
@@ -35484,7 +35480,8 @@
       "version": "2.0.1"
     },
     "progress": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "dev": true
     },
     "promise": {
       "version": "7.3.1",
@@ -35891,8 +35888,7 @@
       }
     },
     "react-hook-form": {
-      "version": "7.33.0",
-      "requires": {}
+      "version": "7.33.0"
     },
     "react-i18next": {
       "version": "11.17.3",
@@ -35939,8 +35935,7 @@
       }
     },
     "react-onclickoutside": {
-      "version": "6.12.2",
-      "requires": {}
+      "version": "6.12.2"
     },
     "react-perfect-scrollbar": {
       "version": "1.5.8",
@@ -35960,8 +35955,7 @@
       "version": "1.0.4"
     },
     "react-range": {
-      "version": "1.8.13",
-      "requires": {}
+      "version": "1.8.13"
     },
     "react-redux": {
       "version": "6.0.1",
@@ -36414,8 +36408,7 @@
           "version": "8.7.1"
         },
         "acorn-import-assertions": {
-          "version": "1.8.0",
-          "requires": {}
+          "version": "1.8.0"
         },
         "ansi-styles": {
           "version": "5.2.0"
@@ -37185,8 +37178,7 @@
           }
         },
         "style-loader": {
-          "version": "3.3.1",
-          "requires": {}
+          "version": "3.3.1"
         },
         "supports-color": {
           "version": "8.1.1",
@@ -37594,8 +37586,7 @@
       }
     },
     "redux-devtools-extension": {
-      "version": "2.13.9",
-      "requires": {}
+      "version": "2.13.9"
     },
     "redux-mock-store": {
       "version": "1.5.4",
@@ -37605,8 +37596,7 @@
       }
     },
     "redux-thunk": {
-      "version": "2.4.1",
-      "requires": {}
+      "version": "2.4.1"
     },
     "reflect.ownkeys": {
       "version": "0.2.0",
@@ -38194,8 +38184,7 @@
       }
     },
     "serialize-query-params": {
-      "version": "1.3.6",
-      "requires": {}
+      "version": "1.3.6"
     },
     "serve-index": {
       "version": "1.9.1",
@@ -39072,6 +39061,7 @@
     },
     "table": {
       "version": "6.8.0",
+      "dev": true,
       "requires": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -39082,6 +39072,7 @@
       "dependencies": {
         "ajv": {
           "version": "8.11.0",
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -39090,13 +39081,16 @@
           }
         },
         "is-fullwidth-code-point": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "dev": true
         },
         "json-schema-traverse": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "dev": true
         },
         "slice-ansi": {
           "version": "4.0.0",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
             "astral-regex": "^2.0.0",
@@ -39105,6 +39099,7 @@
         },
         "string-width": {
           "version": "4.2.3",
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -39623,7 +39618,8 @@
       }
     },
     "typescript": {
-      "version": "4.7.4"
+      "version": "4.7.4",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.31"
@@ -40672,8 +40668,7 @@
       "version": "1.0.2"
     },
     "ws": {
-      "version": "8.8.0",
-      "requires": {}
+      "version": "8.8.0"
     },
     "xml-name-validator": {
       "version": "3.0.0"

--- a/src/assignment/views/AssignmentResponseEdit.tsx
+++ b/src/assignment/views/AssignmentResponseEdit.tsx
@@ -489,8 +489,21 @@ const AssignmentResponseEdit: FunctionComponent<
 			<Container mode="horizontal">
 				<BlockList
 					blocks={(assignmentInfo?.assignmentBlocks || []) as BlockItemBase[]}
-					enableContentLinks={false}
-					canPlay={true}
+					config={{
+						text: {
+							title: {
+								canClickHeading: false,
+							},
+						},
+						item: {
+							meta: {
+								canClickSeries: false,
+							},
+							flowPlayer: {
+								canPlay: true,
+							},
+						},
+					}}
 				/>
 			</Container>
 		);

--- a/src/collection/collection.types.ts
+++ b/src/collection/collection.types.ts
@@ -71,5 +71,5 @@ export interface MarcomEntry {
 }
 
 export interface BlockItemComponent {
-	block: BlockItemBase;
+	block?: BlockItemBase;
 }

--- a/src/collection/components/CollectionFragmentFlowPlayer.tsx
+++ b/src/collection/components/CollectionFragmentFlowPlayer.tsx
@@ -10,7 +10,7 @@ export type CollectionFragmentFlowPlayerProps = BlockItemComponent & FlowPlayerW
 const CollectionFragmentFlowPlayer: FC<CollectionFragmentFlowPlayerProps> = (props) => {
 	const { block, ...rest } = props;
 
-	const meta = block.item_meta as ItemSchema | undefined;
+	const meta = block?.item_meta as ItemSchema | undefined;
 
 	return (
 		<FlowPlayerWrapper
@@ -18,10 +18,14 @@ const CollectionFragmentFlowPlayer: FC<CollectionFragmentFlowPlayerProps> = (pro
 			external_id={meta?.external_id}
 			duration={meta?.duration}
 			title={meta?.title}
-			cuePoints={{
-				start: block.start_oc,
-				end: block.end_oc,
-			}}
+			cuePoints={
+				block
+					? {
+							start: block.start_oc,
+							end: block.end_oc,
+					  }
+					: undefined
+			}
 			{...rest}
 		/>
 	);

--- a/src/collection/components/CollectionFragmentMeta.tsx
+++ b/src/collection/components/CollectionFragmentMeta.tsx
@@ -8,14 +8,14 @@ import { SearchFilter } from '../../search/search.const';
 import { buildLink } from '../../shared/helpers';
 import { BlockItemComponent } from '../collection.types';
 
-export type CollectionFragmentMetaProps = BlockItemComponent & { enableContentLinks: boolean };
+export type CollectionFragmentMetaProps = BlockItemComponent & { canClickSeries?: boolean };
 
-const CollectionFragmentMeta: FC<CollectionFragmentMetaProps> = ({ block, enableContentLinks }) => {
+const CollectionFragmentMeta: FC<CollectionFragmentMetaProps> = ({ block, canClickSeries }) => {
 	const [t] = useTranslation();
 
-	const organisation = block.item_meta?.organisation?.name;
-	const publishedAt = block.item_meta?.published_at;
-	const series = (block.item_meta as ItemSchema)?.series;
+	const organisation = block?.item_meta?.organisation?.name;
+	const publishedAt = block?.item_meta?.published_at;
+	const series = (block?.item_meta as ItemSchema)?.series;
 
 	return organisation || publishedAt || series ? (
 		<section className="u-spacer-bottom">
@@ -34,7 +34,7 @@ const CollectionFragmentMeta: FC<CollectionFragmentMetaProps> = ({ block, enable
 			{series && (
 				<div>
 					{t('collection/views/collection-detail___reeks')}:{' '}
-					{enableContentLinks ? (
+					{canClickSeries ? (
 						<Link
 							target="_blank"
 							to={buildLink(APP_PATH.SEARCH.route, undefined, {

--- a/src/collection/components/CollectionFragmentRichText.tsx
+++ b/src/collection/components/CollectionFragmentRichText.tsx
@@ -20,9 +20,9 @@ const CollectionFragmentRichText: FC<CollectionFragmentRichTextProps> = (props) 
 				className="c-collection-fragment-rich-text__parser c-content"
 				sanitizePreset="full"
 				content={convertToHtml(
-					block.use_custom_fields
+					block?.use_custom_fields
 						? block.custom_description
-						: block.item_meta?.description
+						: block?.item_meta?.description
 				)}
 				{...rest}
 			/>

--- a/src/collection/components/CollectionFragmentTitle.tsx
+++ b/src/collection/components/CollectionFragmentTitle.tsx
@@ -7,18 +7,19 @@ import { buildLink } from '../../shared/helpers';
 import { BlockItemComponent } from '../collection.types';
 
 export interface CollectionFragmentTitleProps extends BlockItemComponent {
-	enableTitleLink?: boolean;
+	canClickHeading?: boolean;
 }
 
-const CollectionFragmentTitle: FC<CollectionFragmentTitleProps> = ({ block, enableTitleLink }) => {
+const CollectionFragmentTitle: FC<CollectionFragmentTitleProps> = ({ block, canClickHeading }) => {
 	const heading = (
 		<BlockHeading type="h2">
-			{block.use_custom_fields ? block.custom_title : block.item_meta?.title}
+			{block?.use_custom_fields ? block.custom_title : block?.item_meta?.title}
 		</BlockHeading>
 	);
 
 	if (
-		enableTitleLink &&
+		canClickHeading &&
+		block &&
 		block.type === 'ITEM' &&
 		block.item_meta?.type?.label &&
 		['video', 'audio'].includes(block.item_meta?.type?.label)

--- a/src/collection/components/CollectionFragmentTypeItem.tsx
+++ b/src/collection/components/CollectionFragmentTypeItem.tsx
@@ -13,12 +13,11 @@ import CollectionFragmentRichText, {
 } from './CollectionFragmentRichText';
 import CollectionFragmentTitle, { CollectionFragmentTitleProps } from './CollectionFragmentTitle';
 
-interface CollectionFragmentTypeItemProps extends DefaultProps {
+export interface CollectionFragmentTypeItemProps extends DefaultProps {
 	title?: CollectionFragmentTitleProps;
 	richText?: CollectionFragmentRichTextProps;
 	meta?: CollectionFragmentMetaProps;
 	flowPlayer?: CollectionFragmentFlowPlayerProps;
-	enableContentLinks: boolean;
 }
 
 const CollectionFragmentTypeItem: FC<CollectionFragmentTypeItemProps> = ({
@@ -27,14 +26,13 @@ const CollectionFragmentTypeItem: FC<CollectionFragmentTypeItemProps> = ({
 	meta,
 	flowPlayer,
 	className,
-	enableContentLinks,
 }) => {
 	const richTextRef = useRef(null);
 	const [time, , formatTimestamps] = useVideoWithTimestamps(richTextRef);
 
 	return (
 		<>
-			{title && <CollectionFragmentTitle {...title} enableTitleLink={enableContentLinks} />}
+			{title && <CollectionFragmentTitle {...title} />}
 			<CollapsibleColumn
 				className={className}
 				grow={
@@ -46,20 +44,15 @@ const CollectionFragmentTypeItem: FC<CollectionFragmentTypeItemProps> = ({
 				}
 				bound={
 					<>
-						{meta && (
-							<CollectionFragmentMeta
-								{...meta}
-								enableContentLinks={enableContentLinks}
-							/>
-						)}
+						{meta && <CollectionFragmentMeta {...meta} />}
 						{richText &&
 							(() => {
 								// Add timestamps
 								const formatted = formatTimestamps(
 									convertToHtml(
-										richText.block.use_custom_fields
-											? richText.block.custom_description
-											: richText.block.item_meta?.description
+										richText.block?.use_custom_fields
+											? richText.block?.custom_description
+											: richText.block?.item_meta?.description
 									) || ''
 								);
 

--- a/src/collection/components/CollectionFragmentTypeText.tsx
+++ b/src/collection/components/CollectionFragmentTypeText.tsx
@@ -5,20 +5,15 @@ import CollectionFragmentRichText, {
 } from './CollectionFragmentRichText';
 import CollectionFragmentTitle, { CollectionFragmentTitleProps } from './CollectionFragmentTitle';
 
-interface CollectionFragmentTypeTextProps {
+export interface CollectionFragmentTypeTextProps {
 	title?: CollectionFragmentTitleProps;
 	richText?: CollectionFragmentRichTextProps;
-	enableContentLinks: boolean;
 }
 
-const CollectionFragmentTypeText: FC<CollectionFragmentTypeTextProps> = ({
-	title,
-	richText,
-	enableContentLinks,
-}) => {
+const CollectionFragmentTypeText: FC<CollectionFragmentTypeTextProps> = ({ title, richText }) => {
 	return (
 		<>
-			{title && <CollectionFragmentTitle {...title} enableTitleLink={enableContentLinks} />}
+			{title && <CollectionFragmentTitle {...title} />}
 			{richText && <CollectionFragmentRichText {...richText} />}
 		</>
 	);

--- a/src/collection/components/index.ts
+++ b/src/collection/components/index.ts
@@ -12,4 +12,4 @@ export { default as FragmentDetail } from './fragment/FragmentDetail';
 export { default as FragmentEdit } from './fragment/FragmentEdit';
 export { default as FragmentList } from './fragment/FragmentList';
 export { default as PublishCollectionModal } from './modals/PublishCollectionModal';
-export { default as CollectionOrAssignmentBlocks } from '../../shared/components/BlockList/BlockList';
+export { default as BlockList } from '../../shared/components/BlockList/BlockList';

--- a/src/collection/views/CollectionDetail.tsx
+++ b/src/collection/views/CollectionDetail.tsx
@@ -68,7 +68,7 @@ import { CollectionService } from '../collection.service';
 import { ContentTypeString, Relation } from '../collection.types';
 import {
 	AutoplayCollectionModal,
-	CollectionOrAssignmentBlocks,
+	BlockList,
 	FragmentList,
 	PublishCollectionModal,
 } from '../components';
@@ -1009,16 +1009,28 @@ const CollectionDetail: FunctionComponent<
 					{/* Start */}
 
 					<Container mode="vertical" className="u-padding-top-l u-padding-bottom-l">
-						<CollectionOrAssignmentBlocks
+						<BlockList
 							blocks={collection.collection_fragments}
-							canPlay={
-								!isAddToBundleModalOpen &&
-								!isDeleteModalOpen &&
-								!isPublishModalOpen &&
-								!isShareThroughEmailModalOpen &&
-								!isAutoplayCollectionModalOpen
-							}
-							enableContentLinks={permissions?.canViewAnyPublishedItems || false}
+							config={{
+								text: {
+									title: {
+										canClickHeading: permissions?.canViewAnyPublishedItems,
+									},
+								},
+								item: {
+									meta: {
+										canClickSeries: permissions?.canViewAnyPublishedItems,
+									},
+									flowPlayer: {
+										canPlay:
+											!isAddToBundleModalOpen &&
+											!isDeleteModalOpen &&
+											!isPublishModalOpen &&
+											!isShareThroughEmailModalOpen &&
+											!isAutoplayCollectionModalOpen,
+									},
+								},
+							}}
 						/>
 					</Container>
 

--- a/src/shared/components/BlockList/BlockList.tsx
+++ b/src/shared/components/BlockList/BlockList.tsx
@@ -11,7 +11,7 @@ import { IconBar } from '../index';
 import { BLOCK_ITEM_ICONS } from './BlockList.consts';
 import { BlockItemBase, BlockListProps } from './BlockList.types';
 
-const BlockList: FC<BlockListProps> = ({ blocks, canPlay, enableContentLinks }) => {
+const BlockList: FC<BlockListProps> = ({ blocks, config }) => {
 	const renderCollectionFragment = (block: BlockItemBase) => {
 		const layout = (children?: ReactNode) => (
 			<Container mode="horizontal" className="u-p-0">
@@ -29,25 +29,25 @@ const BlockList: FC<BlockListProps> = ({ blocks, canPlay, enableContentLinks }) 
 			case CollectionBlockType.TEXT:
 				return layout(
 					<CollectionFragmentTypeText
-						title={{ block: block }}
-						richText={{ block: block }}
-						enableContentLinks={enableContentLinks}
+						{...config?.text}
+						title={{ ...config?.text?.title, block }}
+						richText={{ ...config?.text?.richText, block }}
 					/>
 				);
 			case CollectionBlockType.ITEM:
 				return layout(
 					<CollectionFragmentTypeItem
-						className="m-collection-detail__video-content"
+						{...config?.item}
 						title={{
-							block: block,
+							...config?.item?.title,
+							block,
 						}}
-						richText={{ block: block }}
+						richText={{ ...config?.item?.richText, block }}
 						flowPlayer={{
-							block: block,
-							canPlay,
+							...config?.item?.flowPlayer,
+							block,
 						}}
-						meta={{ block: block, enableContentLinks }}
-						enableContentLinks={enableContentLinks}
+						meta={{ ...config?.item?.meta, block }}
 					/>
 				);
 

--- a/src/shared/components/BlockList/BlockList.types.tsx
+++ b/src/shared/components/BlockList/BlockList.types.tsx
@@ -1,6 +1,8 @@
 import { AssignmentBlockType } from '@viaa/avo2-types/types/assignment';
 import { CollectionFragmentType, CollectionSchema } from '@viaa/avo2-types/types/collection';
 import { ItemSchema } from '@viaa/avo2-types/types/item';
+import { CollectionFragmentTypeItemProps } from '../../../collection/components/CollectionFragmentTypeItem';
+import { CollectionFragmentTypeTextProps } from '../../../collection/components/CollectionFragmentTypeText';
 
 export type BlockItemType = CollectionFragmentType | AssignmentBlockType;
 
@@ -22,8 +24,11 @@ export interface BlockItemBase {
 	item_meta?: ItemSchema | CollectionSchema;
 }
 
+// TODO: move subcomponents to shared to avoid bleed
 export interface BlockListProps {
 	blocks: BlockItemBase[];
-	canPlay: boolean;
-	enableContentLinks: boolean;
+	config?: {
+		text?: Partial<CollectionFragmentTypeTextProps>;
+		item?: Partial<CollectionFragmentTypeItemProps>;
+	};
 }


### PR DESCRIPTION
Instead of toggling features by passing a boolean, pass through optional configurations of all underlying components. In scenarios where these configurations are shared/duplicated they can be split into constants as needed.

Related to https://github.com/viaacode/avo2-client/pull/1384#discussion_r913476732