### PR TITLE
fix(avo-2016): format publish date in fragment metadata

### DIFF
--- a/src/collection/components/CollectionFragmentMeta.tsx
+++ b/src/collection/components/CollectionFragmentMeta.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 
 import { APP_PATH } from '../../constants';
 import { SearchFilter } from '../../search/search.const';
-import { buildLink } from '../../shared/helpers';
+import { buildLink, formatDate } from '../../shared/helpers';
 import { BlockItemComponent } from '../collection.types';
 
 export type CollectionFragmentMetaProps = BlockItemComponent & {
@@ -29,7 +29,8 @@ const CollectionFragmentMeta: FC<CollectionFragmentMetaProps> = ({ block, canCli
 
 			{publishedAt && (
 				<div>
-					{t('collection/views/collection-detail___uitzenddatum')}:<b> {publishedAt}</b>
+					{t('collection/views/collection-detail___uitzenddatum')}:
+					<b> {formatDate(publishedAt)}</b>
 				</div>
 			)}
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2016

![image](https://user-images.githubusercontent.com/1710840/178738162-31c3b61d-9cf1-4661-addd-5a19849e12f3.png)
