### PR TITLE
fix(avo-2087): reset active tab if no search or build assignment

### DIFF
--- a/src/assignment/views/AssignmentResponseEdit/AssignmentResponseEdit.tsx
+++ b/src/assignment/views/AssignmentResponseEdit/AssignmentResponseEdit.tsx
@@ -48,6 +48,7 @@ import { setPositionToIndex } from '../../assignment.helper';
 import { AssignmentService } from '../../assignment.service';
 import {
 	AssignmentResponseFormState,
+	AssignmentType,
 	PupilCollectionFragment,
 	PupilSearchFilterState,
 } from '../../assignment.types';
@@ -291,6 +292,13 @@ const AssignmentResponseEdit: FunctionComponent<AssignmentResponseEditProps & Us
 	const renderTabContent = () => {
 		switch (activeTab) {
 			case ASSIGNMENT_RESPONSE_CREATE_UPDATE_TABS.SEARCH:
+				if (
+					assignment.assignment_type !== AssignmentType.ZOEK &&
+					assignment.assignment_type !== AssignmentType.BOUW
+				) {
+					setTab(ASSIGNMENT_RESPONSE_CREATE_UPDATE_TABS.ASSIGNMENT);
+					return null;
+				}
 				return (
 					<AssignmentResponseSearchTab
 						assignment={assignment}
@@ -313,6 +321,10 @@ const AssignmentResponseEdit: FunctionComponent<AssignmentResponseEditProps & Us
 				);
 
 			case ASSIGNMENT_RESPONSE_CREATE_UPDATE_TABS.MY_COLLECTION:
+				if (assignment.assignment_type !== AssignmentType.BOUW) {
+					setTab(ASSIGNMENT_RESPONSE_CREATE_UPDATE_TABS.ASSIGNMENT);
+					return null;
+				}
 				if (!assignmentResponse) {
 					return (
 						<Spacer margin="top-extra-large">
@@ -342,7 +354,6 @@ const AssignmentResponseEdit: FunctionComponent<AssignmentResponseEditProps & Us
 				);
 
 			case ASSIGNMENT_RESPONSE_CREATE_UPDATE_TABS.ASSIGNMENT:
-			default:
 				return (
 					<AssignmentResponseAssignmentTab
 						blocks={assignment?.blocks || []}
@@ -351,6 +362,10 @@ const AssignmentResponseEdit: FunctionComponent<AssignmentResponseEditProps & Us
 						buildSearchLink={buildAssignmentSearchLink(setFilterState)}
 					/>
 				);
+
+			default:
+				setTab(ASSIGNMENT_RESPONSE_CREATE_UPDATE_TABS.ASSIGNMENT);
+				return null;
 		}
 	};
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2087

After this PR only tab values that match the assignment type are allowed:

For an assignment with type: KIJK:
* ?tab=MY_COLLECTION => ?tab=ASSIGNMENT
* ?tab=SEARCH => ?tab=ASSIGNMENT
* ?tab=BLABLA => ?tab=ASSIGNMENT

for an assignment with type: ZOEK:
* ?tab=MY_COLLECTION => ?tab=ASSIGNMENT
* ?tab=SEARCH => ?tab=SEARCH
* ?tab=BLABLA => ?tab=ASSIGNMENT

for an assignment with type: BOUW:
* ?tab=MY_COLLECTION => ?tab=MY_COLLECTION 
* ?tab=SEARCH => ?tab=SEARCH
* ?tab=BLABLA => ?tab=ASSIGNMENT

![image](https://user-images.githubusercontent.com/1710840/185112229-1e0d5147-68c7-4a6b-8cfb-f0b8ee14f14f.png)
