### PR TITLE
fix(avo-2239): set player start point when initializing + select visible

### DIFF
--- a/src/collection/components/modals/CutFragmentModal.tsx
+++ b/src/collection/components/modals/CutFragmentModal.tsx
@@ -8,7 +8,7 @@ import {
 	ToolbarRight,
 } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
-import { noop } from 'lodash-es';
+import { noop, once } from 'lodash-es';
 import React, { FunctionComponent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -145,6 +145,10 @@ const CutFragmentModal: FunctionComponent<CutFragmentModalProps> = ({
 		onClose();
 	};
 
+	const startStartTimeOnce = once(() => {
+		setModalVideoSeekTime(fragmentStartTime);
+	});
+
 	const fragmentDuration: number = toSeconds(itemMetaData.duration, true) || 0;
 	return (
 		<Modal
@@ -166,6 +170,7 @@ const CutFragmentModal: FunctionComponent<CutFragmentModalProps> = ({
 						end: fragmentEndTime,
 					}}
 					verticalLayout={isMobileWidth()}
+					onPlay={startStartTimeOnce}
 				/>
 				<TimeCropControls
 					className="u-spacer-top-l u-spacer-bottom-l"

--- a/src/item/components/modals/AddToCollectionModal.tsx
+++ b/src/item/components/modals/AddToCollectionModal.tsx
@@ -18,6 +18,7 @@ import {
 	ToolbarRight,
 } from '@viaa/avo2-components';
 import { Avo } from '@viaa/avo2-types';
+import { once } from 'lodash-es';
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -269,6 +270,10 @@ const AddToCollectionModal: FunctionComponent<AddToCollectionModalProps> = ({
 			fragmentDuration
 		);
 
+		const startStartTimeOnce = once(() => {
+			setModalVideoSeekTime(fragmentStartTime);
+		});
+
 		return (
 			<Modal
 				title={t(
@@ -288,6 +293,7 @@ const AddToCollectionModal: FunctionComponent<AddToCollectionModalProps> = ({
 									showTitle
 									showDescription
 									canPlay={isOpen}
+									onPlay={startStartTimeOnce}
 									cuePointsLabel={{ start, end }}
 									verticalLayout={isMobileWidth()}
 								/>

--- a/src/shared/helpers/set-modal-video-seek-time.ts
+++ b/src/shared/helpers/set-modal-video-seek-time.ts
@@ -1,6 +1,6 @@
 export function setModalVideoSeekTime(newTime: number): void {
 	const video: HTMLVideoElement | null = document.querySelector(
-		'.c-modal .c-video-player video'
+		'.c-modal-context--visible .c-modal .c-video-player video'
 	) as HTMLVideoElement | null;
 	if (video) {
 		video.currentTime = newTime;


### PR DESCRIPTION
Sometimes the cut video modal can get into a state where the range control does not update the video.
https://user-images.githubusercontent.com/1710840/210817760-917aad1a-355a-43a1-ab27-7c5648839e25.mp4

This is because there can be 2 videos in different modals, and we're updating the wrong video in a hidden modal:
![image](https://user-images.githubusercontent.com/1710840/210818054-265fbbc2-59cf-4886-8c5c-22e99765f8d3.png)
![image](https://user-images.githubusercontent.com/1710840/210818090-104b03f4-c674-4e03-bcac-d9315e9a766c.png)


Also when you move the range control, the video does not jump to that location after the video initializes.
So i added an onPlay once handler to set the video start point to the start cuepoint when the video is initialized.



