### PR TITLE
fix(pupil-collection): add block can only be text

### DIFF
--- a/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponsePupilCollectionTab.tsx
+++ b/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponsePupilCollectionTab.tsx
@@ -18,6 +18,7 @@ import { compose } from 'redux';
 
 import { ItemsService } from '../../../../admin/items/items.service';
 import { ReactComponent as PupilSvg } from '../../../../assets/images/leerling.svg';
+import { CollectionBlockType } from '../../../../collection/collection.const';
 import { BlockList } from '../../../../collection/components';
 import EmptyStateMessage from '../../../../shared/components/EmptyStateMessage/EmptyStateMessage';
 import MoreOptionsDropdown from '../../../../shared/components/MoreOptionsDropdown/MoreOptionsDropdown';
@@ -166,8 +167,17 @@ const AssignmentResponsePupilCollectionTab: FunctionComponent<
 						icon="plus"
 						type="secondary"
 						onClick={() => {
-							addBlockModal.setEntity(item?.position);
-							addBlockModal.setOpen(true);
+							const newBlocks = insertAtPosition(
+								assignmentResponse.pupil_collection_blocks || [],
+								{
+									id: `${NEW_ASSIGNMENT_BLOCK_ID_PREFIX}${new Date().valueOf()}`,
+									assignment_response_id: assignmentResponse.id,
+									type: CollectionBlockType.TEXT,
+									position: item?.position || 0,
+								} as PupilCollectionFragment
+							);
+
+							updateBlocksInAssignmentResponseState(newBlocks);
 						}}
 					/>
 				),

--- a/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponsePupilCollectionTab.tsx
+++ b/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponsePupilCollectionTab.tsx
@@ -10,31 +10,23 @@ import {
 	ToolbarRight,
 } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
-import { AssignmentBlock } from '@viaa/avo2-types/types/assignment';
 import React, { Dispatch, FunctionComponent, SetStateAction, useState } from 'react';
 import { Controller, UseFormReturn } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { compose } from 'redux';
 
-import { ItemsService } from '../../../../admin/items/items.service';
 import { ReactComponent as PupilSvg } from '../../../../assets/images/leerling.svg';
 import { CollectionBlockType } from '../../../../collection/collection.const';
 import { BlockList } from '../../../../collection/components';
 import EmptyStateMessage from '../../../../shared/components/EmptyStateMessage/EmptyStateMessage';
 import MoreOptionsDropdown from '../../../../shared/components/MoreOptionsDropdown/MoreOptionsDropdown';
 import { isMobileWidth } from '../../../../shared/helpers';
-import withUser, { UserProps } from '../../../../shared/hocs/withUser';
 import { useDraggableListModal } from '../../../../shared/hooks/use-draggable-list-modal';
 import { ToastService } from '../../../../shared/services';
 import {
 	ASSIGNMENT_RESPONSE_CREATE_UPDATE_TABS,
 	NEW_ASSIGNMENT_BLOCK_ID_PREFIX,
 } from '../../../assignment.const';
-import {
-	AssignmentBlockType,
-	AssignmentResponseFormState,
-	PupilCollectionFragment,
-} from '../../../assignment.types';
+import { AssignmentResponseFormState, PupilCollectionFragment } from '../../../assignment.types';
 import { insertAtPosition } from '../../../helpers/insert-at-position';
 import {
 	useAssignmentBlockChangeHandler,
@@ -61,8 +53,7 @@ interface AssignmentResponsePupilCollectionTabProps {
 
 const AssignmentResponsePupilCollectionTab: FunctionComponent<
 	AssignmentResponsePupilCollectionTabProps &
-		Pick<UseFormReturn<AssignmentResponseFormState>, 'setValue' | 'control'> &
-		UserProps
+		Pick<UseFormReturn<AssignmentResponseFormState>, 'setValue' | 'control'>
 > = ({
 	pastDeadline,
 	assignmentResponse,
@@ -71,7 +62,6 @@ const AssignmentResponsePupilCollectionTab: FunctionComponent<
 	control,
 	onShowPreviewClicked,
 	setTab,
-	user,
 }) => {
 	const [t] = useTranslation();
 	const [isMobileOptionsMenuOpen, setIsMobileOptionsMenuOpen] = useState<boolean>(false);
@@ -114,36 +104,12 @@ const AssignmentResponsePupilCollectionTab: FunctionComponent<
 	// Effects
 
 	// Events
-	const onAddItem = async (itemExternalId: string) => {
-		if (addBlockModal.entity == null) {
-			return;
-		}
-
-		// fetch item details
-		const item_meta = (await ItemsService.fetchItemByExternalId(itemExternalId)) || undefined;
-		const newBlocks = insertAtPosition<Partial<Avo.Core.BlockItemBase>>(
-			assignmentResponse?.pupil_collection_blocks || [],
-			{
-				id: `${NEW_ASSIGNMENT_BLOCK_ID_PREFIX}${new Date().valueOf()}`,
-				item_meta,
-				type: AssignmentBlockType.ITEM,
-				fragment_id: itemExternalId,
-				position: addBlockModal.entity,
-			} as AssignmentBlock
-		) as AssignmentBlock[];
-
-		updateBlocksInAssignmentResponseState(newBlocks);
-	};
-	const [renderedModals, confirmSliceModal, addBlockModal] = useBlockListModals(
+	const [renderedModals, confirmSliceModal] = useBlockListModals(
 		assignmentResponse?.pupil_collection_blocks || [],
 		updateBlocksInAssignmentResponseState,
 		{
 			confirmSliceConfig: {
 				responses: [],
-			},
-			addBookmarkFragmentConfig: {
-				user,
-				addFragmentCallback: onAddItem,
 			},
 		}
 	);
@@ -364,7 +330,4 @@ const AssignmentResponsePupilCollectionTab: FunctionComponent<
 	);
 };
 
-export default compose(withUser)(AssignmentResponsePupilCollectionTab) as FunctionComponent<
-	AssignmentResponsePupilCollectionTabProps &
-		Pick<UseFormReturn<AssignmentResponseFormState>, 'setValue' | 'control'>
->;
+export default AssignmentResponsePupilCollectionTab;


### PR DESCRIPTION
It seems like this one got lost during the big merging

![image](https://user-images.githubusercontent.com/1710840/178480227-ccba2d98-bc83-4466-9cd9-da786df15b67.png)
