### PR TITLE
feat(avo-1912): plus button on pupil collection adds text block

### DIFF
--- a/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponsePupilCollectionTab.tsx
+++ b/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponsePupilCollectionTab.tsx
@@ -176,8 +176,16 @@ const AssignmentResponsePupilCollectionTab: FunctionComponent<
 									icon="plus"
 									type="secondary"
 									onClick={() => {
-										addBlockModal.setEntity(item?.position);
-										addBlockModal.setOpen(true);
+										const newBlocks = insertAtPosition(
+											assignmentResponse.pupil_collection_blocks || [],
+											{
+												id: `${NEW_ASSIGNMENT_BLOCK_ID_PREFIX}${new Date().valueOf()}`,
+												type: AssignmentBlockType.TEXT,
+												position: item?.position,
+											} as unknown as PupilCollectionFragment
+										);
+
+										updateBlocksInAssignmentResponseState(newBlocks);
 									}}
 								/>
 							),


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-1912

Since pupils have no bookmarks or own collections, they can only add text blocks using the plus button.
To add fragments they need to use the search tab.

![image](https://user-images.githubusercontent.com/1710840/177834737-283d573e-72d1-439f-a122-539a523efcb7.png)
![image](https://user-images.githubusercontent.com/1710840/177834730-c1c91987-3efd-4670-833c-a2242c9b9ff1.png)
