### PR TITLE
fix(avo-2114): avoid collections that are null in bookmarks

### DIFF
--- a/src/assignment/views/AssignmentEdit.tsx
+++ b/src/assignment/views/AssignmentEdit.tsx
@@ -442,7 +442,7 @@ const AssignmentEdit: FunctionComponent<DefaultSecureRouteProps<{ id: string }>>
 
 	const renderTabs = useMemo(() => <Tabs tabs={tabs} onClick={onTabClick} />, [tabs, onTabClick]);
 
-	const renderTabContent = useMemo(() => {
+	const renderedTabContent = useMemo(() => {
 		switch (tab) {
 			case ASSIGNMENT_CREATE_UPDATE_TABS.Inhoud:
 				if (pastDeadline) {
@@ -547,7 +547,9 @@ const AssignmentEdit: FunctionComponent<DefaultSecureRouteProps<{ id: string }>>
 						</Spacer>
 					)}
 
-					<Spacer margin={['top-large', 'bottom-extra-large']}>{renderTabContent}</Spacer>
+					<Spacer margin={['top-large', 'bottom-extra-large']}>
+						{renderedTabContent}
+					</Spacer>
 
 					{renderedModals}
 					{draggableListModal}

--- a/src/collection/collection.gql.ts
+++ b/src/collection/collection.gql.ts
@@ -151,7 +151,11 @@ export const GET_BOOKMARKED_COLLECTIONS_BY_OWNER = gql`
 		$where: [app_collection_bookmarks_bool_exp] = []
 	) {
 		app_collection_bookmarks(
-			where: { profile_id: { _eq: $owner_profile_id }, _and: $where }
+			where: {
+				profile_id: { _eq: $owner_profile_id }
+				bookmarkedCollection: {}
+				_and: $where
+			}
 			offset: $offset
 			limit: $limit
 			order_by: $order

--- a/src/collection/collection.service.ts
+++ b/src/collection/collection.service.ts
@@ -1293,7 +1293,7 @@ export class CollectionService {
 			}
 
 			const bookmarks = response?.data?.app_collection_bookmarks || [];
-			return bookmarks.map((bookmark: any) => bookmark.bookmarkedCollection);
+			return compact(bookmarks.map((bookmark: any) => bookmark.bookmarkedCollection)); // bookmarkedCollection can sometimes be null apparently
 		} catch (err) {
 			throw new CustomError('Fetch bookmarked collections by owner failed', err, {
 				variables,


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2114

I'm guessing the collection was removed and the bookmark was not?
We'll need to investigate this further in the future.

before: blank screen because of error:
```
Cannot read properties of null (reading 'id')
```
![image](https://user-images.githubusercontent.com/1710840/185152782-06d16a62-bad9-4674-a2a2-b8afeda0bb69.png)


after:
![image](https://user-images.githubusercontent.com/1710840/185152628-9fa89b0e-5b21-457d-970a-7fe585ee6fc9.png)
