### PR TITLE
fix(avo-2175): correctly set audio still svg in media grid block

### DIFF
--- a/src/admin/content-block/components/wrappers/MediaGridWrapper/MediaGridWrapper.tsx
+++ b/src/admin/content-block/components/wrappers/MediaGridWrapper/MediaGridWrapper.tsx
@@ -20,6 +20,7 @@ import {
 import { APP_PATH } from '../../../../../constants';
 import { ItemVideoDescription } from '../../../../../item/components';
 import { LoadingErrorLoadedComponent, LoadingInfo } from '../../../../../shared/components';
+import { DEFAULT_AUDIO_STILL } from '../../../../../shared/constants';
 import { buildLink, CustomError, formatDate, isMobileWidth } from '../../../../../shared/helpers';
 import { defaultRenderBookmarkButton } from '../../../../../shared/helpers/default-render-bookmark-button';
 import { parseIntOrDefault } from '../../../../../shared/helpers/parsers/number';
@@ -221,7 +222,10 @@ const MediaGridWrapper: FunctionComponent<
 				meta: isItem
 					? itemDuration
 					: `${collectionItems} ${isCollection ? 'items' : 'collecties'}`,
-				src: itemOrCollection?.thumbnail_path || '',
+				src:
+					(itemLabel === 'audio'
+						? DEFAULT_AUDIO_STILL
+						: itemOrCollection?.thumbnail_path) || '',
 			},
 			src: itemOrCollection?.src,
 			item_collaterals: get(itemOrCollection, 'item_collaterals', null),


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2175

before:
![image](https://user-images.githubusercontent.com/1710840/194565928-90ca7718-ef00-4192-be85-74f50b1cc03c.png)


after:
![image](https://user-images.githubusercontent.com/1710840/194565947-52fa587d-3502-4cb3-9710-afc080b34f75.png)

