### PR TITLE
fix(avo-2210): Add better typing for FilterableColumn ids

### DIFF
--- a/src/admin/assignments/assignments.const.ts
+++ b/src/admin/assignments/assignments.const.ts
@@ -1,6 +1,7 @@
 import { ButtonType, SelectOption } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
 
+import { AssignmentOverviewTableColumns } from '../../assignment/assignment.types';
 import { PermissionName, PermissionService } from '../../authentication/helpers/permission-service';
 import { BooleanCheckboxDropdownProps } from '../../shared/components/BooleanCheckboxDropdown/BooleanCheckboxDropdown';
 import { ROUTE_PARTS } from '../../shared/constants';
@@ -8,31 +9,11 @@ import { tText } from '../../shared/helpers/translate';
 import { TableColumnDataType } from '../../shared/types/table-column-data-type';
 import { FilterableColumn } from '../shared/components/FilterTable/FilterTable';
 
-import { AssignmentsOverviewTableCols } from './assignments.types';
-
 export const ASSIGNMENTS_PATH = {
 	ASSIGNMENTS_OVERVIEW: `/${ROUTE_PARTS.admin}/${ROUTE_PARTS.assignments}`,
 };
 
 export const ITEMS_PER_PAGE = 20;
-
-export const TABLE_COLUMN_TO_DATABASE_ORDER_OBJECT: Partial<{
-	[columnId in AssignmentsOverviewTableCols]: (order: Avo.Search.OrderDirection) => any;
-}> = {
-	author: (order: Avo.Search.OrderDirection) => ({
-		owner: { full_name: order },
-	}),
-	views: (order: Avo.Search.OrderDirection) => ({
-		view_counts_aggregate: {
-			sum: {
-				count: order,
-			},
-		},
-	}),
-	pupilCollections: (order: Avo.Search.OrderDirection) => ({
-		responses_aggregate: { count: order },
-	}),
-};
 
 export type AssignmentBulkActionOption = SelectOption<string> & {
 	confirm?: boolean;
@@ -60,79 +41,80 @@ export const GET_ASSIGNMENT_BULK_ACTIONS = (user: Avo.User.User): AssignmentBulk
 	];
 };
 
