### PR TITLE
fix(avo-1934): correctly check permissions for assignment responses view

### DIFF
--- a/src/assignment/views/AssignmentResponses.tsx
+++ b/src/assignment/views/AssignmentResponses.tsx
@@ -177,10 +177,10 @@ const AssignmentResponses: FunctionComponent<AssignmentResponsesProps> = ({
 	const fetchAssignment = useCallback(async () => {
 		try {
 			if (
-				PermissionService.hasPerm(user, PermissionName.VIEW_ASSIGNMENTS) ||
-				PermissionService.hasPerm(user, PermissionName.VIEW_ANY_ASSIGNMENTS) ||
-				PermissionService.hasPerm(user, PermissionName.VIEW_ANY_ASSIGNMENT_RESPONSES) ||
-				PermissionService.hasPerm(user, PermissionName.VIEW_OWN_ASSIGNMENT_RESPONSES)
+				!PermissionService.hasPerm(user, PermissionName.VIEW_ASSIGNMENTS) &&
+				!PermissionService.hasPerm(user, PermissionName.VIEW_ANY_ASSIGNMENTS) &&
+				!PermissionService.hasPerm(user, PermissionName.VIEW_ANY_ASSIGNMENT_RESPONSES) &&
+				!PermissionService.hasPerm(user, PermissionName.VIEW_OWN_ASSIGNMENT_RESPONSES)
 			) {
 				setLoadingInfo({
 					message: t(


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-1934

also added missing permissions to the database:
- VIEW_OWN_ASSIGNMENT_RESPONSES
- VIEW_ANY_ASSIGNMENT_RESPONSES

![image](https://user-images.githubusercontent.com/1710840/179979845-ae1a82ee-0a1d-4f42-b4fd-21e963433941.png)
![image](https://user-images.githubusercontent.com/1710840/179979856-574714b7-6639-474f-9a35-1917ce4a689a.png)
