### PR TITLE
fix(avo-2156): don't show nudging modal when user logs in using leerid

### DIFF
--- a/src/shared/components/ACMIDMNudgeModal/ACMIDMNudgeModal.tsx
+++ b/src/shared/components/ACMIDMNudgeModal/ACMIDMNudgeModal.tsx
@@ -51,7 +51,11 @@ const ACMIDMNudgeModal: FC<UserProps & UiStateProps & RouteComponentProps> = ({
 				ProfilePreference.DoNotShow
 			);
 
-			const hasVlaamseOverheidLinked = !!(user && hasIdpLinked(user, 'VLAAMSEOVERHEID'));
+			const hasVlaamseOverheidLinked = !!(
+				user &&
+				hasIdpLinked(user, 'VLAAMSEOVERHEID__SUB_ID') &&
+				hasIdpLinked(user, 'VLAAMSEOVERHEID__ACCOUNT_ID')
+			);
 			const profileIsComplete = !!(user && isProfileComplete(user));
 
 			setShowNudgingModal(


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2156

We'll only be able to test this on QAS, but from debugging QAS, it is clear what the issue is:
![image](https://user-images.githubusercontent.com/1710840/189846129-7a89dbca-8577-4208-96cb-44c9ae276f69.png)
