### PR TITLE
fix(avo-1895): track search events + disable quick_lane events for now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@react-hook/resize-observer": "^1.2.5",
         "@storybook/addon-actions": "^6.3.12",
         "@viaa/avo2-components": "^1.97.10",
-        "@viaa/avo2-types": "2.43.0",
+        "@viaa/avo2-types": "2.44.3",
         "apollo-boost": "^0.4.9",
         "apollo-link": "^1.2.14",
         "braft-editor": "^2.3.9",
@@ -4574,9 +4574,9 @@
       }
     },
     "node_modules/@viaa/avo2-types": {
-      "version": "2.43.0",
-      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-types/-/avo2-types-2.43.0.tgz",
-      "integrity": "sha512-q0mGmSbAGCv/K4gYC3pKgQD2UrnOa/ZsYaNcgFyUJ1CZP+Z08jMmbpPxH+bfQvH2vbZnC0lyk/lVGs5bD0oRWA=="
+      "version": "2.44.3",
+      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-types/-/avo2-types-2.44.3.tgz",
+      "integrity": "sha512-TUumHCjLPCT04d0V8ujGdtJYun/zaOZnBj2nQQ7hi4HHUjtJlv0THK1Mh+ru5mfchwthl2BstjPryWIymo2LXw=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -28860,9 +28860,9 @@
       }
     },
     "@viaa/avo2-types": {
-      "version": "2.43.0",
-      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-types/-/avo2-types-2.43.0.tgz",
-      "integrity": "sha512-q0mGmSbAGCv/K4gYC3pKgQD2UrnOa/ZsYaNcgFyUJ1CZP+Z08jMmbpPxH+bfQvH2vbZnC0lyk/lVGs5bD0oRWA=="
+      "version": "2.44.3",
+      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-types/-/avo2-types-2.44.3.tgz",
+      "integrity": "sha512-TUumHCjLPCT04d0V8ujGdtJYun/zaOZnBj2nQQ7hi4HHUjtJlv0THK1Mh+ru5mfchwthl2BstjPryWIymo2LXw=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@react-hook/resize-observer": "^1.2.5",
     "@storybook/addon-actions": "^6.3.12",
     "@viaa/avo2-components": "^1.97.10",
-    "@viaa/avo2-types": "2.43.0",
+    "@viaa/avo2-types": "2.44.3",
     "apollo-boost": "^0.4.9",
     "apollo-link": "^1.2.14",
     "braft-editor": "^2.3.9",

--- a/src/quick-lane/views/QuickLaneDetail.tsx
+++ b/src/quick-lane/views/QuickLaneDetail.tsx
@@ -1,10 +1,3 @@
-import classnames from 'classnames';
-import { get } from 'lodash-es';
-import React, { FunctionComponent, ReactElement, useCallback, useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import MetaTags from 'react-meta-tags';
-import { generatePath } from 'react-router';
-
 import {
 	BlockHeading,
 	Button,
@@ -21,6 +14,12 @@ import {
 import { Avo } from '@viaa/avo2-types';
 import { CollectionSchema } from '@viaa/avo2-types/types/collection';
 import { ItemSchema } from '@viaa/avo2-types/types/item';
+import classnames from 'classnames';
+import { get } from 'lodash-es';
+import React, { FunctionComponent, ReactElement, useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import MetaTags from 'react-meta-tags';
+import { generatePath } from 'react-router';
 
 import { AssignmentLayout } from '../../assignment/assignment.types';
 import { DefaultSecureRouteProps } from '../../authentication/components/SecuredRoute';
@@ -31,14 +30,13 @@ import { ErrorView } from '../../error/views';
 import { ItemVideoDescription } from '../../item/components';
 import { LoadingErrorLoadedComponent, LoadingInfo } from '../../shared/components';
 import { CustomError, isMobileWidth, renderAvatar } from '../../shared/helpers';
-import { trackEvents } from '../../shared/services/event-logging-service';
 import { QuickLaneUrlObject } from '../../shared/types';
 import { isCollection, isItem } from '../quick-lane.helpers';
 import { QuickLaneService } from '../quick-lane.service';
 
 import './QuickLaneDetail.scss';
 
-interface QuickLaneDetailProps extends DefaultSecureRouteProps<{ id: string }> {}
+type QuickLaneDetailProps = DefaultSecureRouteProps<{ id: string }>;
 
 const QuickLaneDetail: FunctionComponent<QuickLaneDetailProps> = ({
 	history,
@@ -128,14 +126,15 @@ const QuickLaneDetail: FunctionComponent<QuickLaneDetailProps> = ({
 
 			// Analytics
 
-			trackEvents(
-				{
-					object: String(response.id),
-					object_type: 'quick_lane',
-					action: 'view',
-				},
-				user
-			);
+			// TODO re-enable this once task https://meemoo.atlassian.net/browse/AVO-2177 is fixed
+			// trackEvents(
+			// 	{
+			// 		object: String(response.id),
+			// 		object_type: 'quick_lane',
+			// 		action: 'view',
+			// 	},
+			// 	user
+			// );
 		} catch (err) {
 			console.error(
 				new CustomError('Failed to fetch quick lane and content for detail page', err, {

--- a/src/search/components/BlockSearch.tsx
+++ b/src/search/components/BlockSearch.tsx
@@ -27,11 +27,11 @@ import { useDebounce } from '../../shared/hooks';
 import { ToastService } from '../../shared/services';
 import { KeyCode } from '../../shared/types';
 import { AppState } from '../../store';
+import { SearchFilter } from '../search.const';
 import { getSearchResults } from '../store/actions';
 import { selectSearchLoading, selectSearchResults } from '../store/selectors';
 
 import './BlockSearch.scss';
-import { SearchFilter } from '../search.const';
 
 interface BlockSearchProps extends DefaultSecureRouteProps {
 	searchResults: Avo.Search.Search | null;

--- a/src/search/views/Search.tsx
+++ b/src/search/views/Search.tsx
@@ -10,7 +10,8 @@ import {
 	ToolbarTitle,
 } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
-import React, { FunctionComponent, ReactNode, ReactText, useState } from 'react';
+import { isEmpty } from 'lodash-es';
+import React, { FunctionComponent, ReactNode, ReactText, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import MetaTags from 'react-meta-tags';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
@@ -38,6 +39,7 @@ import { getMoreOptionsLabel } from '../../shared/constants';
 import { copyToClipboard, generateContentLinkString } from '../../shared/helpers';
 import withUser, { UserProps } from '../../shared/hocs/withUser';
 import { ToastService } from '../../shared/services';
+import { trackEvents } from '../../shared/services/event-logging-service';
 import { SearchFiltersAndResults } from '../components';
 import { FilterState } from '../search.types';
 
@@ -58,6 +60,20 @@ const Search: FunctionComponent<UserProps & RouteComponentProps> = ({ user }) =>
 		FilterState,
 		(FilterState: FilterState, updateType?: UrlUpdateType) => void
 	];
+
+	useEffect(() => {
+		if (!isEmpty(filterState.filters)) {
+			trackEvents(
+				{
+					object: filterState.filters?.query || '',
+					object_type: 'query',
+					action: 'search',
+					resource: filterState.filters,
+				},
+				user
+			);
+		}
+	}, [filterState]);
 
 	const handleOptionClicked = (optionId: string | number | ReactText) => {
 		setIsOptionsMenuOpen(false);

--- a/src/shared/services/event-logging-service.ts
+++ b/src/shared/services/event-logging-service.ts
@@ -29,10 +29,12 @@ export function trackEvents(
 			(event: MinimalClientEvent): Avo.EventLogging.Event => {
 				return {
 					occurred_at: new Date().toISOString(),
-					source_url: window.location.href, // url when the event was triggered
+					source_url: window.location.origin + window.location.pathname, // url when the event was triggered
 					subject: get(user, 'profile.id', 'anonymous'), // Entity making causing the event
 					subject_type: 'user',
-					source_querystring: insideIframe() ? window.parent.location.href : '',
+					source_querystring: insideIframe()
+						? window.parent.location.href
+						: window.location.search,
 					...event,
 					message: '', // AVO-1675: message should be anonymous and is redundant: leave it empty
 				};


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-1895
https://meemoo.atlassian.net/browse/AVO-2177

also fixed event url => split url from query params

event for search on homepage:
![image](https://user-images.githubusercontent.com/1710840/192580538-8b2c7767-46b6-49a3-98d3-d3811a2704c4.png)

event for search on search page:
![image](https://user-images.githubusercontent.com/1710840/192580571-fd7e5ab1-579f-45bc-9780-d0d0aad29841.png)

event for search from assignment page:
![image](https://user-images.githubusercontent.com/1710840/192580603-06b15317-d87c-42e2-87e4-2b3d31ac735a.png)
