### PR TITLE
fix(avo-2375): add back buttons to detail and edit pages

### DIFF
--- a/src/admin/content-page/views/ContentPageDetailPage.tsx
+++ b/src/admin/content-page/views/ContentPageDetailPage.tsx
@@ -5,14 +5,10 @@ import MetaTags from 'react-meta-tags';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
 import { GENERATE_SITE_TITLE } from '../../../constants';
-import { navigate } from '../../../shared/helpers';
 import useTranslation from '../../../shared/hooks/useTranslation';
-import { Back } from '../../shared/components/Back/Back';
 import { withAdminCoreConfig } from '../../shared/hoc/with-admin-core-config';
-import { CONTENT_PAGE_PATH } from '../content-page.consts';
 
 const ContentPageDetailPage: FunctionComponent<DefaultSecureRouteProps<ContentPageDetailProps>> = ({
-	history,
 	match,
 }) => {
 	const { id } = match.params;
@@ -35,16 +31,7 @@ const ContentPageDetailPage: FunctionComponent<DefaultSecureRouteProps<ContentPa
 					<meta name="description" content={item.seoDescription || ''} />
 				</MetaTags>
 			)}
-			<ContentPageDetail
-				className="c-admin-core"
-				id={id}
-				loaded={setItem}
-				renderBack={() => (
-					<Back
-						onClick={() => navigate(history, CONTENT_PAGE_PATH.CONTENT_PAGE_OVERVIEW)}
-					/>
-				)}
-			/>
+			<ContentPageDetail className="c-admin-core" id={id} loaded={setItem} />
 		</>
 	);
 };

--- a/src/admin/content-page/views/ContentPageEditPage.tsx
+++ b/src/admin/content-page/views/ContentPageEditPage.tsx
@@ -3,25 +3,13 @@ import type { ContentPageDetailProps } from '@meemoo/admin-core-ui';
 import React, { FunctionComponent } from 'react';
 
 import { DefaultSecureRouteProps } from '../../../authentication/components/SecuredRoute';
-import { navigate } from '../../../shared/helpers';
-import { Back } from '../../shared/components/Back/Back';
 import { withAdminCoreConfig } from '../../shared/hoc/with-admin-core-config';
-import { CONTENT_PAGE_PATH } from '../content-page.consts';
 
 const ContentPageDetailPage: FunctionComponent<DefaultSecureRouteProps<ContentPageDetailProps>> = ({
-	history,
 	match,
 }) => {
 	const { id } = match.params;
-	return (
-		<ContentPageEdit
-			className="c-admin-core c-admin__content-page-edit"
-			id={id}
-			renderBack={() => (
-				<Back onClick={() => navigate(history, CONTENT_PAGE_PATH.CONTENT_PAGE_OVERVIEW)} />
-			)}
-		/>
-	);
+	return <ContentPageEdit className="c-admin-core c-admin__content-page-edit" id={id} />;
 };
 
 export default withAdminCoreConfig(ContentPageDetailPage as FunctionComponent);

--- a/src/admin/shared/hoc/with-admin-core-config.const.tsx
+++ b/src/admin/shared/hoc/with-admin-core-config.const.tsx
@@ -75,6 +75,7 @@ export function getAdminCoreConfig(user?: Avo.User.User): AdminConfig {
 				arrowUp: { name: 'arrow-up' },
 				sortTable: { name: 'chevrons-up-and-down' },
 				arrowDown: { name: 'arrow-down' },
+				chevronLeft: { name: 'chevron-left' },
 			},
 			list: () => [],
 		},

--- a/src/styles/admin-core/_back-button.scss
+++ b/src/styles/admin-core/_back-button.scss
@@ -1,0 +1,4 @@
+.c-admin__back .c-button {
+	padding: 0.8rem;
+	margin-right: 0.8rem;
+}

--- a/src/styles/admin-core/_index.scss
+++ b/src/styles/admin-core/_index.scss
@@ -1,3 +1,5 @@
 @import './header';
 @import './toolbar';
 @import './user-group-select';
+@import './spinner';
+@import './back-button';

--- a/src/styles/admin-core/_spinner.scss
+++ b/src/styles/admin-core/_spinner.scss
@@ -1,0 +1,4 @@
+.o-app--admin__main > div > .c-spinner--large {
+	left: calc(50% - 2rem);
+	top: calc(50vh - 2rem);
+}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2375

requires PR: https://github.com/viaacode/react-admin-core-module/pull/104

page:
* http://localhost:8080/admin/gebruikers/a900a663-c319-4b3c-99da-ede663ad29fc
* http://localhost:8080/admin/gebruikers/a900a663-c319-4b3c-99da-ede663ad29fc/bewerk
* http://localhost:8080/admin/content/1529
* http://localhost:8080/admin/content/1529/bewerk
* http://localhost:8080/admin/navigatie/footer-links
* http://localhost:8080/admin/navigatie/footer-links/1/bewerk

before:
![image](https://user-images.githubusercontent.com/1710840/216096564-de3f786e-ff0d-44e3-b4e9-b0ebcf92a6d9.png)

after:
![image](https://user-images.githubusercontent.com/1710840/216096537-aeae8fec-e2dc-4038-a7b4-2115b9208d0a.png)