### PR TITLE
fix(avo-2076): update collection import logic

### DIFF
--- a/src/assignment/assignment.service.ts
+++ b/src/assignment/assignment.service.ts
@@ -1182,10 +1182,10 @@ export class AssignmentService {
 				} else {
 					// ITEM
 					// custom_title and custom_description remain null
-					block.original_title = withDescription ? fragment.custom_title : null;
-					block.original_description = withDescription
-						? fragment.custom_description
-						: null;
+					// regardless of withDescription: ALWAYS copy the fragment custom title and description to the original fields
+					// Since importing from collection, the collection is the source of truth and the original == collection fields
+					block.original_title = fragment.custom_title;
+					block.original_description = fragment.custom_description;
 					block.use_custom_fields = !withDescription;
 					block.type = AssignmentBlockType.ITEM;
 				}

--- a/src/assignment/hooks/assignment-content-modals.tsx
+++ b/src/assignment/hooks/assignment-content-modals.tsx
@@ -197,19 +197,11 @@ export function useBlockListModals(
 										type: collectionItem.type,
 										fragment_id: collectionItem.external_id,
 										position: getAddBlockModalPosition + index,
-										original_title: withDescription
-											? collectionItem.custom_title
-											: null,
-										original_description: withDescription
-											? collectionItem.custom_description
-											: null,
-										custom_title: collectionItem.use_custom_fields
-											? collectionItem.custom_title
-											: null,
-										custom_description: collectionItem.use_custom_fields
-											? collectionItem.custom_description
-											: null,
-										use_custom_fields: collectionItem.use_custom_fields,
+										original_title: collectionItem.custom_title,
+										original_description: collectionItem.custom_description,
+										custom_title: null,
+										custom_description: null,
+										use_custom_fields: !withDescription,
 										start_oc: collectionItem.start_oc,
 										end_oc: collectionItem.end_oc,
 										thumbnail_path: collectionItem.thumbnail_path,


### PR DESCRIPTION
- origineel tab === onediteerbaar, tekst zoals te zien bij het collectie item
- eigen tekst === initieel zelfde tekst als origineel, maar wel editeerbaar

De toggle voor importeren met/zonder beschrijving heeft geen invloed op de overgenomen data, maar wel op welk tabje (origineel/geen beschrijving) standaard 'actief' is na importeren in de opdracht