### PR TITLE
fix(avo-2037): remove available_at and answer_url from duplicate

### DIFF
--- a/src/assignment/assignment.service.ts
+++ b/src/assignment/assignment.service.ts
@@ -654,10 +654,12 @@ export class AssignmentService {
 		}
 
 		// clone the assignment
-		const newAssignment = {
+		const newAssignment: Partial<Avo.Assignment.Assignment_v2> = {
 			...cloneDeep(initialAssignment),
 			title: newTitle,
+			available_at: new Date().toISOString(),
 			deadline_at: null,
+			answer_url: null,
 		};
 
 		delete newAssignment.id;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2037

* delete answer_url 
* set available_at to duplication date

original assignment:
![image](https://user-images.githubusercontent.com/1710840/179165930-122feeae-077e-40ab-8423-c9432d6a24c5.png)

copied assignment:
![image](https://user-images.githubusercontent.com/1710840/179165959-680fd3c1-c81e-49a1-961c-ade4dde91629.png)
