### PR TITLE
fix(avo-1672): make the h2 titles in a page overview block smaller

### DIFF
--- a/src/admin/content-block/components/ContentBlockPreview/ContentBlockPreview.scss
+++ b/src/admin/content-block/components/ContentBlockPreview/ContentBlockPreview.scss
@@ -4,6 +4,16 @@
 	opacity: 0;
 }
 
+.c-content-page-overview-block {
+	.c-page-overview-news-list,
+	.c-page-overview-project-list {
+		h2,
+		h3 {
+			font-size: 2.1rem;
+		}
+	}
+}
+
 .c-content-block {
 	position: relative;
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-1672

We want the headings to decrease 1 by 1 for seo reasons. But an h2 is too large esthetically.
So for page overview blocks we resize the h2 font size to 2.1 instead of 2.4 rem

in https://meemoo.atlassian.net/browse/AVO-2176 we'll make this configurable, so the user can choose their own size. But this task should best be taken up after the integration of the admin-core in avo.

![ezgif com-gif-maker (13)](https://user-images.githubusercontent.com/1710840/192560635-3dd46fcc-e742-4260-b0e3-62327089bbca.gif)
