### PR TITLE
fix(avo-2136): rework nudging modal show/hide

### DIFF
--- a/src/shared/services/profile-preferences.service.ts
+++ b/src/shared/services/profile-preferences.service.ts
@@ -8,12 +8,21 @@ import { CustomError } from '../helpers';
 
 import { dataService } from './data-service';
 
-export enum ProfilePreference {
+export enum ProfilePreferenceKey {
 	DoNotShow = 'DO_NOT_SHOW',
 }
 
+export interface ProfilePreference {
+	id: number;
+	profile_id: string;
+	key: 'DO_NOT_SHOW' | string;
+}
+
 export class ProfilePreferencesService {
-	static async fetchProfilePreference(profileId: string, key: ProfilePreference): Promise<any> {
+	static async fetchProfilePreference(
+		profileId: string,
+		key: ProfilePreferenceKey
+	): Promise<ProfilePreference[]> {
 		try {
 			const response = await dataService.query({
 				query: GET_PROFILE_PREFERENCE,
@@ -29,14 +38,17 @@ export class ProfilePreferencesService {
 		}
 	}
 
-	static async setProfilePreference(profileId: string, key: ProfilePreference): Promise<any> {
+	static async setProfilePreference(
+		profileId: string,
+		key: ProfilePreferenceKey
+	): Promise<number> {
 		try {
 			const response = await dataService.mutate({
 				mutation: SET_PROFILE_PREFERENCE,
 				variables: { profileId, key },
 			});
 
-			return response;
+			return response?.data?.insert_users_profile_preferences?.affected_rows;
 		} catch (err) {
 			throw new CustomError('Het inserten van de profile preference is mislukt.', err, {
 				query: SET_PROFILE_PREFERENCE,


### PR DESCRIPTION
Currently the nudging modal is visible after logging in with itsme.
That is probably due to:
```
			const hasVlaamseOverheidLinked =
				!!user &&
				hasIdpLinked(user, 'VLAAMSEOVERHEID__SUB_ID') &&
				hasIdpLinked(user, 'VLAAMSEOVERHEID__ACCOUNT_ID');
```
which should be using an OR operator:
```			
			const hasVlaamseOverheidLinked =
				!!user &&
				(hasIdpLinked(user, 'VLAAMSEOVERHEID__SUB_ID') ||
					hasIdpLinked(user, 'VLAAMSEOVERHEID__ACCOUNT_ID'));
```

But also this doesn't seem to react to changes in routes, since we only update the show/hide modal if certain conditions are true. But we should also hide it, in the other case when the conditions are false.
```
		if (user && !isOnAccountLinkingPage && (!isPupil || (isPupil && !isOnAssignmentPage))) {
			fetchProfilePreference();
		}
```