### PR TITLE
fix(avo-2129): change queries to use last blocked at

### DIFF
--- a/src/admin/users/user.const.ts
+++ b/src/admin/users/user.const.ts
@@ -257,13 +257,21 @@ export const TABLE_COLUMN_TO_DATABASE_ORDER_OBJECT: Partial<{
 		is_blocked: order,
 	}),
 	blocked_at: (order: Avo.Search.OrderDirection) => ({
-		blocked_at: {
-			max: order,
+		last_blocked_at: {
+			aggregate: {
+				max: {
+					created_at: order,
+				},
+			},
 		},
 	}),
 	unblocked_at: (order: Avo.Search.OrderDirection) => ({
-		unblocked_at: {
-			max: order,
+		last_unblocked_at: {
+			aggregate: {
+				max: {
+					created_at: order,
+				},
+			},
 		},
 	}),
 	stamboek: (order: Avo.Search.OrderDirection) => ({

--- a/src/admin/users/user.gql.ts
+++ b/src/admin/users/user.gql.ts
@@ -84,11 +84,19 @@ export const GET_USER_BY_ID = gql`
 			group_name
 			company_name
 			company_id
-			blocked_at {
-				max
+			last_blocked_at: audits_aggregate(where: { event: { _eq: "BLOCKED" } }) {
+				aggregate {
+					max {
+						created_at
+					}
+				}
 			}
-			unblocked_at {
-				max
+			last_unblocked_at: audits_aggregate(where: { event: { _eq: "UNBLOCKED" } }) {
+				aggregate {
+					max {
+						created_at
+					}
+				}
 			}
 			classifications {
 				id
@@ -129,11 +137,19 @@ export const GET_USERS = gql`
 			mail
 			last_access_at
 			is_blocked
-			blocked_at {
-				date: max
+			last_blocked_at: audits_aggregate(where: { event: { _eq: "BLOCKED" } }) {
+				aggregate {
+					max {
+						created_at
+					}
+				}
 			}
-			unblocked_at {
-				date: max
+			last_unblocked_at: audits_aggregate(where: { event: { _eq: "UNBLOCKED" } }) {
+				aggregate {
+					max {
+						created_at
+					}
+				}
 			}
 			profile_id
 			stamboek
@@ -198,11 +214,19 @@ export const GET_USERS_IN_SAME_COMPANY = gql`
 			mail
 			last_access_at
 			is_blocked
-			blocked_at {
-				date: max
+			last_blocked_at: audits_aggregate(where: { event: { _eq: "BLOCKED" } }) {
+				aggregate {
+					max {
+						created_at
+					}
+				}
 			}
-			unblocked_at {
-				date: max
+			last_unblocked_at: audits_aggregate(where: { event: { _eq: "UNBLOCKED" } }) {
+				aggregate {
+					max {
+						created_at
+					}
+				}
 			}
 			profile_id
 			stamboek

--- a/src/admin/users/user.service.ts
+++ b/src/admin/users/user.service.ts
@@ -84,7 +84,7 @@ export class UserService {
 		} catch (err) {
 			throw new CustomError('Failed to get profile by id from the database', err, {
 				profileId,
-				query: 'GET_USER_BY_ID',
+				query: 'GET_USER_TEMP_ACCESS_BY_ID',
 			});
 		}
 	}

--- a/src/admin/users/user.types.ts
+++ b/src/admin/users/user.types.ts
@@ -131,11 +131,19 @@ export interface UserSummaryView {
 		temp_access: UserTempAccess | null;
 	};
 	is_blocked: boolean;
-	blocked_at: {
-		date: string;
+	last_blocked_at: {
+		aggregate: {
+			max: {
+				created_at: string | null;
+			};
+		};
 	};
-	unblocked_at: {
-		date: string;
+	last_unblocked_at: {
+		aggregate: {
+			max: {
+				created_at: string | null;
+			};
+		};
 	};
 	profile_id: string;
 	stamboek: string | null;

--- a/src/admin/users/views/UserDetail.tsx
+++ b/src/admin/users/views/UserDetail.tsx
@@ -444,11 +444,11 @@ const UserDetail: FunctionComponent<UserDetailProps> = ({ history, match, user }
 							])}
 							{renderDateDetailRows(storedProfile, [
 								[
-									'blocked_at.max',
+									'last_blocked_at.aggregate.max.created_at',
 									t('admin/users/views/user-detail___laatst-geblokeerd-op'),
 								],
 								[
-									'unblocked_at.max',
+									'last_unblocked_at.aggregate.max.created_at',
 									t('admin/users/views/user-detail___laatst-gedeblokkeerd-op'),
 								],
 							])}

--- a/src/admin/users/views/UserOverview.tsx
+++ b/src/admin/users/views/UserOverview.tsx
@@ -162,10 +162,8 @@ const UserOverview: FunctionComponent<UserOverviewProps & RouteComponentProps & 
 				...getDateRangeFilters(
 					filters,
 					['blocked_at', 'unblocked_at'],
-					[
-						'last_blocked_at.aggregate.max.created_at',
-						'last_unblocked_at.aggregate.max.created_at',
-					]
+					// Filtering has to happen on blocked_at, fetching on last_blocked_at: https://meemoo.atlassian.net/browse/AVO-2129?focusedCommentId=34844
+					['blocked_at.max', 'unblocked_at.max']
 				)
 			);
 

--- a/src/admin/users/views/UserOverview.tsx
+++ b/src/admin/users/views/UserOverview.tsx
@@ -163,7 +163,10 @@ const UserOverview: FunctionComponent<UserOverviewProps & RouteComponentProps & 
 				...getDateRangeFilters(
 					filters,
 					['blocked_at', 'unblocked_at'],
-					['blocked_at.max', 'unblocked_at.max']
+					[
+						'last_blocked_at.aggregate.max.created_at',
+						'last_unblocked_at.aggregate.max.created_at',
+					]
 				)
 			);
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2129

Requires proxy PR: https://github.com/viaacode/avo2-proxy/pull/508

This should make the get users query less resource intensive when no blocked_at or unblocked_at filters are used.