### PR TITLE
fix(avo-2020): hide back button on preview as pupil

### DIFF
--- a/src/assignment/components/AssignmentPupilPreview.tsx
+++ b/src/assignment/components/AssignmentPupilPreview.tsx
@@ -63,6 +63,7 @@ const AssignmentPupilPreview: FC<AssignmentPupilPreviewProps & UserProps> = ({
 				assignment={assignment as Avo.Assignment.Assignment_v2}
 				assignmentResponse={assignmentResponse}
 				setAssignmentResponse={setAssignmentResponse}
+				showBackButton={false}
 				onAssignmentChanged={async () => {
 					// Ignore changes to assignment during preview
 				}}

--- a/src/assignment/views/AssignmentResponseEdit/AssignmentResponseEdit.tsx
+++ b/src/assignment/views/AssignmentResponseEdit/AssignmentResponseEdit.tsx
@@ -61,6 +61,7 @@ interface AssignmentResponseEditProps {
 	assignment: Avo.Assignment.Assignment_v2;
 	assignmentResponse: Avo.Assignment.Response_v2 | null;
 	setAssignmentResponse: (newResponse: Avo.Assignment.Response_v2 | null) => void;
+	showBackButton: boolean;
 	onAssignmentChanged: () => Promise<void>;
 	onShowPreviewClicked: () => void;
 }
@@ -70,6 +71,7 @@ const AssignmentResponseEdit: FunctionComponent<AssignmentResponseEditProps & Us
 	assignmentResponse,
 	onAssignmentChanged,
 	setAssignmentResponse,
+	showBackButton,
 	onShowPreviewClicked,
 	user,
 }) => {
@@ -290,7 +292,7 @@ const AssignmentResponseEdit: FunctionComponent<AssignmentResponseEditProps & Us
 			<div className="c-assignment-response-page c-assignment-response-page--edit c-sticky-save-bar__wrapper">
 				<div>
 					<AssignmentHeading
-						back={renderBackButton}
+						back={showBackButton ? renderBackButton : undefined}
 						title={renderedTitle}
 						tabs={renderTabs()}
 						info={

--- a/src/assignment/views/AssignmentResponseEdit/AssignmentResponseEditPage.tsx
+++ b/src/assignment/views/AssignmentResponseEdit/AssignmentResponseEditPage.tsx
@@ -215,6 +215,7 @@ const AssignmentResponseEditPage: FunctionComponent<
 				assignment={assignment}
 				assignmentResponse={assignmentResponse}
 				setAssignmentResponse={setAssignmentResponse}
+				showBackButton
 				onShowPreviewClicked={() => {
 					setIsTeacherPreviewEnabled(true);
 				}}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2020

before:
![image](https://user-images.githubusercontent.com/1710840/178940155-6e8bab56-3e66-4d8e-b08c-ef18c8748bb0.png)


after:
![image](https://user-images.githubusercontent.com/1710840/178940186-06391fb0-0a58-4eb2-b4d9-cd2cf5d78ceb.png)
