### PR TITLE
fix(avo-2359): make border for first column specific to translations

### DIFF
--- a/src/admin/shared/layouts/AdminLayout/AdminLayout.scss
+++ b/src/admin/shared/layouts/AdminLayout/AdminLayout.scss
@@ -76,7 +76,7 @@
 		}
 	}
 
-	.c-table td:nth-child(2) {
+	[class^='TranslationsOverviewPage_c-translations-overview'] .c-table td:nth-child(2) {
 		border-left: 1px solid lightgray;
 		padding: 3rem;
 	}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2359

page: http://localhost:8080/admin/gebruikers

before:
![image](https://user-images.githubusercontent.com/1710840/216112395-06a45b19-4a0b-44bf-8732-926d73766481.png)

after:
![image](https://user-images.githubusercontent.com/1710840/216112188-b96bb68f-5c51-46d1-a6bc-33b7aead59a1.png)
![image](https://user-images.githubusercontent.com/1710840/216112479-ec187f3a-8a8e-4e8e-bed7-63135f18a735.png)
