### PR TITLE
fix(avo-2049): show unsaved changes modal above the other modals

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,0 +1,7 @@
+.c-modal__unsaved-changes {
+	z-index: 62; // Just above the other modals
+
+	+ .c-modal-backdrop--visible {
+		z-index: 61; // Just above the other modals
+	}
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { waitForTranslations } from './shared/translations/i18n';
 import store from './store';
 
 import './styles/main.scss';
+import './App.scss';
 
 const history = createBrowserHistory();
 wrapHistory(history, {
@@ -129,6 +130,7 @@ const Root: FunctionComponent = () => {
 						<QueryParamProvider ReactRouterRoute={Route}>
 							<AppWithRouter />
 							<ConfirmModal
+								className="c-modal__unsaved-changes"
 								isOpen={isUnsavedChangesModalOpen}
 								confirmCallback={() => {
 									setIsUnsavedChangesModalOpen(false);

--- a/src/assignment/views/AssignmentCreate.tsx
+++ b/src/assignment/views/AssignmentCreate.tsx
@@ -14,15 +14,17 @@ import React, {
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
-import { Link, Prompt } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { DefaultSecureRouteProps } from '../../authentication/components/SecuredRoute';
 import { APP_PATH, GENERATE_SITE_TITLE } from '../../constants';
 import { LoadingErrorLoadedComponent, LoadingInfo } from '../../shared/components';
+import { BeforeUnloadPrompt } from '../../shared/components/BeforeUnloadPrompt/BeforeUnloadPrompt';
 import EmptyStateMessage from '../../shared/components/EmptyStateMessage/EmptyStateMessage';
 import { StickySaveBar } from '../../shared/components/StickySaveBar/StickySaveBar';
 import { navigate } from '../../shared/helpers';
 import { useDraggableListModal } from '../../shared/hooks/use-draggable-list-modal';
+import { useWarningBeforeUnload } from '../../shared/hooks/useWarningBeforeUnload';
 import { ToastService } from '../../shared/services';
 import { trackEvents } from '../../shared/services/event-logging-service';
 import { ASSIGNMENT_CREATE_UPDATE_TABS, ASSIGNMENT_FORM_SCHEMA } from '../assignment.const';
@@ -46,7 +48,6 @@ import {
 
 import './AssignmentCreate.scss';
 import './AssignmentPage.scss';
-import { useWarningBeforeUnload } from '../../shared/hooks/useWarningBeforeUnload';
 
 const AssignmentCreate: FunctionComponent<DefaultSecureRouteProps> = ({ user, history }) => {
 	const [t] = useTranslation();
@@ -364,13 +365,6 @@ const AssignmentCreate: FunctionComponent<DefaultSecureRouteProps> = ({ user, hi
 
 					{renderedModals}
 					{draggableListModal}
-
-					<Prompt
-						when={isDirty}
-						message={t(
-							'assignment/views/assignment-create___er-zijn-nog-niet-opgeslagen-wijzigingen-weet-u-zeker-dat-u-de-pagina-wil-verlaten'
-						)}
-					/>
 				</Container>
 			</div>
 
@@ -419,6 +413,8 @@ const AssignmentCreate: FunctionComponent<DefaultSecureRouteProps> = ({ user, hi
 				loadingInfo={loadingInfo}
 				notFoundError={t('assignment/views/assignment-edit___de-opdracht-is-niet-gevonden')}
 			/>
+
+			<BeforeUnloadPrompt when={isDirty} />
 		</>
 	);
 };

--- a/src/assignment/views/AssignmentCreate.tsx
+++ b/src/assignment/views/AssignmentCreate.tsx
@@ -414,7 +414,7 @@ const AssignmentCreate: FunctionComponent<DefaultSecureRouteProps> = ({ user, hi
 				notFoundError={t('assignment/views/assignment-edit___de-opdracht-is-niet-gevonden')}
 			/>
 
-			<BeforeUnloadPrompt when={isDirty} />
+			<BeforeUnloadPrompt when={true} />
 		</>
 	);
 };

--- a/src/assignment/views/AssignmentCreate.tsx
+++ b/src/assignment/views/AssignmentCreate.tsx
@@ -131,7 +131,7 @@ const AssignmentCreate: FunctionComponent<DefaultSecureRouteProps> = ({ user, hi
 
 	// UI
 	useWarningBeforeUnload({
-		when: isDirty,
+		when: true, // Always do on create
 	});
 	const [loadingInfo, setLoadingInfo] = useState<LoadingInfo>({ state: 'loading' });
 	const [tabs, tab, , onTabClick] = useAssignmentTeacherTabs();

--- a/src/assignment/views/AssignmentCreate.tsx
+++ b/src/assignment/views/AssignmentCreate.tsx
@@ -65,7 +65,6 @@ const AssignmentCreate: FunctionComponent<DefaultSecureRouteProps> = ({ user, hi
 		reset: resetForm,
 		setValue,
 		trigger,
-		formState: { isDirty },
 	} = form;
 
 	const updateBlocksInAssignmentState = (newBlocks: Avo.Core.BlockItemBase[]) => {

--- a/src/assignment/views/AssignmentEdit.tsx
+++ b/src/assignment/views/AssignmentEdit.tsx
@@ -26,7 +26,7 @@ import React, {
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
-import { Link, Prompt } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { DefaultSecureRouteProps } from '../../authentication/components/SecuredRoute';
 import { PermissionName, PermissionService } from '../../authentication/helpers/permission-service';
@@ -35,6 +35,7 @@ import { BlockList } from '../../collection/components';
 import { GENERATE_SITE_TITLE } from '../../constants';
 import { ErrorView } from '../../error/views';
 import { ErrorViewQueryParams } from '../../error/views/ErrorView';
+import { BeforeUnloadPrompt } from '../../shared/components/BeforeUnloadPrompt/BeforeUnloadPrompt';
 import { StickySaveBar } from '../../shared/components/StickySaveBar/StickySaveBar';
 import { useDraggableListModal } from '../../shared/hooks/use-draggable-list-modal';
 import { useWarningBeforeUnload } from '../../shared/hooks/useWarningBeforeUnload';
@@ -563,13 +564,6 @@ const AssignmentEdit: FunctionComponent<DefaultSecureRouteProps<{ id: string }>>
 							},
 						}}
 					/>
-
-					<Prompt
-						when={isDirty}
-						message={t(
-							'assignment/views/assignment-edit___er-zijn-nog-niet-opgeslagen-wijzigingen-weet-u-zeker-dat-u-de-pagina-wil-verlaten'
-						)}
-					/>
 				</Container>
 			</div>
 
@@ -623,6 +617,8 @@ const AssignmentEdit: FunctionComponent<DefaultSecureRouteProps<{ id: string }>>
 			</MetaTags>
 
 			{renderPageContent()}
+
+			<BeforeUnloadPrompt when={isDirty} />
 		</>
 	);
 };

--- a/src/assignment/views/AssignmentResponseEdit/AssignmentResponseEdit.tsx
+++ b/src/assignment/views/AssignmentResponseEdit/AssignmentResponseEdit.tsx
@@ -20,7 +20,7 @@ import React, {
 } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { Link, Prompt } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
 	JsonParam,
 	NumberParam,
@@ -32,9 +32,11 @@ import {
 import { CollectionBlockType } from '../../../collection/collection.const';
 import { FilterState } from '../../../search/search.types';
 import { InteractiveTour } from '../../../shared/components';
+import { BeforeUnloadPrompt } from '../../../shared/components/BeforeUnloadPrompt/BeforeUnloadPrompt';
 import { StickySaveBar } from '../../../shared/components/StickySaveBar/StickySaveBar';
 import { formatTimestamp } from '../../../shared/helpers';
 import withUser, { UserProps } from '../../../shared/hocs/withUser';
+import { useWarningBeforeUnload } from '../../../shared/hooks/useWarningBeforeUnload';
 import { ToastService } from '../../../shared/services';
 import {
 	ASSIGNMENT_RESPONSE_CREATE_UPDATE_TABS,
@@ -50,6 +52,7 @@ import {
 import AssignmentHeading from '../../components/AssignmentHeading';
 import AssignmentMetadata from '../../components/AssignmentMetadata';
 import { buildAssignmentSearchLink } from '../../helpers/build-search-link';
+import { cleanupTitleAndDescriptions } from '../../helpers/cleanup-title-and-descriptions';
 import { backToOverview } from '../../helpers/links';
 import { useAssignmentPupilTabs } from '../../hooks';
 import { useAssignmentPastDeadline } from '../../hooks/assignment-past-deadline';
@@ -60,8 +63,6 @@ import AssignmentResponseSearchTab from './tabs/AssignmentResponseSearchTab';
 
 import '../AssignmentPage.scss';
 import './AssignmentResponseEdit.scss';
-import { cleanupTitleAndDescriptions } from '../../helpers/cleanup-title-and-descriptions';
-import { useWarningBeforeUnload } from '../../../shared/hooks/useWarningBeforeUnload';
 
 interface AssignmentResponseEditProps {
 	assignment: Avo.Assignment.Assignment_v2;
@@ -390,12 +391,7 @@ const AssignmentResponseEdit: FunctionComponent<AssignmentResponseEditProps & Us
 
 					<Spacer margin={['bottom-large']} />
 
-					<Prompt
-						when={isDirty}
-						message={t(
-							'assignment/views/assignment-edit___er-zijn-nog-niet-opgeslagen-wijzigingen-weet-u-zeker-dat-u-de-pagina-wil-verlaten'
-						)}
-					/>
+					<BeforeUnloadPrompt when={isDirty} />
 				</div>
 
 				{/* Must always be the second and last element inside the c-sticky-save-bar__wrapper */}

--- a/src/collection/components/CollectionOrBundleEdit.tsx
+++ b/src/collection/components/CollectionOrBundleEdit.tsx
@@ -26,7 +26,6 @@ import React, {
 import { useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 import { matchPath, withRouter } from 'react-router';
-import { Prompt } from 'react-router-dom';
 import { compose } from 'redux';
 
 import { ItemsService } from '../../admin/items/items.service';
@@ -40,6 +39,7 @@ import {
 	LoadingErrorLoadedComponent,
 	LoadingInfo,
 } from '../../shared/components';
+import { BeforeUnloadPrompt } from '../../shared/components/BeforeUnloadPrompt/BeforeUnloadPrompt';
 import MoreOptionsDropdown from '../../shared/components/MoreOptionsDropdown/MoreOptionsDropdown';
 import {
 	buildLink,
@@ -1280,13 +1280,8 @@ const CollectionOrBundleEdit: FunctionComponent<
 					onClose={() => setEnterItemIdModalOpen(false)}
 					inputCallback={handleAddItemById}
 				/>
-				{draggableListModal}{' '}
-				<Prompt
-					when={shouldBlockNavigation()}
-					message={t(
-						'collection/components/collection-or-bundle-edit___er-zijn-nog-niet-opgeslagen-wijzigingen-weet-u-zeker-dat-u-de-pagina-wil-verlaten'
-					)}
-				/>
+				{draggableListModal}
+				<BeforeUnloadPrompt when={shouldBlockNavigation()} />
 			</>
 		);
 	};

--- a/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -24,6 +24,7 @@ export interface ConfirmModalProps {
 	isOpen: boolean;
 	onClose?: () => void;
 	confirmCallback?: () => void;
+	className?: string;
 }
 
 const ConfirmModal: FunctionComponent<ConfirmModalProps> = ({
@@ -39,9 +40,11 @@ const ConfirmModal: FunctionComponent<ConfirmModalProps> = ({
 	onClose = noop,
 	isOpen,
 	confirmCallback = noop,
+	className,
 }) => {
 	return (
 		<Modal
+			className={className}
 			isOpen={isOpen}
 			title={title && sanitizeHtml(title, 'basic')}
 			size="small"


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2049

* show unsaved changes modal on top of opened modals
* also show unsaved changes modal during previews

![image](https://user-images.githubusercontent.com/1710840/179988056-75a18f52-68b3-478c-a324-8c23d1ce1303.png)
![image](https://user-images.githubusercontent.com/1710840/179988068-9fe4b491-1d70-44a3-8592-1a3f0020d7a2.png)
![image](https://user-images.githubusercontent.com/1710840/179988005-9bca6142-9b0e-4dae-960a-197c90ff40a3.png)
![image](https://user-images.githubusercontent.com/1710840/179988036-bbe383c2-6312-4d05-918c-5ba05db44789.png)
![image](https://user-images.githubusercontent.com/1710840/179988020-750581c3-034e-473a-bae6-f323905c33fe.png)