-export const GET_ASSIGNMENT_OVERVIEW_TABLE_COLS: () => FilterableColumn[] = () => [
-	{
-		id: 'title',
-		label: tText('admin/assignments/assignments___title'),
-		sortable: true,
-		visibleByDefault: true,
-	},
-	{
-		id: 'author',
-		label: tText('admin/assignments/assignments___auteur'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'MultiUserSelectDropdown',
-	},
-	{
-		id: 'created_at',
-		label: tText('admin/assignments/assignments___aangemaakt-op'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
-		dataType: TableColumnDataType.dateTime,
-	},
-	{
-		id: 'updated_at',
-		label: tText('admin/assignments/assignments___aangepast-op'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
-		dataType: TableColumnDataType.dateTime,
-	},
-	{
-		id: 'deadline_at',
-		label: tText('admin/assignments/assignments___vervaldatum'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
-		dataType: TableColumnDataType.dateTime,
-	},
-	{
-		id: 'status',
-		label: tText('admin/assignments/assignments___status'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'BooleanCheckboxDropdown',
-		filterProps: {
-			trueLabel: tText('admin/assignments/assignments___actief'),
-			falseLabel: tText('admin/assignments/assignments___afgelopen'),
-			includeEmpty: false,
-		} as BooleanCheckboxDropdownProps,
-		dataType: TableColumnDataType.boolean,
-	},
-	{
-		id: 'responses',
-		label: tText('admin/assignments/assignments___leerlingencollecties'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'BooleanCheckboxDropdown',
-		filterProps: {
-			includeEmpty: false,
-		} as BooleanCheckboxDropdownProps,
-		dataType: TableColumnDataType.boolean,
-	},
-	{
-		id: 'views',
-		icon: 'eye',
-		tooltip: 'views',
-		sortable: true,
-		visibleByDefault: true,
-	},
-	{
-		id: 'actions',
-		tooltip: 'actions',
-		sortable: false,
-		visibleByDefault: true,
-	},
-];
+export const GET_ASSIGNMENT_OVERVIEW_TABLE_COLS: () => FilterableColumn<AssignmentOverviewTableColumns>[] =
+	() => [
+		{
+			id: 'title',
+			label: tText('admin/assignments/assignments___title'),
+			sortable: true,
+			visibleByDefault: true,
+		},
+		{
+			id: 'author',
+			label: tText('admin/assignments/assignments___auteur'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'MultiUserSelectDropdown',
+		},
+		{
+			id: 'created_at',
+			label: tText('admin/assignments/assignments___aangemaakt-op'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'DateRangeDropdown',
+			dataType: TableColumnDataType.dateTime,
+		},
+		{
+			id: 'updated_at',
+			label: tText('admin/assignments/assignments___aangepast-op'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'DateRangeDropdown',
+			dataType: TableColumnDataType.dateTime,
+		},
+		{
+			id: 'deadline_at',
+			label: tText('admin/assignments/assignments___vervaldatum'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'DateRangeDropdown',
+			dataType: TableColumnDataType.dateTime,
+		},
+		{
+			id: 'status',
+			label: tText('admin/assignments/assignments___status'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'BooleanCheckboxDropdown',
+			filterProps: {
+				trueLabel: tText('admin/assignments/assignments___actief'),
+				falseLabel: tText('admin/assignments/assignments___afgelopen'),
+				includeEmpty: false,
+			} as BooleanCheckboxDropdownProps,
+			dataType: TableColumnDataType.boolean,
+		},
+		{
+			id: 'responses',
+			label: tText('admin/assignments/assignments___leerlingencollecties'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'BooleanCheckboxDropdown',
+			filterProps: {
+				includeEmpty: false,
+			} as BooleanCheckboxDropdownProps,
+			dataType: TableColumnDataType.boolean,
+		},
+		{
+			id: 'views',
+			icon: 'eye',
+			tooltip: 'views',
+			sortable: true,
+			visibleByDefault: true,
+		},
+		{
+			id: 'actions',
+			tooltip: 'actions',
+			sortable: false,
+			visibleByDefault: true,
+		},
+	];

--- a/src/admin/collectionsOrBundles/collections-or-bundles.const.ts
+++ b/src/admin/collectionsOrBundles/collections-or-bundles.const.ts
@@ -171,7 +171,7 @@ export const GET_COLLECTION_BULK_ACTIONS = (): CollectionBulkActionOption[] => {
 	];
 };
 
-const getCollectionTitleColumn = (): FilterableColumn => ({
+const getCollectionTitleColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'title',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___title'),
 	sortable: true,
@@ -179,7 +179,7 @@ const getCollectionTitleColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.string,
 });
 
-const getCollectionAuthorColumn = (): FilterableColumn => ({
+const getCollectionAuthorColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'owner_profile_id',
 	label: tText('admin/collections-or-bundles/views/collections-or-bundles-overview___auteur'),
 	sortable: true,
@@ -191,7 +191,7 @@ const getCollectionAuthorColumn = (): FilterableColumn => ({
 const getCollectionAuthorUserGroupColumn = (
 	userGroupOptions: CheckboxOption[],
 	visibleByDefault: boolean
-): FilterableColumn => ({
+): FilterableColumn<CollectionTableCols> => ({
 	visibleByDefault,
 	id: 'author_user_group',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___auteur-rol'),
@@ -203,7 +203,7 @@ const getCollectionAuthorUserGroupColumn = (
 	dataType: TableColumnDataType.string,
 });
 
-const getCollectionLastUpdatedByColumn = (): FilterableColumn => ({
+const getCollectionLastUpdatedByColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'last_updated_by_profile',
 	label: tText(
 		'admin/collections-or-bundles/views/collections-or-bundles-overview___laatste-bewerkt-door'
@@ -213,7 +213,7 @@ const getCollectionLastUpdatedByColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.string,
 });
 
-const getCollectionCreatedAtColumn = (): FilterableColumn => ({
+const getCollectionCreatedAtColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'created_at',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___aangemaakt-op'),
 	sortable: true,
@@ -223,7 +223,7 @@ const getCollectionCreatedAtColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.dateTime,
 });
 
-const getCollectionUpdatedAtColumn = (): FilterableColumn => ({
+const getCollectionUpdatedAtColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'updated_at',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___aangepast-op'),
 	sortable: true,
@@ -233,7 +233,7 @@ const getCollectionUpdatedAtColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.dateTime,
 });
 
-const getCollectionIsPublicColumn = (): FilterableColumn => ({
+const getCollectionIsPublicColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'is_public',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___publiek'),
 	sortable: true,
@@ -242,7 +242,9 @@ const getCollectionIsPublicColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.boolean,
 });
 
-const getCollectionLabelsColumn = (collectionLabelOptions: CheckboxOption[]): FilterableColumn => ({
+const getCollectionLabelsColumn = (
+	collectionLabelOptions: CheckboxOption[]
+): FilterableColumn<CollectionTableCols> => ({
 	id: 'collection_labels',
 	label: tText('admin/collections-or-bundles/views/collections-or-bundles-overview___labels'),
 	sortable: false,
@@ -253,7 +255,7 @@ const getCollectionLabelsColumn = (collectionLabelOptions: CheckboxOption[]): Fi
 	} as CheckboxDropdownModalProps,
 });
 
-const getCollectionIsCopyColumn = (): FilterableColumn => ({
+const getCollectionIsCopyColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'is_copy',
 	label: tText('admin/collections-or-bundles/views/collections-or-bundles-overview___kopie'),
 	sortable: false,
@@ -261,7 +263,7 @@ const getCollectionIsCopyColumn = (): FilterableColumn => ({
 	filterType: 'BooleanCheckboxDropdown',
 });
 
-const getCollectionManagedColumn = (): FilterableColumn => ({
+const getCollectionManagedColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'is_managed',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___redactie'),
 	sortable: true,
@@ -270,7 +272,7 @@ const getCollectionManagedColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.boolean,
 });
 
-const getCollectionViewsColumn = (): FilterableColumn => ({
+const getCollectionViewsColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'views',
 	tooltip: tText('admin/collections-or-bundles/collections-or-bundles___bekeken'),
 	icon: 'eye',
@@ -279,7 +281,7 @@ const getCollectionViewsColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.number,
 });
 
-const getCollectionBookmarksColumn = (): FilterableColumn => ({
+const getCollectionBookmarksColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'bookmarks',
 	tooltip: tText(
 		'admin/collections-or-bundles/views/collections-or-bundles-overview___aantal-keer-opgenomen-in-een-bladwijzer'
@@ -290,7 +292,7 @@ const getCollectionBookmarksColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.number,
 });
 
-const getCollectionCopiesColumn = (): FilterableColumn => ({
+const getCollectionCopiesColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'copies',
 	tooltip: tText(
 		'admin/collections-or-bundles/views/collections-or-bundles-overview___aantal-keer-gekopieerd'
@@ -301,7 +303,9 @@ const getCollectionCopiesColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.number,
 });
 
-const getCollectionInBundleColumn = (isCollection: boolean): FilterableColumn[] => {
+const getCollectionInBundleColumn = (
+	isCollection: boolean
+): FilterableColumn<CollectionTableCols>[] => {
 	if (isCollection) {
 		return [
 			{
@@ -319,7 +323,9 @@ const getCollectionInBundleColumn = (isCollection: boolean): FilterableColumn[] 
 	return [];
 };
 
-const getCollectionInAssignmentColumn = (isCollection: boolean): FilterableColumn[] => {
+const getCollectionInAssignmentColumn = (
+	isCollection: boolean
+): FilterableColumn<CollectionTableCols>[] => {
 	if (isCollection) {
 		return [
 			{
@@ -337,7 +343,7 @@ const getCollectionInAssignmentColumn = (isCollection: boolean): FilterableColum
 	return [];
 };
 
-const getCollectionQuickLanesColumn = (): FilterableColumn => ({
+const getCollectionQuickLanesColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'quick_lane_links',
 	tooltip: tText(
 		'admin/collections-or-bundles/collections-or-bundles___aantal-keer-gedeeld-met-leerlingen'
@@ -348,7 +354,9 @@ const getCollectionQuickLanesColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.number,
 });
 
-const getCollectionSubjectsColumn = (subjects: string[]): FilterableColumn => ({
+const getCollectionSubjectsColumn = (
+	subjects: string[]
+): FilterableColumn<CollectionTableCols> => ({
 	id: 'subjects',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___vakken'),
 	sortable: false,
@@ -359,7 +367,9 @@ const getCollectionSubjectsColumn = (subjects: string[]): FilterableColumn => ({
 	} as CheckboxDropdownModalProps,
 });
 
-const getCollectionEducationLevelsColumn = (educationLevels: string[]): FilterableColumn => ({
+const getCollectionEducationLevelsColumn = (
+	educationLevels: string[]
+): FilterableColumn<CollectionTableCols> => ({
 	id: 'education_levels',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___opleidingsniveaus'),
 	sortable: false,
@@ -372,7 +382,7 @@ const getCollectionEducationLevelsColumn = (educationLevels: string[]): Filterab
 
 const getCollectionOrganisationColumn = (
 	organisationOptions: CheckboxOption[]
-): FilterableColumn => ({
+): FilterableColumn<CollectionTableCols> => ({
 	id: 'organisation',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___organisatie'),
 	sortable: false,
@@ -383,7 +393,7 @@ const getCollectionOrganisationColumn = (
 	} as CheckboxDropdownModalProps,
 });
 
-const getActualisationStatusColumn = (): FilterableColumn => ({
+const getActualisationStatusColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'actualisation_status',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___status'),
 	sortable: true,
@@ -395,7 +405,7 @@ const getActualisationStatusColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.string,
 });
 
-const getActualisationLastActualisedAtColumn = (): FilterableColumn => ({
+const getActualisationLastActualisedAtColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'actualisation_last_actualised_at',
 	label: tText(
 		'admin/collections-or-bundles/collections-or-bundles___datum-laatste-actualisatie'
@@ -406,7 +416,7 @@ const getActualisationLastActualisedAtColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.dateTime,
 });
 
-const getActualisationStatusValidUntilColumn = (): FilterableColumn => ({
+const getActualisationStatusValidUntilColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'actualisation_status_valid_until',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___vervaldatum'),
 	sortable: true,
@@ -419,7 +429,7 @@ const getActualisationStatusValidUntilColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.dateTime,
 });
 
-const getActualisationApprovedAtColumn = (): FilterableColumn => ({
+const getActualisationApprovedAtColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'actualisation_approved_at',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___datum-goedkeuring'),
 	sortable: true,
@@ -428,7 +438,7 @@ const getActualisationApprovedAtColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.dateTime,
 });
 
-const getActualisationResponsibleProfileColumn = (): FilterableColumn => ({
+const getActualisationResponsibleProfileColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'actualisation_manager',
 	label: tText(
 		'admin/collections-or-bundles/collections-or-bundles___actualisatie-verantwoordelijke'
@@ -439,7 +449,7 @@ const getActualisationResponsibleProfileColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.string,
 });
 
-const getQualityCheckLanguageCheckColumn = (): FilterableColumn => ({
+const getQualityCheckLanguageCheckColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'quality_check_language_check',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___taalcheck'),
 	sortable: true,
@@ -453,7 +463,7 @@ const getQualityCheckLanguageCheckColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.boolean,
 });
 
-const getQualityCheckQualityCheckColumn = (): FilterableColumn => ({
+const getQualityCheckQualityCheckColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'quality_check_quality_check',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___kwaliteitscontrole'),
 	sortable: true,
@@ -467,7 +477,7 @@ const getQualityCheckQualityCheckColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.boolean,
 });
 
-const getQualityCheckApprovedAtColumn = (): FilterableColumn => ({
+const getQualityCheckApprovedAtColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'quality_check_approved_at',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___datum-goedkeuring'),
 	sortable: true,
@@ -477,7 +487,7 @@ const getQualityCheckApprovedAtColumn = (): FilterableColumn => ({
 
 const getMarcomLastCommunicationChannelTypeColumn = (
 	channelTypeOptions: CheckboxOption[]
-): FilterableColumn => ({
+): FilterableColumn<CollectionTableCols> => ({
 	id: 'marcom_last_communication_channel_type',
 	label: tText(
 		'admin/collections-or-bundles/collections-or-bundles___laatste-communicatie-kanaal-type'
@@ -493,7 +503,7 @@ const getMarcomLastCommunicationChannelTypeColumn = (
 
 const getMarcomLastCommunicationChannelNameColumn = (
 	channelNameOptions: CheckboxOption[]
-): FilterableColumn => ({
+): FilterableColumn<CollectionTableCols> => ({
 	id: 'marcom_last_communication_channel_name',
 	label: tText(
 		'admin/collections-or-bundles/collections-or-bundles___laatste-communicatie-kanaal-naam'
@@ -508,7 +518,7 @@ const getMarcomLastCommunicationChannelNameColumn = (
 	dataType: TableColumnDataType.string,
 });
 
-const getMarcomLastCommunicationAtColumn = (): FilterableColumn => ({
+const getMarcomLastCommunicationAtColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'marcom_last_communication_at',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___laatste-communicatiedatum'),
 	sortable: true,
@@ -516,7 +526,7 @@ const getMarcomLastCommunicationAtColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.dateTime,
 });
 
-const getMarcomKlascementColumn = (): FilterableColumn => ({
+const getMarcomKlascementColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'marcom_klascement',
 	label: tText('admin/collections-or-bundles/collections-or-bundles___klas-cement'),
 	sortable: true,
@@ -524,7 +534,7 @@ const getMarcomKlascementColumn = (): FilterableColumn => ({
 	dataType: TableColumnDataType.boolean,
 });
 
-const getMarcomLastUpdatedByColumn = (): FilterableColumn => ({
+const getMarcomLastUpdatedByColumn = (): FilterableColumn<CollectionTableCols> => ({
 	id: 'last_updated_by_profile',
 	label: tText(
 		'admin/collections-or-bundles/views/collections-or-bundles-overview___laatste-bewerkt-door'
@@ -541,7 +551,7 @@ export const GET_COLLECTIONS_COLUMNS = (
 	subjects: string[],
 	educationLevels: string[],
 	organisations: CheckboxOption[]
-): FilterableColumn[] => [
+): FilterableColumn<CollectionTableCols>[] => [
 	getCollectionTitleColumn(),
 	getCollectionAuthorColumn(),
 	getCollectionAuthorUserGroupColumn(userGroupOptions, true),
@@ -576,7 +586,7 @@ export const GET_COLLECTION_ACTUALISATION_COLUMNS = (
 	subjects: string[],
 	educationLevels: string[],
 	organisations: CheckboxOption[]
-): FilterableColumn[] => [
+): FilterableColumn<CollectionTableCols>[] => [
 	getCollectionTitleColumn(),
 	getCollectionAuthorColumn(),
 	getCollectionAuthorUserGroupColumn(userGroupOptions, false),
@@ -608,7 +618,7 @@ export const GET_COLLECTION_QUALITY_CHECK_COLUMNS = (
 	subjects: string[],
 	educationLevels: string[],
 	organisations: CheckboxOption[]
-): FilterableColumn[] => [
+): FilterableColumn<CollectionTableCols>[] => [
 	getCollectionTitleColumn(),
 	getCollectionAuthorColumn(),
 	getCollectionAuthorUserGroupColumn(userGroupOptions, false),
@@ -640,7 +650,7 @@ export const GET_COLLECTION_MARCOM_COLUMNS = (
 	educationLevels: string[],
 	organisations: CheckboxOption[],
 	channelTypeOptions: CheckboxOption[]
-): FilterableColumn[] => [
+): FilterableColumn<CollectionTableCols>[] => [
 	getCollectionTitleColumn(),
 	getCollectionAuthorColumn(),
 	getCollectionAuthorUserGroupColumn(userGroupOptions, false),

--- a/src/admin/content-page-labels/views/ContentPageLabelOverview.tsx
+++ b/src/admin/content-page-labels/views/ContentPageLabelOverview.tsx
@@ -120,57 +120,60 @@ const ContentPageLabelOverview: FunctionComponent<ContentPageLabelOverviewProps>
 		})
 	);
 
-	const getContentPageLabelOverviewTableCols: () => FilterableColumn[] = () => [
-		{
-			id: 'label',
-			label: tText('admin/content-page-labels/views/content-page-label-overview___label'),
-			sortable: true,
-			visibleByDefault: true,
-			dataType: TableColumnDataType.string,
-		},
-		{
-			id: 'content_type',
-			label: tText('admin/content-page-labels/views/content-page-label-overview___type'),
-			sortable: true,
-			visibleByDefault: true,
-			filterType: 'CheckboxDropdownModal',
-			filterProps: {
-				options: contentTypeOptions,
-			} as CheckboxDropdownModalProps,
-			dataType: TableColumnDataType.string,
-		},
-		{
-			id: 'link_to',
-			label: tText('admin/content-page-labels/views/content-page-label-overview___link'),
-			sortable: false,
-			visibleByDefault: true,
-		},
-		{
-			id: 'created_at',
-			label: tText(
-				'admin/content-page-labels/views/content-page-label-overview___gemaakt-op'
-			),
-			sortable: true,
-			visibleByDefault: true,
-			filterType: 'DateRangeDropdown',
-			dataType: TableColumnDataType.dateTime,
-		},
-		{
-			id: 'updated_at',
-			label: tText(
-				'admin/content-page-labels/views/content-page-label-overview___aangepast-op'
-			),
-			sortable: true,
-			visibleByDefault: true,
-			filterType: 'DateRangeDropdown',
-			dataType: TableColumnDataType.dateTime,
-		},
-		{
-			id: 'actions',
-			tooltip: tText('admin/content-page-labels/views/content-page-label-overview___acties'),
-			visibleByDefault: true,
-		},
-	];
+	const getContentPageLabelOverviewTableCols: () => FilterableColumn<ContentPageLabelOverviewTableCols>[] =
+		() => [
+			{
+				id: 'label',
+				label: tText('admin/content-page-labels/views/content-page-label-overview___label'),
+				sortable: true,
+				visibleByDefault: true,
+				dataType: TableColumnDataType.string,
+			},
+			{
+				id: 'content_type',
+				label: tText('admin/content-page-labels/views/content-page-label-overview___type'),
+				sortable: true,
+				visibleByDefault: true,
+				filterType: 'CheckboxDropdownModal',
+				filterProps: {
+					options: contentTypeOptions,
+				} as CheckboxDropdownModalProps,
+				dataType: TableColumnDataType.string,
+			},
+			{
+				id: 'link_to',
+				label: tText('admin/content-page-labels/views/content-page-label-overview___link'),
+				sortable: false,
+				visibleByDefault: true,
+			},
+			{
+				id: 'created_at',
+				label: tText(
+					'admin/content-page-labels/views/content-page-label-overview___gemaakt-op'
+				),
+				sortable: true,
+				visibleByDefault: true,
+				filterType: 'DateRangeDropdown',
+				dataType: TableColumnDataType.dateTime,
+			},
+			{
+				id: 'updated_at',
+				label: tText(
+					'admin/content-page-labels/views/content-page-label-overview___aangepast-op'
+				),
+				sortable: true,
+				visibleByDefault: true,
+				filterType: 'DateRangeDropdown',
+				dataType: TableColumnDataType.dateTime,
+			},
+			{
+				id: 'actions',
+				tooltip: tText(
+					'admin/content-page-labels/views/content-page-label-overview___acties'
+				),
+				visibleByDefault: true,
+			},
+		];
 
 	// Methods
 	const handleDelete = async () => {

--- a/src/admin/content/content.const.tsx
+++ b/src/admin/content/content.const.tsx
@@ -17,7 +17,11 @@ export const GET_CONTENT_PAGE_OVERVIEW_COLUMNS: (
 	contentTypeOptions: CheckboxOption[],
 	userGroupOptions: CheckboxOption[],
 	contentPageLabelOptions: CheckboxOption[]
-) => FilterableColumn[] = (contentTypeOptions, userGroupOptions, contentPageLabelOptions) => [
+) => FilterableColumn<ContentOverviewTableCols>[] = (
+	contentTypeOptions,
+	userGroupOptions,
+	contentPageLabelOptions
+) => [
 	{
 		id: 'title',
 		label: tText('admin/content/content___titel'),

--- a/src/admin/interactive-tour/interactive-tour.const.ts
+++ b/src/admin/interactive-tour/interactive-tour.const.ts
@@ -4,7 +4,10 @@ import { generateRandomId } from '../../shared/helpers/uuid';
 import { TableColumnDataType } from '../../shared/types/table-column-data-type';
 import { FilterableColumn } from '../shared/components/FilterTable/FilterTable';
 
-import { EditableInteractiveTour } from './interactive-tour.types';
+import {
+	EditableInteractiveTour,
+	InteractiveTourOverviewTableCols,
+} from './interactive-tour.types';
 
 export const INTERACTIVE_TOUR_PATH = {
 	INTERACTIVE_TOUR_OVERVIEW: `/${ROUTE_PARTS.admin}/${ROUTE_PARTS.interactiveTours}`,
@@ -15,43 +18,44 @@ export const INTERACTIVE_TOUR_PATH = {
 
 export const ITEMS_PER_PAGE = 10;
 
-export const GET_INTERACTIVE_TOUR_OVERVIEW_TABLE_COLS: () => FilterableColumn[] = () => [
-	{
-		id: 'name',
-		label: tText('admin/interactive-tour/interactive-tour___naam'),
-		sortable: true,
-		visibleByDefault: true,
-		dataType: TableColumnDataType.string,
-	},
-	{
-		id: 'page_id',
-		label: tText('admin/interactive-tour/interactive-tour___pagina'),
-		sortable: true,
-		visibleByDefault: true,
-		dataType: TableColumnDataType.string,
-	},
-	{
-		id: 'created_at',
-		label: tText('admin/interactive-tour/interactive-tour___aangemaakt-op'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
-		dataType: TableColumnDataType.dateTime,
-	},
-	{
-		id: 'updated_at',
-		label: tText('admin/interactive-tour/interactive-tour___aangepast-op'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
-		dataType: TableColumnDataType.dateTime,
-	},
-	{
-		id: 'actions',
-		tooltip: tText('admin/interactive-tour/interactive-tour___acties'),
-		visibleByDefault: true,
-	},
-];
+export const GET_INTERACTIVE_TOUR_OVERVIEW_TABLE_COLS: () => FilterableColumn<InteractiveTourOverviewTableCols>[] =
+	() => [
+		{
+			id: 'name',
+			label: tText('admin/interactive-tour/interactive-tour___naam'),
+			sortable: true,
+			visibleByDefault: true,
+			dataType: TableColumnDataType.string,
+		},
+		{
+			id: 'page_id',
+			label: tText('admin/interactive-tour/interactive-tour___pagina'),
+			sortable: true,
+			visibleByDefault: true,
+			dataType: TableColumnDataType.string,
+		},
+		{
+			id: 'created_at',
+			label: tText('admin/interactive-tour/interactive-tour___aangemaakt-op'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'DateRangeDropdown',
+			dataType: TableColumnDataType.dateTime,
+		},
+		{
+			id: 'updated_at',
+			label: tText('admin/interactive-tour/interactive-tour___aangepast-op'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'DateRangeDropdown',
+			dataType: TableColumnDataType.dateTime,
+		},
+		{
+			id: 'actions',
+			tooltip: tText('admin/interactive-tour/interactive-tour___acties'),
+			visibleByDefault: true,
+		},
+	];
 
 export function getInitialInteractiveTour(): Omit<EditableInteractiveTour, 'id'> {
 	return {

--- a/src/admin/items/items.const.ts
+++ b/src/admin/items/items.const.ts
@@ -6,7 +6,7 @@ import { tText } from '../../shared/helpers/translate';
 import { TableColumnDataType } from '../../shared/types/table-column-data-type';
 import { FilterableColumn } from '../shared/components/FilterTable/FilterTable';
 
-import { ItemsOverviewTableCols } from './items.types';
+import { ItemsOverviewTableCols, UnpublishedItemsOverviewTableCols } from './items.types';
 
 export const ITEMS_PATH = {
 	ITEMS_OVERVIEW: `/${ROUTE_PARTS.admin}/${ROUTE_PARTS.items}`,
@@ -191,53 +191,54 @@ export const GET_ITEM_OVERVIEW_TABLE_COLS: (
 	},
 ];
 
-export const GET_PUBLISH_ITEM_OVERVIEW_TABLE_COLS: () => FilterableColumn[] = () => [
-	{
-		id: 'title',
-		label: tText('admin/items/items___titel'),
-		sortable: true,
-		visibleByDefault: true,
-		dataType: TableColumnDataType.string,
-	},
-	{
-		id: 'pid',
-		label: tText('admin/items/items___pid'),
-		sortable: true,
-		visibleByDefault: true,
-		dataType: TableColumnDataType.string,
-	},
-	{
-		id: 'updated_at',
-		label: tText('admin/items/items___aangepast-op-mam'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
-		dataType: TableColumnDataType.dateTime,
-	},
-	{
-		id: 'status',
-		label: tText('admin/items/items___status'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'CheckboxDropdownModal',
-		filterProps: {
-			options: [
-				{
-					label: tText('admin/items/items___nieuw'),
-					id: 'NEW',
-				},
-				{
-					label: tText('admin/items/items___update'),
-					id: 'UPDATE',
-				},
-			],
+export const GET_PUBLISH_ITEM_OVERVIEW_TABLE_COLS: () => FilterableColumn<UnpublishedItemsOverviewTableCols>[] =
+	() => [
+		{
+			id: 'title',
+			label: tText('admin/items/items___titel'),
+			sortable: true,
+			visibleByDefault: true,
+			dataType: TableColumnDataType.string,
 		},
+		{
+			id: 'pid',
+			label: tText('admin/items/items___pid'),
+			sortable: true,
+			visibleByDefault: true,
+			dataType: TableColumnDataType.string,
+		},
+		{
+			id: 'updated_at',
+			label: tText('admin/items/items___aangepast-op-mam'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'DateRangeDropdown',
+			dataType: TableColumnDataType.dateTime,
+		},
+		{
+			id: 'status',
+			label: tText('admin/items/items___status'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'CheckboxDropdownModal',
+			filterProps: {
+				options: [
+					{
+						label: tText('admin/items/items___nieuw'),
+						id: 'NEW',
+					},
+					{
+						label: tText('admin/items/items___update'),
+						id: 'UPDATE',
+					},
+				],
+			},
 
-		dataType: TableColumnDataType.string,
-	},
-	{
-		id: 'actions',
-		tooltip: tText('admin/items/items___acties'),
-		visibleByDefault: true,
-	},
-];
+			dataType: TableColumnDataType.string,
+		},
+		{
+			id: 'actions',
+			tooltip: tText('admin/items/items___acties'),
+			visibleByDefault: true,
+		},
+	];

--- a/src/admin/items/views/ItemDetail.tsx
+++ b/src/admin/items/views/ItemDetail.tsx
@@ -30,7 +30,7 @@ import {
 } from '../../../shared/components';
 import WYSIWYGWrapper from '../../../shared/components/WYSIWYGWrapper/WYSIWYGWrapper';
 import { WYSIWYG_OPTIONS_FULL } from '../../../shared/constants';
-import { QUICK_LANE_DEFAULTS } from '../../../shared/constants/quick-lane';
+import { QUICK_LANE_DEFAULTS, QuickLaneColumn } from '../../../shared/constants/quick-lane';
 import { Lookup_Enum_Relation_Types_Enum } from '../../../shared/generated/graphql-db-types';
 import { buildLink, CustomError, navigate, sanitizeHtml } from '../../../shared/helpers';
 import { getSubtitles } from '../../../shared/helpers/get-subtitles';
@@ -237,7 +237,7 @@ const ItemDetail: FunctionComponent<ItemDetailProps> = ({ history, match }) => {
 		);
 	};
 
-	const handleQuickLaneColumnClick = (id: string) => {
+	const handleQuickLaneColumnClick = (id: QuickLaneColumn) => {
 		const sortOrder = quickLaneSortOrder === 'asc' ? 'desc' : 'asc'; // toggle
 
 		setQuickLaneSortColumn(id);
@@ -401,7 +401,7 @@ const ItemDetail: FunctionComponent<ItemDetailProps> = ({ history, match }) => {
 					emptyStateMessage={tText(
 						'admin/items/views/item-detail___dit-fragment-is-nog-niet-gedeeld'
 					)}
-					onColumnClick={handleQuickLaneColumnClick}
+					onColumnClick={handleQuickLaneColumnClick as any}
 					sortColumn={quickLaneSortColumn}
 					sortOrder={quickLaneSortOrder}
 				/>

--- a/src/admin/pupil-collection/pupil-collection.const.ts
+++ b/src/admin/pupil-collection/pupil-collection.const.ts
@@ -1,6 +1,7 @@
 import { Avo } from '@viaa/avo2-types';
 
 import { PermissionName, PermissionService } from '../../authentication/helpers/permission-service';
+import { PupilCollectionOverviewTableColumns } from '../../pupil-collection/pupil-collection.types';
 import { BooleanCheckboxDropdownProps } from '../../shared/components/BooleanCheckboxDropdown/BooleanCheckboxDropdown';
 import { ROUTE_PARTS } from '../../shared/constants';
 import { tText } from '../../shared/helpers/translate';
@@ -37,74 +38,75 @@ export const GET_PUPIL_COLLECTION_BULK_ACTIONS = (
 	];
 };
 
-export const GET_PUPIL_COLLECTIONS_OVERVIEW_TABLE_COLS: () => FilterableColumn[] = () => [
-	{
-		id: 'title',
-		label: tText('admin/pupil-collection/pupil-collection___titel-collectie'),
-		sortable: true,
-		visibleByDefault: true,
-	},
-	{
-		id: 'pupil',
-		label: tText('admin/pupil-collection/pupil-collection___leerling'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'MultiUserSelectDropdown',
-	},
-	{
-		id: 'assignmentTitle',
-		label: tText('admin/pupil-collection/pupil-collection___titel-opdracht'),
-		sortable: true,
-		visibleByDefault: true,
-	},
-	{
-		id: 'teacher',
-		label: tText('admin/pupil-collection/pupil-collection___lesgever'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'MultiUserSelectDropdown',
-	},
-	{
-		id: 'created_at',
-		label: tText('admin/assignments/assignments___aangemaakt-op'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
-		dataType: TableColumnDataType.dateTime,
-	},
-	{
-		id: 'updated_at',
-		label: tText('admin/assignments/assignments___aangepast-op'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
-		dataType: TableColumnDataType.dateTime,
-	},
-	{
-		id: 'deadline_at',
-		label: tText('admin/assignments/assignments___vervaldatum'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
-		dataType: TableColumnDataType.dateTime,
-	},
-	{
-		id: 'status',
-		label: tText('admin/assignments/assignments___status'),
-		sortable: true,
-		visibleByDefault: true,
-		filterType: 'BooleanCheckboxDropdown',
-		filterProps: {
-			trueLabel: tText('admin/assignments/assignments___actief'),
-			falseLabel: tText('admin/assignments/assignments___afgelopen'),
-			includeEmpty: false,
-		} as BooleanCheckboxDropdownProps,
-		dataType: TableColumnDataType.boolean,
-	},
-	{
-		id: 'actions',
-		tooltip: 'actions',
-		sortable: false,
-		visibleByDefault: true,
-	},
-];
+export const GET_PUPIL_COLLECTIONS_OVERVIEW_TABLE_COLS: () => FilterableColumn<PupilCollectionOverviewTableColumns>[] =
+	() => [
+		{
+			id: 'title',
+			label: tText('admin/pupil-collection/pupil-collection___titel-collectie'),
+			sortable: true,
+			visibleByDefault: true,
+		},
+		{
+			id: 'pupil',
+			label: tText('admin/pupil-collection/pupil-collection___leerling'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'MultiUserSelectDropdown',
+		},
+		{
+			id: 'assignmentTitle',
+			label: tText('admin/pupil-collection/pupil-collection___titel-opdracht'),
+			sortable: true,
+			visibleByDefault: true,
+		},
+		{
+			id: 'teacher',
+			label: tText('admin/pupil-collection/pupil-collection___lesgever'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'MultiUserSelectDropdown',
+		},
+		{
+			id: 'created_at',
+			label: tText('admin/assignments/assignments___aangemaakt-op'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'DateRangeDropdown',
+			dataType: TableColumnDataType.dateTime,
+		},
+		{
+			id: 'updated_at',
+			label: tText('admin/assignments/assignments___aangepast-op'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'DateRangeDropdown',
+			dataType: TableColumnDataType.dateTime,
+		},
+		{
+			id: 'deadline_at',
+			label: tText('admin/assignments/assignments___vervaldatum'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'DateRangeDropdown',
+			dataType: TableColumnDataType.dateTime,
+		},
+		{
+			id: 'status',
+			label: tText('admin/assignments/assignments___status'),
+			sortable: true,
+			visibleByDefault: true,
+			filterType: 'BooleanCheckboxDropdown',
+			filterProps: {
+				trueLabel: tText('admin/assignments/assignments___actief'),
+				falseLabel: tText('admin/assignments/assignments___afgelopen'),
+				includeEmpty: false,
+			} as BooleanCheckboxDropdownProps,
+			dataType: TableColumnDataType.boolean,
+		},
+		{
+			id: 'actions',
+			tooltip: 'actions',
+			sortable: false,
+			visibleByDefault: true,
+		},
+	];

--- a/src/admin/shared/components/FilterTable/FilterTable.tsx
+++ b/src/admin/shared/components/FilterTable/FilterTable.tsx
@@ -58,7 +58,7 @@ export interface FilterableTableState {
 	page: number;
 }
 
-export interface FilterableColumn extends TableColumn {
+export interface FilterableColumn<T = string> extends Omit<TableColumn, 'id'> {
 	filterType?:
 		| 'CheckboxDropdownModal'
 		| 'DateRangeDropdown'
@@ -68,6 +68,7 @@ export interface FilterableColumn extends TableColumn {
 		| 'MultiEducationalOrganisationSelectModal';
 	filterProps?: any;
 	visibleByDefault: boolean;
+	id: T;
 }
 
 interface FilterTableProps extends RouteComponentProps {

--- a/src/admin/users/user.const.ts
+++ b/src/admin/users/user.const.ts
@@ -27,7 +27,7 @@ export const GET_USER_OVERVIEW_TABLE_COLS: (
 	educationLevels: CheckboxOption[],
 	subjects: CheckboxOption[],
 	idps: CheckboxOption[]
-) => FilterableColumn[] = (
+) => FilterableColumn<UserOverviewTableCol>[] = (
 	user: Avo.User.User | undefined,
 	userGroupOptions: CheckboxOption[],
 	companyOptions: CheckboxOption[],
@@ -37,38 +37,38 @@ export const GET_USER_OVERVIEW_TABLE_COLS: (
 	idps: CheckboxOption[]
 ) => [
 	{
-		id: 'id',
+		id: 'id' as const,
 		label: tText('admin/users/user___id'),
 		sortable: false,
 		visibleByDefault: false,
 	},
 	{
-		id: 'first_name',
+		id: 'first_name' as const,
 		label: tText('admin/users/user___voornaam'),
 		sortable: true,
 		visibleByDefault: true,
 		dataType: TableColumnDataType.string,
 	},
 	{
-		id: 'last_name',
+		id: 'last_name' as const,
 		label: tText('admin/users/user___achternaam'),
 		sortable: true,
 		visibleByDefault: true,
 		dataType: TableColumnDataType.string,
 	},
 	{
-		id: 'mail',
+		id: 'mail' as const,
 		label: tText('admin/users/user___email'),
 		sortable: true,
 		visibleByDefault: true,
 		dataType: TableColumnDataType.string,
 	},
 	{
-		id: 'user_group',
+		id: 'user_group' as const,
 		label: tText('admin/users/user___gebruikersgroep'),
 		sortable: true,
 		visibleByDefault: true,
-		filterType: 'CheckboxDropdownModal',
+		filterType: 'CheckboxDropdownModal' as const,
 		filterProps: {
 			options: [
 				...userGroupOptions,
@@ -78,11 +78,11 @@ export const GET_USER_OVERVIEW_TABLE_COLS: (
 		dataType: TableColumnDataType.string,
 	},
 	{
-		id: 'business_category',
+		id: 'business_category' as const,
 		label: tText('admin/users/user___oormerk'),
 		sortable: true,
 		visibleByDefault: true,
-		filterType: 'CheckboxDropdownModal',
+		filterType: 'CheckboxDropdownModal' as const,
 		filterProps: {
 			options: [
 				...businessCategoryOptions,
@@ -92,45 +92,45 @@ export const GET_USER_OVERVIEW_TABLE_COLS: (
 		dataType: TableColumnDataType.string,
 	},
 	{
-		id: 'is_exception',
+		id: 'is_exception' as const,
 		label: tText('admin/users/user___uitzonderingsaccount'),
 		sortable: true,
 		visibleByDefault: true,
-		filterType: 'BooleanCheckboxDropdown',
+		filterType: 'BooleanCheckboxDropdown' as const,
 		dataType: TableColumnDataType.boolean,
 	},
 	{
-		id: 'is_blocked',
+		id: 'is_blocked' as const,
 		label: tText('admin/users/user___geblokkeerd'),
 		sortable: true,
 		visibleByDefault: true,
-		filterType: 'BooleanCheckboxDropdown',
+		filterType: 'BooleanCheckboxDropdown' as const,
 		dataType: TableColumnDataType.boolean,
 	},
 	{
-		id: 'blocked_at',
+		id: 'blocked_at' as const,
 		label: tText('admin/users/user___geblokkeerd-op'),
 		sortable: true,
 		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
+		filterType: 'DateRangeDropdown' as const,
 		dataType: TableColumnDataType.dateTime,
 	},
 	{
-		id: 'unblocked_at',
+		id: 'unblocked_at' as const,
 		label: tText('admin/users/user___ongeblokkeerd-op'),
 		sortable: true,
 		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
+		filterType: 'DateRangeDropdown' as const,
 		dataType: TableColumnDataType.dateTime,
 	},
-	...((PermissionService.hasPerm(user, PermissionName.EDIT_USER_TEMP_ACCESS)
+	...(PermissionService.hasPerm(user, PermissionName.EDIT_USER_TEMP_ACCESS)
 		? [
 				{
-					id: 'temp_access',
+					id: 'temp_access' as const,
 					label: tText('admin/users/user___tijdelijke-toegang'),
 					sortable: true,
 					visibleByDefault: false,
-					filterType: 'CheckboxDropdownModal',
+					filterType: 'CheckboxDropdownModal' as const,
 					filterProps: {
 						options: [
 							{
@@ -146,35 +146,35 @@ export const GET_USER_OVERVIEW_TABLE_COLS: (
 					dataType: TableColumnDataType.booleanNullsLast, // Users without a value are always last when sorting
 				},
 				{
-					id: 'temp_access_from',
+					id: 'temp_access_from' as const,
 					label: tText('admin/users/user___te-deblokkeren-op'),
 					sortable: true,
 					visibleByDefault: false,
 					dataType: TableColumnDataType.dateTime,
 				},
 				{
-					id: 'temp_access_until',
+					id: 'temp_access_until' as const,
 					label: tText('admin/users/user___te-blokkeren-op'),
 					sortable: true,
 					visibleByDefault: false,
 					dataType: TableColumnDataType.dateTime,
 				},
 		  ]
-		: []) as FilterableColumn[]),
+		: []),
 	{
-		id: 'stamboek',
+		id: 'stamboek' as const,
 		label: tText('admin/users/user___stamboek'),
 		sortable: true,
 		visibleByDefault: true,
-		filterType: 'BooleanCheckboxDropdown',
+		filterType: 'BooleanCheckboxDropdown' as const,
 		dataType: TableColumnDataType.number,
 	},
 	{
-		id: 'organisation',
+		id: 'organisation' as const,
 		label: tText('admin/users/user___organisatie'),
 		sortable: true,
 		visibleByDefault: true,
-		filterType: 'CheckboxDropdownModal',
+		filterType: 'CheckboxDropdownModal' as const,
 		filterProps: {
 			options: [
 				...companyOptions,
@@ -184,27 +184,27 @@ export const GET_USER_OVERVIEW_TABLE_COLS: (
 		dataType: TableColumnDataType.string,
 	},
 	{
-		id: 'created_at',
+		id: 'created_at' as const,
 		label: tText('admin/users/user___gebruiker-sinds'),
 		sortable: true,
 		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
+		filterType: 'DateRangeDropdown' as const,
 		dataType: TableColumnDataType.dateTime,
 	},
 	{
-		id: 'last_access_at',
+		id: 'last_access_at' as const,
 		label: tText('admin/users/user___laatste-toegang'),
 		sortable: true,
 		visibleByDefault: true,
-		filterType: 'DateRangeDropdown',
+		filterType: 'DateRangeDropdown' as const,
 		dataType: TableColumnDataType.dateTime,
 	},
 	{
-		id: 'education_levels',
+		id: 'education_levels' as const,
 		label: tText('admin/users/user___onderwijs-niveaus'),
 		sortable: false,
 		visibleByDefault: false,
-		filterType: 'CheckboxDropdownModal',
+		filterType: 'CheckboxDropdownModal' as const,
 		filterProps: {
 			options: [
 				...educationLevels,
@@ -214,31 +214,31 @@ export const GET_USER_OVERVIEW_TABLE_COLS: (
 		} as CheckboxDropdownModalProps,
 	},
 	{
-		id: 'subjects',
+		id: 'subjects' as const,
 		label: tText('admin/users/user___vakken'),
 		sortable: false,
 		visibleByDefault: false,
-		filterType: 'CheckboxDropdownModal',
+		filterType: 'CheckboxDropdownModal' as const,
 		filterProps: {
 			options: [...subjects, { label: tText('admin/users/user___leeg'), id: NULL_FILTER }],
 		} as CheckboxDropdownModalProps,
 	},
 	{
-		id: 'idps',
+		id: 'idps' as const,
 		label: tText('admin/users/user___toegang-via'),
 		sortable: false,
 		visibleByDefault: false,
-		filterType: 'CheckboxDropdownModal',
+		filterType: 'CheckboxDropdownModal' as const,
 		filterProps: {
 			options: [...idps, { label: tText('admin/users/user___leeg'), id: NULL_FILTER }],
 		} as CheckboxDropdownModalProps,
 	},
 	{
-		id: 'educational_organisations',
+		id: 'educational_organisations' as const,
 		label: tText('admin/users/user___educatieve-organisaties'),
 		sortable: false,
 		visibleByDefault: false,
-		filterType: 'MultiEducationalOrganisationSelectModal',
+		filterType: 'MultiEducationalOrganisationSelectModal' as const,
 	},
 ];
 

--- a/src/collection/components/CollectionOrBundleEditAdmin.tsx
+++ b/src/collection/components/CollectionOrBundleEditAdmin.tsx
@@ -28,7 +28,7 @@ import { APP_PATH } from '../../constants';
 import AssociatedQuickLaneTable, {
 	AssociatedQuickLaneTableOrderBy,
 } from '../../quick-lane/components/AssociatedQuickLaneTable';
-import { QUICK_LANE_DEFAULTS } from '../../shared/constants/quick-lane';
+import { QUICK_LANE_DEFAULTS, QuickLaneColumn } from '../../shared/constants/quick-lane';
 import { buildLink, CustomError, formatTimestamp, getFullName } from '../../shared/helpers';
 import { truncateTableValue } from '../../shared/helpers/truncate';
 import withUser, { UserProps } from '../../shared/hocs/withUser';
@@ -196,7 +196,7 @@ const CollectionOrBundleEditAdmin: FunctionComponent<
 		);
 	};
 
-	const handleQuickLaneColumnClick = (id: string) => {
+	const handleQuickLaneColumnClick = (id: QuickLaneColumn) => {
 		const sortOrder = quickLaneSortOrder === 'asc' ? 'desc' : 'asc'; // toggle
 
 		setQuickLaneSortColumn(id);
@@ -346,7 +346,7 @@ const CollectionOrBundleEditAdmin: FunctionComponent<
 					emptyStateMessage={tText(
 						'collection/components/collection-or-bundle-edit-admin___deze-collectie-is-nog-niet-gedeeld'
 					)}
-					onColumnClick={handleQuickLaneColumnClick}
+					onColumnClick={handleQuickLaneColumnClick as any}
 					sortColumn={quickLaneSortColumn}
 					sortOrder={quickLaneSortOrder}
 				/>

--- a/src/quick-lane/components/AssociatedQuickLaneTable.tsx
+++ b/src/quick-lane/components/AssociatedQuickLaneTable.tsx
@@ -3,7 +3,7 @@ import { TableColumnSchema } from '@viaa/avo2-components/dist/esm/components/Tab
 import React, { FunctionComponent } from 'react';
 
 import QuickLaneFilterTableCell from '../../shared/components/QuickLaneFilterTableCell/QuickLaneFilterTableCell';
-import { QUICK_LANE_COLUMNS } from '../../shared/constants/quick-lane';
+import { QuickLaneColumn } from '../../shared/constants/quick-lane';
 import { isMobileWidth } from '../../shared/helpers';
 import useTranslation from '../../shared/hooks/useTranslation';
 import { QuickLaneUrlObject } from '../../shared/types';
@@ -18,7 +18,7 @@ const AssociatedQuickLaneTable: FunctionComponent<TableProps> = ({
 }) => {
 	const { tText } = useTranslation();
 
-	const renderAssociatedQuickLaneTableCell = (data: QuickLaneUrlObject, id: string) => (
+	const renderAssociatedQuickLaneTableCell = (data: QuickLaneUrlObject, id: QuickLaneColumn) => (
 		<QuickLaneFilterTableCell id={id} data={data} />
 	);
 
@@ -28,7 +28,7 @@ const AssociatedQuickLaneTable: FunctionComponent<TableProps> = ({
 				columns={
 					[
 						{
-							id: QUICK_LANE_COLUMNS.TITLE,
+							id: 'title',
 							label: tText('workspace/views/quick-lane-overview___titel'),
 							sortable: true,
 							dataType: TableColumnDataType.string,
@@ -38,7 +38,7 @@ const AssociatedQuickLaneTable: FunctionComponent<TableProps> = ({
 							? []
 							: [
 									{
-										id: QUICK_LANE_COLUMNS.AUTHOR,
+										id: 'author',
 										label: tText(
 											'workspace/views/quick-lane-overview___aangemaakt-door'
 										),
@@ -46,7 +46,7 @@ const AssociatedQuickLaneTable: FunctionComponent<TableProps> = ({
 										dataType: TableColumnDataType.string,
 									},
 									{
-										id: QUICK_LANE_COLUMNS.ORGANISATION,
+										id: 'organisation',
 										label: tText(
 											'workspace/views/quick-lane-overview___organisatie'
 										),
@@ -54,7 +54,7 @@ const AssociatedQuickLaneTable: FunctionComponent<TableProps> = ({
 										dataType: TableColumnDataType.string,
 									},
 									{
-										id: QUICK_LANE_COLUMNS.CREATED_AT,
+										id: 'created_at',
 										label: tText(
 											'workspace/views/quick-lane-overview___aangemaakt-op'
 										),
@@ -62,12 +62,12 @@ const AssociatedQuickLaneTable: FunctionComponent<TableProps> = ({
 										dataType: TableColumnDataType.dateTime,
 									},
 							  ]),
-					] as TableColumnSchema[]
+					] as (Omit<TableColumnSchema, 'id'> & { id: QuickLaneColumn })[]
 				}
 				data={data}
 				emptyStateMessage={emptyStateMessage}
 				onColumnClick={onColumnClick}
-				renderCell={renderAssociatedQuickLaneTableCell}
+				renderCell={renderAssociatedQuickLaneTableCell as any}
 				sortColumn={sortColumn}
 				sortOrder={sortOrder}
 				variant="bordered"
@@ -79,7 +79,7 @@ const AssociatedQuickLaneTable: FunctionComponent<TableProps> = ({
 
 export default AssociatedQuickLaneTable as FunctionComponent<TableProps>;
 
-export const AssociatedQuickLaneTableOrderBy = {
-	[QUICK_LANE_COLUMNS.AUTHOR]: 'owner.user.full_name',
-	[QUICK_LANE_COLUMNS.ORGANISATION]: 'owner.organisation.name',
+export const AssociatedQuickLaneTableOrderBy: Partial<Record<QuickLaneColumn, string>> = {
+	author: 'owner.user.full_name',
+	organisation: 'owner.organisation.name',
 };

--- a/src/shared/components/QuickLaneFilterTableCell/QuickLaneFilterTableCell.tsx
+++ b/src/shared/components/QuickLaneFilterTableCell/QuickLaneFilterTableCell.tsx
@@ -2,13 +2,13 @@ import React, { FC, ReactNode } from 'react';
 
 import { isCollection, isItem } from '../../../quick-lane/quick-lane.helpers';
 import useTranslation from '../../../shared/hooks/useTranslation';
-import { QUICK_LANE_COLUMNS } from '../../constants/quick-lane';
+import { QuickLaneColumn } from '../../constants/quick-lane';
 import { formatDate, formatTimestamp } from '../../helpers';
 import { QuickLaneUrlObject } from '../../types';
 import QuickLaneLink from '../QuickLaneLink/QuickLaneLink';
 
 interface QuickLaneFilterTableCellProps {
-	id: string;
+	id: QuickLaneColumn;
 	data: QuickLaneUrlObject;
 	actions?: (data?: QuickLaneUrlObject) => ReactNode;
 }
@@ -38,7 +38,7 @@ const QuickLaneFilterTableCell: FC<QuickLaneFilterTableCellProps> = ({
 	};
 
 	switch (id) {
-		case QUICK_LANE_COLUMNS.TITLE:
+		case 'title':
 			return data.title.length <= 0 ? (
 				<span className="u-text-muted">
 					{tHtml('workspace/views/quick-lane-overview___geen')}
@@ -47,20 +47,20 @@ const QuickLaneFilterTableCell: FC<QuickLaneFilterTableCellProps> = ({
 				<QuickLaneLink id={data.id} label={data.title} />
 			);
 
-		case QUICK_LANE_COLUMNS.CONTENT_LABEL:
+		case 'content_label':
 			return <span>{getItemTypeLabel(data)}</span>;
 
-		case QUICK_LANE_COLUMNS.AUTHOR:
+		case 'author':
 			return <span>{data.owner?.user.full_name || '-'}</span>;
 
-		case QUICK_LANE_COLUMNS.CREATED_AT:
-		case QUICK_LANE_COLUMNS.UPDATED_AT:
+		case 'created_at':
+		case 'updated_at':
 			return getItemTimestamp(data);
 
-		case QUICK_LANE_COLUMNS.ORGANISATION:
+		case 'organisation':
 			return <span>{data.owner?.organisation?.name || '-'}</span>;
 
-		case QUICK_LANE_COLUMNS.ACTIONS:
+		case 'action':
 			return <>{actions(data)}</>;
 	}
 

--- a/src/shared/constants/quick-lane.ts
+++ b/src/shared/constants/quick-lane.ts
@@ -1,15 +1,14 @@
-export const QUICK_LANE_COLUMNS = {
-	TITLE: 'title',
-	CREATED_AT: 'created_at',
-	UPDATED_AT: 'updated_at',
-	CONTENT_LABEL: 'content_label',
-	AUTHOR: 'author',
-	ORGANISATION: 'organisation',
-	ACTIONS: 'action',
-};
+export type QuickLaneColumn =
+	| 'title'
+	| 'created_at'
+	| 'updated_at'
+	| 'content_label'
+	| 'author'
+	| 'organisation'
+	| 'action';
 
 export const QUICK_LANE_DEFAULTS = {
-	sort_column: QUICK_LANE_COLUMNS.CREATED_AT,
+	sort_column: 'created_at',
 	sort_order: 'desc',
 };
 

--- a/src/workspace/views/QuickLaneOverview.tsx
+++ b/src/workspace/views/QuickLaneOverview.tsx
@@ -13,7 +13,7 @@ import { QuickLaneService } from '../../quick-lane/quick-lane.service';
 import { DeleteObjectModal, LoadingInfo } from '../../shared/components';
 import QuickLaneFilterTableCell from '../../shared/components/QuickLaneFilterTableCell/QuickLaneFilterTableCell';
 import QuickLaneModal from '../../shared/components/QuickLaneModal/QuickLaneModal';
-import { QUICK_LANE_COLUMNS, QUICK_LANE_DEFAULTS } from '../../shared/constants/quick-lane';
+import { QUICK_LANE_DEFAULTS, QuickLaneColumn } from '../../shared/constants/quick-lane';
 import { CustomError, isMobileWidth } from '../../shared/helpers';
 import { copyQuickLaneToClipboard } from '../../shared/helpers/generate-quick-lane-href';
 import { getTypeOptions, isOrganisational, isPersonal } from '../../shared/helpers/quick-lane';
@@ -63,9 +63,9 @@ const QuickLaneOverview: FunctionComponent<QuickLaneOverviewProps> = ({ user }) 
 
 	// Configuration
 
-	const columns: FilterableColumn[] = [
+	const columns: FilterableColumn<QuickLaneColumn>[] = [
 		{
-			id: QUICK_LANE_COLUMNS.TITLE,
+			id: 'title',
 			label: tText('workspace/views/quick-lane-overview___titel'),
 			sortable: true,
 			dataType: TableColumnDataType.string,
@@ -76,56 +76,56 @@ const QuickLaneOverview: FunctionComponent<QuickLaneOverviewProps> = ({ user }) 
 			? []
 			: [
 					{
-						id: QUICK_LANE_COLUMNS.CONTENT_LABEL,
+						id: 'content_label' as const,
 						label: tText('workspace/views/quick-lane-overview___type'),
 						sortable: true,
 						dataType: TableColumnDataType.string,
 						visibleByDefault: true,
-						filterType: 'CheckboxDropdownModal',
+						filterType: 'CheckboxDropdownModal' as const,
 						filterProps: { options: getTypeOptions() },
 					},
 
 					...(isOrganisational(user)
 						? [
 								{
-									id: QUICK_LANE_COLUMNS.AUTHOR,
+									id: 'author' as const,
 									label: tText(
 										'workspace/views/quick-lane-overview___aangemaakt-door'
 									),
 									sortable: true,
 									dataType: TableColumnDataType.string,
 									visibleByDefault: true,
-									filterType: 'MultiUserSelectDropdown',
+									filterType: 'MultiUserSelectDropdown' as const,
 								},
 						  ]
 						: []),
 
 					...[
 						{
-							id: QUICK_LANE_COLUMNS.CREATED_AT,
+							id: 'created_at' as const,
 							label: tText('workspace/views/quick-lane-overview___aangemaakt-op'),
 							sortable: true,
 							dataType: TableColumnDataType.dateTime,
 							visibleByDefault: true,
-							filterType: 'DateRangeDropdown',
+							filterType: 'DateRangeDropdown' as const,
 						},
 						// Disabled due to: https://meemoo.atlassian.net/browse/AVO-1753?focusedCommentId=24892
 						// {
-						// 	id: QUICK_LANE_COLUMNS.UPDATED_AT,
+						// 	id: 'updated_at' as const,
 						// 	label: tText('workspace/views/quick-lane-overview___aangepast-op'),
 						// 	sortable: true,
 						// 	dataType: TableColumnDataType.dateTime,
 						// 	visibleByDefault: true,
-						// 	filterType: 'DateRangeDropdown',
+						// 	filterType: 'DateRangeDropdown' as const,
 						// },
 					],
 			  ]),
 		{
-			id: QUICK_LANE_COLUMNS.ACTIONS,
+			id: 'action',
 			sortable: false,
 			visibleByDefault: true,
 		},
-	] as FilterableColumn[];
+	];
 
 	// Data
 
@@ -263,7 +263,7 @@ const QuickLaneOverview: FunctionComponent<QuickLaneOverviewProps> = ({ user }) 
 
 	// Rendering
 
-	const renderCell = (data: QuickLaneUrlObject, id: string) => (
+	const renderCell = (data: QuickLaneUrlObject, id: QuickLaneColumn) => (
 		<QuickLaneFilterTableCell
 			id={id}
 			data={data}
@@ -352,7 +352,7 @@ const QuickLaneOverview: FunctionComponent<QuickLaneOverviewProps> = ({ user }) 
 						setFilters(state as QuickLaneOverviewFilterState);
 					}
 				}}
-				renderCell={renderCell}
+				renderCell={renderCell as any}
 				renderNoResults={() => <h1>NoResults</h1>}
 				searchTextPlaceholder={tText(
 					'workspace/views/quick-lane-overview___zoek-op-titel-of-naam-van-de-auteur'


### PR DESCRIPTION
This helps with the GRAPHQL query => REST endpoint migration
since we get typescript errors if the column ids do not match the correct columnId type

![image](https://user-images.githubusercontent.com/1710840/204849383-21730f16-9437-4a52-9ccc-164898006c5e.png)
