### PR TITLE
fix(avo-2133): change cookiebot script to account for new script format

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
 			type="text/javascript"></script>
 
 	<!-- Init .env variables -->
-	<script src="%PUBLIC_URL%/env-config.js"></script>
+	<script src="%PUBLIC_URL%/env-config.js" data-cookieconsent="ignore"></script>
 
 	<!-- Google Tag Manager -->
 	<script>

--- a/scripts/add-cookiebot-ignore-attributes.ts
+++ b/scripts/add-cookiebot-ignore-attributes.ts
@@ -1,15 +1,15 @@
 import path from 'path';
+
 import replace, { ReplaceResult } from 'replace-in-file';
 
 replace
 	.replaceInFile({
 		files: path.join(__dirname, '../build/index.html'),
-		from: /<script src="(.*?\.chunk.js)"><\/script><script src="(.*?\.chunk.js)"><\/script><\/body><\/html>/g,
-		to:
-			'<script src="$1" data-cookieconsent="ignore"></script><script src="$2" data-cookieconsent="ignore"></script></body></html>',
+		from: /<script defer="defer" src="(\/static\/js\/main\.[^.]+\.js)"><\/script>/g,
+		to: '<script defer="defer" src="$1" data-cookieconsent="ignore"></script>',
 	})
 	.then((results: ReplaceResult[]) => {
-		console.info('Succesfully added cookiebot ignore attributes:', results);
+		console.info('Successfully added cookiebot ignore attributes:', results);
 	})
 	.catch((error: any) => {
 		console.error('Failed to add cookiebot ignore attributes', error);


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2133

Vroeger was het formaat:
```
<script src="/static/js/main.c866a515.chunk.js"></script></body></html>
 ```

en nu is het formaat:
```
<script  defer="defer" src="/static/js/main.c866a515.js"></script>
```