### PR TITLE
fix(avo-2023): add outline to rich text editor buttons

### DIFF
--- a/src/shared/components/WYSIWYGWrapper/WYSIWYGWrapper.scss
+++ b/src/shared/components/WYSIWYGWrapper/WYSIWYGWrapper.scss
@@ -1,3 +1,16 @@
-.DraftEditor-editorContainer .public-DraftEditor-content > div > div:first-child {
-	margin-top: 0;
+@import '../../../styles/settings/colors';
+
+.DraftEditor-editorContainer {
+	.public-DraftEditor-content > div > div:first-child {
+		margin-top: 0;
+	}
+}
+
+.c-rich-text-editor {
+	.control-item,
+	.dropdown-handler {
+		&:focus {
+			outline: 2px solid $color-teal-bright;
+		}
+	}
 }


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2023

Add outline to rich text editor buttons so it is clear to the user where the focus is during tabbing

![image](https://user-images.githubusercontent.com/1710840/178949760-7e4e2ed3-93e2-4ad3-b71a-f25614c90bad.png)
