### PR TITLE
fix(assignment-edit): import collection under item_meta instead of item

### DIFF
--- a/src/assignment/views/AssignmentEdit.tsx
+++ b/src/assignment/views/AssignmentEdit.tsx
@@ -218,7 +218,8 @@ const AssignmentEdit: FunctionComponent<DefaultSecureRouteProps<{ id: string }>>
 		const collection = await CollectionService.fetchCollectionOrBundleById(
 			collectionId,
 			'collection',
-			undefined
+			undefined,
+			true
 		);
 
 		if (!collection) {
@@ -229,20 +230,26 @@ const AssignmentEdit: FunctionComponent<DefaultSecureRouteProps<{ id: string }>>
 		}
 
 		if (collection.collection_fragments) {
-			const blocks = collection.collection_fragments.map((collectionItem, index) => ({
-				id: `${NEW_ASSIGNMENT_BLOCK_ID_PREFIX}${new Date().valueOf() + index}`,
-				item: collectionItem.item_meta,
-				type: collectionItem.type,
-				fragment_id: collectionItem.external_id,
-				position: (addBlockModal.entity || 0) + index,
-				original_title: withDescription ? collectionItem.custom_title : null,
-				original_description: withDescription ? collectionItem.custom_description : null,
-				custom_title: collectionItem.use_custom_fields ? collectionItem.custom_title : null,
-				custom_description: collectionItem.use_custom_fields
-					? collectionItem.custom_description
-					: null,
-				use_custom_fields: collectionItem.use_custom_fields,
-			}));
+			const blocks = collection.collection_fragments.map(
+				(collectionItem, index): Partial<AssignmentBlock> => ({
+					id: `${NEW_ASSIGNMENT_BLOCK_ID_PREFIX}${new Date().valueOf() + index}`,
+					item_meta: collectionItem.item_meta,
+					type: collectionItem.type,
+					fragment_id: collectionItem.external_id,
+					position: (addBlockModal.entity || 0) + index,
+					original_title: withDescription ? collectionItem.custom_title : null,
+					original_description: withDescription
+						? collectionItem.custom_description
+						: null,
+					custom_title: collectionItem.use_custom_fields
+						? collectionItem.custom_title
+						: null,
+					custom_description: collectionItem.use_custom_fields
+						? collectionItem.custom_description
+						: null,
+					use_custom_fields: collectionItem.use_custom_fields,
+				})
+			);
 			const newAssignmentBlocks = insertMultipleAtPosition(
 				assignment.blocks,
 				blocks as unknown as AssignmentBlock[]


### PR DESCRIPTION
When importing a collection from the assignment edit page (plus button => collection)

before:
![image](https://user-images.githubusercontent.com/1710840/178033887-330f8e65-e891-485a-acbd-276ef585ff38.png)

after:
![image](https://user-images.githubusercontent.com/1710840/178033908-066ff66d-af10-4cc6-a900-67592bb3c56e.png)
