### PR TITLE
fix(avo-2041): rename urls params from id to responseId everywhere

### DIFF
--- a/src/assignment/views/AssignmentPupilCollectionDetail.tsx
+++ b/src/assignment/views/AssignmentPupilCollectionDetail.tsx
@@ -17,7 +17,7 @@ import AssignmentHeading from '../components/AssignmentHeading';
 import AssignmentMetadata from '../components/AssignmentMetadata';
 
 type AssignmentPupilCollectionDetailProps = DefaultSecureRouteProps<{
-	id: string;
+	responseId: string;
 	assignmentId: string;
 }>;
 
@@ -30,10 +30,11 @@ const AssignmentPupilCollectionDetail: FunctionComponent<AssignmentPupilCollecti
 	const [assignment, setAssignment] = useState<Avo.Assignment.Assignment_v2 | null>(null);
 	const [assignmentResponse, setAssignmentResponse] =
 		useState<Avo.Assignment.Response_v2 | null>();
+	const assignmentId = match.params.assignmentId;
+	const assignmentResponseId = match.params.responseId;
 
 	const fetchAssignmentResponse = useCallback(
 		async (tempAssignment: Avo.Assignment.Assignment_v2) => {
-			const assignmentResponseId = match.params.id;
 			const canViewAssignmentResponses = await PermissionService.hasPermissions(
 				[
 					PermissionName.EDIT_ANY_ASSIGNMENTS,
@@ -54,13 +55,11 @@ const AssignmentPupilCollectionDetail: FunctionComponent<AssignmentPupilCollecti
 
 			return AssignmentService.getAssignmentResponseById(assignmentResponseId);
 		},
-		[setAssignmentResponse, match.params.id]
+		[setAssignmentResponse, assignmentResponseId]
 	);
 
 	const fetchAssignment = useCallback(async () => {
 		try {
-			const assignmentId = match.params.assignmentId;
-
 			const tempAssignment = await AssignmentService.fetchAssignmentById(assignmentId);
 
 			setAssignmentResponse(await fetchAssignmentResponse(tempAssignment));
@@ -70,7 +69,7 @@ const AssignmentPupilCollectionDetail: FunctionComponent<AssignmentPupilCollecti
 			console.error(
 				new CustomError('Failed to fetch assignment and response', err, {
 					user,
-					id: match.params.id,
+					id: assignmentResponseId,
 				})
 			);
 			setLoadingInfo({
@@ -80,7 +79,7 @@ const AssignmentPupilCollectionDetail: FunctionComponent<AssignmentPupilCollecti
 				),
 			});
 		}
-	}, [setAssignment, setLoadingInfo, match.params.assignmentId, t, user]);
+	}, [setAssignment, setLoadingInfo, assignmentResponseId, t, user]);
 
 	// Effects
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2041

example url:
http://localhost:8080/werkruimte/opdrachten/48b8f26d-a151-4d3c-8809-ca1ee6060f7d/antwoorden/947b030d-dcac-4133-9ad5-12f209c059e3

before:
![image](https://user-images.githubusercontent.com/1710840/179520914-c99a39b4-7c77-452b-b2c5-7278b1bbfbf8.png)

after:
![image](https://user-images.githubusercontent.com/1710840/179520890-90784d65-e422-43fb-9a5d-7f7c96625bfb.png)
