### PR TITLE
fix(avo-2221): increase subtitle fontsize when flowplayer is fullscreen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@popperjs/core": "^2.5.4",
         "@react-hook/resize-observer": "^1.2.5",
         "@storybook/addon-actions": "^6.3.12",
-        "@viaa/avo2-components": "^1.97.12",
+        "@viaa/avo2-components": "^1.97.13",
         "@viaa/avo2-types": "2.44.3",
         "apollo-boost": "^0.4.9",
         "apollo-link": "^1.2.14",
@@ -4548,9 +4548,9 @@
       }
     },
     "node_modules/@viaa/avo2-components": {
-      "version": "1.97.12",
-      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-components/-/avo2-components-1.97.12.tgz",
-      "integrity": "sha512-eQjB7YjY9pmk9y6cfBoUuVfNTrs030m2ICNQTFxV1GJxZWDwiqvEw8zsN3ru3TCPQe9pltoCDsiZ+cZfNnOMOw==",
+      "version": "1.97.13",
+      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-components/-/avo2-components-1.97.13.tgz",
+      "integrity": "sha512-e4O/pA8i61bRpD8YVNStvsZtFo/Pl1ftS1dMdz68W4usqGCb8w8f9uKKN7GThD1Xxo1hkwVVgWuGPjsPncEiEA==",
       "dependencies": {
         "@flowplayer/player": "3.2.8",
         "@popperjs/core": "^2.5.4",
@@ -28840,9 +28840,9 @@
       }
     },
     "@viaa/avo2-components": {
-      "version": "1.97.12",
-      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-components/-/avo2-components-1.97.12.tgz",
-      "integrity": "sha512-eQjB7YjY9pmk9y6cfBoUuVfNTrs030m2ICNQTFxV1GJxZWDwiqvEw8zsN3ru3TCPQe9pltoCDsiZ+cZfNnOMOw==",
+      "version": "1.97.13",
+      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-components/-/avo2-components-1.97.13.tgz",
+      "integrity": "sha512-e4O/pA8i61bRpD8YVNStvsZtFo/Pl1ftS1dMdz68W4usqGCb8w8f9uKKN7GThD1Xxo1hkwVVgWuGPjsPncEiEA==",
       "requires": {
         "@flowplayer/player": "3.2.8",
         "@popperjs/core": "^2.5.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@popperjs/core": "^2.5.4",
     "@react-hook/resize-observer": "^1.2.5",
     "@storybook/addon-actions": "^6.3.12",
-    "@viaa/avo2-components": "^1.97.12",
+    "@viaa/avo2-components": "^1.97.13",
     "@viaa/avo2-types": "2.44.3",
     "apollo-boost": "^0.4.9",
     "apollo-link": "^1.2.14",


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2221

only when screen width is > 700px

example: http://localhost:8080/item/x34mk94f4m

code is located in this commit on avo2 components: https://github.com/viaacode/avo2-components/commit/91d98856c99464ab216446e756c29552450ed2d7
```
		@media (min-width: $g-bp2) {
			.fp-captions {
				font-size: 43px; // https://meemoo.atlassian.net/browse/AVO-2221
			}
		}
```

before:
![image](https://user-images.githubusercontent.com/1710840/194515897-5cc83adf-6b23-422f-886f-d56ac23f00f2.png)


after:
![image](https://user-images.githubusercontent.com/1710840/194515888-edfbb238-d5bf-438d-8663-c092263fd888.png)
