### PR TITLE
feat(avo-2343): redirect klaar to uitgeklaard project page

### DIFF
--- a/src/dynamic-route-resolver/dynamic-route-resolver.const.ts
+++ b/src/dynamic-route-resolver/dynamic-route-resolver.const.ts
@@ -31,6 +31,7 @@ export const GET_REDIRECTS: () => { [avo1Path: string]: string } = () => ({
 		'/nieuws/barend-van-heusden-aan-het-woord-over-cultuur-de-spiegel',
 
 	'/klaar.json': `${getEnv('PROXY_URL')}/klaar/klaar.json`,
+	'/projecten/klaar': '/projecten/uitgeklaard',
 });
 
 export const GET_ERROR_MESSAGES: () => { [key: string]: string } = () => ({


### PR DESCRIPTION
The /projecten/klaar page has been changed to /projecten/uitgeklaard

In various content pages, they still reference /projecten/klaar

This PR adds a redirect from /projecten/klaar to /projecten/uitgeklaard to the dynamic route resolver component


You can test the redirect by visiting: http://localhost:8080/projecten/klaar