### PR TITLE
feat(add-item-coll-modal): make table scrollable

### DIFF
--- a/src/assignment/modals/AddBookmarkFragmentModal.tsx
+++ b/src/assignment/modals/AddBookmarkFragmentModal.tsx
@@ -19,6 +19,7 @@ import { Avo } from '@viaa/avo2-types';
 import { noop } from 'lodash-es';
 import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import ScrollBar from 'react-perfect-scrollbar';
 
 import { LoadingErrorLoadedComponent, LoadingInfo } from '../../shared/components';
 import { CustomError, formatDate, isMobileWidth } from '../../shared/helpers';
@@ -30,6 +31,8 @@ import { BookmarkInfo } from '../../shared/services/bookmarks-views-plays-servic
 import i18n from '../../shared/translations/i18n';
 import { TableColumnDataType } from '../../shared/types/table-column-data-type';
 import { AssignmentOverviewTableColumns } from '../assignment.types';
+
+import './AddItemsModals.scss';
 
 // Column definitions
 const GET_ADD_BOOKMARK_FRAGMENT_COLUMNS = (): TableColumn[] => [
@@ -247,31 +250,34 @@ const AddBookmarkFragmentModal: FunctionComponent<AddBookmarkFragmentModalProps>
 					</FormGroup>
 				</Form>
 
-				<Table
-					columns={tableColumns}
-					data={bookmarks || undefined}
-					emptyStateMessage={
-						filterString
-							? t(
-									'assignment/views/assignment-overview___er-zijn-geen-opdrachten-die-voldoen-aan-de-zoekopdracht'
-							  )
-							: t(
-									'assignment/views/assignment-overview___er-zijn-nog-geen-opdrachten-aangemaakt'
-							  )
-					}
-					renderCell={(rowData: BookmarkInfo, colKey: string) =>
-						renderCell(rowData, colKey as keyof BookmarkInfo)
-					}
-					rowKey="contentLinkId"
-					variant="styled"
-					onColumnClick={handleColumnClick as any}
-					sortColumn={sortColumn}
-					sortOrder={sortOrder}
-					useCards={isMobileWidth()}
-					showRadioButtons
-					selectedItemIds={selectedBookmarkId ? [selectedBookmarkId] : []}
-					onSelectionChanged={handleSelectedBookmarkItemChanged}
-				/>
+				<ScrollBar>
+					<Table
+						columns={tableColumns}
+						data={bookmarks || undefined}
+						emptyStateMessage={
+							filterString
+								? t(
+										'assignment/views/assignment-overview___er-zijn-geen-opdrachten-die-voldoen-aan-de-zoekopdracht'
+								  )
+								: t(
+										'assignment/views/assignment-overview___er-zijn-nog-geen-opdrachten-aangemaakt'
+								  )
+						}
+						renderCell={(rowData: BookmarkInfo, colKey: string) =>
+							renderCell(rowData, colKey as keyof BookmarkInfo)
+						}
+						rowKey="contentLinkId"
+						variant="styled"
+						onColumnClick={handleColumnClick as any}
+						sortColumn={sortColumn}
+						sortOrder={sortOrder}
+						useCards={isMobileWidth()}
+						showRadioButtons
+						selectedItemIds={selectedBookmarkId ? [selectedBookmarkId] : []}
+						onSelectionChanged={handleSelectedBookmarkItemChanged}
+					/>
+				</ScrollBar>
+
 				{renderFooterActions()}
 			</>
 		);
@@ -286,7 +292,7 @@ const AddBookmarkFragmentModal: FunctionComponent<AddBookmarkFragmentModalProps>
 			size="large"
 			onClose={onClose}
 			scrollable
-			className="c-content"
+			className="c-content c-add-fragment-modal"
 		>
 			<ModalBody>
 				<LoadingErrorLoadedComponent

