### PR TITLE
fix(avo-1454): remove some content page link from the admin sidebar

### DIFF
--- a/src/admin/admin.const.ts
+++ b/src/admin/admin.const.ts
@@ -158,42 +158,6 @@ export const GET_NAV_ITEMS = async (userPermissions: string[]): Promise<Navigati
 				key: 'content',
 				exact: false,
 				subLinks: [
-					{
-						label: i18n.t('admin/admin___paginas'),
-						location: ADMIN_PATH.PAGES,
-						key: 'pages',
-						exact: true,
-					},
-					{
-						label: i18n.t('admin/admin___projecten'),
-						location: ADMIN_PATH.PROJECTS,
-						key: 'projects',
-						exact: true,
-					},
-					{
-						label: i18n.t('admin/admin___nieuws'),
-						location: ADMIN_PATH.NEWS,
-						key: 'news',
-						exact: true,
-					},
-					{
-						label: i18n.t('admin/admin___screencasts'),
-						location: ADMIN_PATH.SCREENCASTS,
-						key: 'screencasts',
-						exact: true,
-					},
-					{
-						label: i18n.t('admin/admin___fa-qs'),
-						location: ADMIN_PATH.FAQS,
-						key: 'faqs',
-						exact: true,
-					},
-					{
-						label: i18n.t('admin/admin___overzichtspaginas'),
-						location: ADMIN_PATH.OVERVIEWS,
-						key: 'faqs',
-						exact: true,
-					},
 					// Only show the startpages to the users that can edit all pages
 					...(userPermissions.includes(PermissionName.EDIT_ANY_CONTENT_PAGES)
 						? [


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-1454

before:
![image](https://user-images.githubusercontent.com/1710840/192320454-74e05896-7432-4f1e-ae4e-67600f5dbb40.png)

after:
![image](https://user-images.githubusercontent.com/1710840/192320497-263deccd-f5e6-4c42-a141-e58ed69c9370.png)
