### PR TITLE
fix(avo-2103): only count items in responses overview, no text blocks

### DIFF
--- a/src/assignment/assignment.gql.ts
+++ b/src/assignment/assignment.gql.ts
@@ -234,7 +234,7 @@ export const GET_ASSIGNMENT_RESPONSES_BY_ASSIGNMENT_ID = gql`
 			id
 			collection_title
 			updated_at
-			pupil_collection_blocks_aggregate {
+			pupil_collection_blocks_aggregate(where: { type: { _eq: "ITEM" } }) {
 				aggregate {
 					count
 				}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2103

requires proxy PR to whitelist the modified query: https://github.com/viaacode/avo2-proxy/pull/480

before:
![image](https://user-images.githubusercontent.com/1710840/185645056-a44298ab-26aa-40a7-92ea-0df7e0b55be3.png)

![image](https://user-images.githubusercontent.com/1710840/185645201-9dd2e755-e868-49ce-8e0c-261122a18eb1.png)



after:
![image](https://user-images.githubusercontent.com/1710840/185645030-7dfdc947-5239-4c21-8ca0-9364d69214c7.png)