--- a/src/assignment/modals/AddCollectionModal.tsx
+++ b/src/assignment/modals/AddCollectionModal.tsx
@@ -23,6 +23,7 @@ import { Avo } from '@viaa/avo2-types';
 import { noop } from 'lodash-es';
 import React, { FC, FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import ScrollBar from 'react-perfect-scrollbar';
 import { compose } from 'redux';
 
 import { CollectionService } from '../../collection/collection.service';
@@ -37,6 +38,8 @@ import { ToastService } from '../../shared/services';
 import i18n from '../../shared/translations/i18n';
 import { TableColumnDataType } from '../../shared/types/table-column-data-type';
 import { AssignmentOverviewTableColumns } from '../assignment.types';
+
+import './AddItemsModals.scss';
 
 // Column definitions
 const GET_ADD_COLLECTION_COLUMNS = (): TableColumn[] => [
@@ -325,31 +328,34 @@ const AddCollectionModal: FunctionComponent<AddCollectionModalProps> = ({
 					</ToolbarRight>
 				</Toolbar>
 
-				<Table
-					columns={tableColumns}
-					data={collections || undefined}
-					emptyStateMessage={
-						filterString
-							? t(
-									'assignment/modals/add-collection-modal___er-zijn-geen-collecties-die-voldoen-aan-de-zoekopdracht'
-							  )
-							: t(
-									'assignment/modals/add-collection-modal___er-zijn-nog-geen-collecties-aangemaakt'
-							  )
-					}
-					renderCell={(rowData: Avo.Collection.Collection, colKey: string) =>
-						renderCell(rowData, colKey as keyof Avo.Collection.Collection)
-					}
-					rowKey="id"
-					variant="styled"
-					onColumnClick={handleColumnClick as any}
-					sortColumn={sortColumn}
-					sortOrder={sortOrder}
-					useCards={isMobileWidth()}
-					showRadioButtons
-					selectedItemIds={selectedCollectionId ? [selectedCollectionId] : []}
-					onSelectionChanged={handleSelectedCollectionChanged}
-				/>
+				<ScrollBar>
+					<Table
+						columns={tableColumns}
+						data={collections || undefined}
+						emptyStateMessage={
+							filterString
+								? t(
+										'assignment/modals/add-collection-modal___er-zijn-geen-collecties-die-voldoen-aan-de-zoekopdracht'
+								  )
+								: t(
+										'assignment/modals/add-collection-modal___er-zijn-nog-geen-collecties-aangemaakt'
+								  )
+						}
+						renderCell={(rowData: Avo.Collection.Collection, colKey: string) =>
+							renderCell(rowData, colKey as keyof Avo.Collection.Collection)
+						}
+						rowKey="id"
+						variant="styled"
+						onColumnClick={handleColumnClick as any}
+						sortColumn={sortColumn}
+						sortOrder={sortOrder}
+						useCards={isMobileWidth()}
+						showRadioButtons
+						selectedItemIds={selectedCollectionId ? [selectedCollectionId] : []}
+						onSelectionChanged={handleSelectedCollectionChanged}
+					/>
+				</ScrollBar>
+
 				{renderFooterActions()}
 			</>
 		);
@@ -362,7 +368,7 @@ const AddCollectionModal: FunctionComponent<AddCollectionModalProps> = ({
 			size="large"
 			onClose={onClose}
 			scrollable
-			className="c-content"
+			className="c-content c-add-collection-modal"
 		>
 			<ModalBody>
 				<LoadingErrorLoadedComponent

--- a/src/assignment/modals/AddItemsModals.scss
+++ b/src/assignment/modals/AddItemsModals.scss
@@ -1,0 +1,20 @@
+@import '../../styles/settings/variables';
+
+.c-add-fragment-modal,
+.c-add-collection-modal {
+	.c-thumbnail {
+		margin-right: 10px;
+		max-width: 125px;
+		height: 70px;
+	}
+
+	.scrollbar-container {
+		.scrollbar-container {
+			max-height: 100vh;
+
+			@media screen and (min-width: $g-bp1) {
+				max-height: 60vh;
+			}
+		}
+	}
+}


### PR DESCRIPTION
so the action buttons are always visible
also make all video thumbnails the same size

before:
![image](https://user-images.githubusercontent.com/1710840/178037910-586988ba-15a7-41ef-b36b-2ac6ee387c01.png)
![image](https://user-images.githubusercontent.com/1710840/178037934-7537dc73-2cd1-40ec-9a17-c3e9c8258337.png)


after:
![image](https://user-images.githubusercontent.com/1710840/178037958-b7ec0056-37c3-4de4-abf5-439fa3928205.png)
![image](https://user-images.githubusercontent.com/1710840/178037972-6a0f2dfa-c6fb-40a8-9c55-145a9dc746db.png)
