### PR TITLE
feat(avo-1473): scroll to overview block when url contains label param

### DIFF
--- a/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/PageOverviewWrapper/PageOverviewWrapper.tsx
@@ -19,6 +19,7 @@ import { ROUTE_PARTS } from '../../../../../shared/constants';
 import { CustomError, getEnv } from '../../../../../shared/helpers';
 import { fetchWithLogout } from '../../../../../shared/helpers/fetch-with-logout';
 import { useDebounce } from '../../../../../shared/hooks';
+import { useScrollToSelector } from '../../../../../shared/hooks/scroll-to-selector';
 import { ToastService } from '../../../../../shared/services';
 import { ContentPageService } from '../../../../../shared/services/content-page-service';
 import i18n from '../../../../../shared/translations/i18n';
@@ -100,6 +101,9 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps> = ({
 	const [loadingInfo, setLoadingInfo] = useState<LoadingInfo>({ state: 'loading' });
 	const [selectedTabObjects, setSelectedTabObjects] = useState<LabelObj[]>([]);
 	const [focusedPage, setFocusedPage] = useState<PageInfo | null>(null);
+
+	// Scroll down to the overview block if a label was clicked: https://meemoo.atlassian.net/browse/AVO-1473
+	useScrollToSelector(queryParamsState.label?.length ? '.c-content-page-overview-block' : null);
 
 	const debouncedItemsPerPage = useDebounce(itemsPerPage || 1000, 200); // Default to 1000 if itemsPerPage is zero
 
@@ -331,7 +335,9 @@ const PageOverviewWrapper: FunctionComponent<PageOverviewWrapperProps> = ({
 				buttonAltTitle={buttonAltTitle}
 				focusedPage={focusedPage}
 				getLabelLink={(label: string) => {
-					return `/${ROUTE_PARTS.news}?label=${encodeURIComponent(label)}`;
+					return `${window.location.origin}/${
+						ROUTE_PARTS.news
+					}?label=${encodeURIComponent(label)}`;
 				}}
 				renderLink={renderLink}
 			/>

--- a/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponseSearchTab.tsx
+++ b/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponseSearchTab.tsx
@@ -18,7 +18,7 @@ import { PupilCollectionService } from '../../../../pupil-collection/pupil-colle
 import { SearchFiltersAndResults } from '../../../../search/components';
 import { FilterState } from '../../../../search/search.types';
 import withUser, { UserProps } from '../../../../shared/hocs/withUser';
-import { useScrollToId } from '../../../../shared/hooks/scroll-to-id';
+import { useScrollToSelector } from '../../../../shared/hooks/scroll-to-selector';
 import { ToastService } from '../../../../shared/services';
 import { trackEvents } from '../../../../shared/services/event-logging-service';
 import {
@@ -54,7 +54,7 @@ const AssignmentResponseSearchTab: FunctionComponent<
 	// UI
 	const [isAddToAssignmentModalOpen, setIsAddToAssignmentModalOpen] = useState<boolean>(false);
 	const [selectedItem, setSelectedItem] = useState<Avo.Item.Item | null>(null);
-	useScrollToId(filterState.focus ? `search-result-${filterState.focus}` : null);
+	useScrollToSelector(filterState.focus ? `#search-result-${filterState.focus}` : null);
 
 	// HTTP
 

--- a/src/shared/hooks/scroll-to-selector.ts
+++ b/src/shared/hooks/scroll-to-selector.ts
@@ -1,17 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export function useScrollToId(id: string | null): void {
+export function useScrollToSelector(selector: string | null): void {
 	const [timerId, setTimerId] = useState<number | null>(null);
 	const scrollDownToFocusedItem = useCallback(() => {
-		if (id) {
-			const item = document.getElementById(id);
+		if (selector) {
+			const item = document.querySelector(selector) as HTMLElement | null;
 			if (item && item.offsetTop) {
-				window.scrollTo(0, item.offsetTop - 0.4 * window.innerHeight);
-				setTimeout(() => {
-					if (window.scrollY === 0) {
-						scrollDownToFocusedItem();
-					}
-				}, 100);
+				item.scrollIntoView();
 			} else {
 				if (timerId) {
 					clearTimeout(timerId);
@@ -23,7 +18,7 @@ export function useScrollToId(id: string | null): void {
 				);
 			}
 		}
-	}, [id]);
+	}, [selector]);
 
 	useEffect(() => {
 		scrollDownToFocusedItem();


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-1473

if the label query param has a value scroll down to the first page overview block on the page if it exists

page used in the example: https://onderwijs-qas.hetarchief.be/partners

before:
https://user-images.githubusercontent.com/1710840/192516065-7b8caa69-37ca-4c64-9eed-13b435a00b34.mp4

after:
https://user-images.githubusercontent.com/1710840/192516060-a42bbc6f-706f-4e8e-9156-dbe7e5e9e83a.mp4