### PR TITLE
fix(avo-2371): show success link account toast after translations were loaded

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ wrapHistory(history, {
 });
 
 const App: FunctionComponent<RouteComponentProps & UserProps> = (props) => {
+	const { tHtml } = useTranslation();
 	const isAdminRoute = new RegExp(`^/${ROUTE_PARTS.admin}`, 'g').test(props.location.pathname);
 
 	const [loadingInfo, setLoadingInfo] = useState<LoadingInfo>({ state: 'loading' });
@@ -73,6 +74,19 @@ const App: FunctionComponent<RouteComponentProps & UserProps> = (props) => {
 			document.body.classList.remove('hide-zendesk-widget');
 		}
 	}, [props.user]);
+
+	useEffect(() => {
+		if (loadingInfo.state === 'loaded') {
+			const url = new URL(window.location.href);
+			const linked: Avo.Auth.IdpLinkedSuccessQueryParam = 'linked';
+			const hasLinked = url.searchParams.get(linked) !== null;
+			if (hasLinked) {
+				ToastService.success(tHtml('app___je-account-is-gekoppeld'));
+				url.searchParams.delete(linked);
+				history.replace(url.toString().replace(url.origin, ''));
+			}
+		}
+	}, [loadingInfo]);
 
 	// Render
 	const renderApp = () => {
@@ -128,17 +142,6 @@ const queryClient = new QueryClient();
 const Root: FunctionComponent = () => {
 	const { tHtml } = useTranslation();
 	const [isUnsavedChangesModalOpen, setIsUnsavedChangesModalOpen] = useState(false);
-
-	useEffect(() => {
-		const url = new URL(window.location.href);
-		const linked: Avo.Auth.IdpLinkedSuccessQueryParam = 'linked';
-		const hasLinked = url.searchParams.get(linked) !== null;
-		if (hasLinked) {
-			ToastService.success(tHtml('app___je-account-is-gekoppeld'));
-			url.searchParams.delete(linked);
-			history.replace(url.toString().replace(url.origin, ''));
-		}
-	}, []);
 
 	return (
 		<QueryClientProvider client={queryClient}>

--- a/src/admin/shared/layouts/AdminLayout/AdminLayout.scss
+++ b/src/admin/shared/layouts/AdminLayout/AdminLayout.scss
@@ -16,6 +16,10 @@
 		}
 	}
 
+	.c-toolbar .c-button + .c-button {
+		margin-left: $g-spacer-unit;
+	}
+
 	.m-admin-layout-content {
 		overflow-y: auto;
 		height: calc(100vh - 64px);


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2371

pagina: https://onderwijs-qas.hetarchief.be/instellingen/koppelingen

before:
![image](https://user-images.githubusercontent.com/1710840/215847724-91d96bc1-6320-4b75-8094-4dc00111f0b6.png)

after:
![image](https://user-images.githubusercontent.com/1710840/215847744-36175c9b-01e5-4de4-99f7-304138991de0.png)
