### PR TITLE
fix(avo-2398): reset cuepoints for cutting videos when modal closes

### DIFF
--- a/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponseSearchTab.tsx
+++ b/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponseSearchTab.tsx
@@ -144,6 +144,16 @@ const AssignmentResponseSearchTab: FunctionComponent<
 		}
 	};
 
+	const handleReturnToSearchResults = () => {
+		setIsAddToAssignmentModalOpen(false);
+		setSelectedItem(null);
+		setFilterState({
+			...filterState,
+			focus: filterState.selectedSearchResultId,
+			selectedSearchResultId: undefined,
+		});
+	};
+
 	// Render
 
 	const renderDetailLink = (linkText: string | ReactNode, id: string) => {
@@ -235,13 +245,7 @@ const AssignmentResponseSearchTab: FunctionComponent<
 							<Button
 								type="link"
 								className="c-return--search-results"
-								onClick={() => {
-									setFilterState({
-										...filterState,
-										focus: filterState.selectedSearchResultId,
-										selectedSearchResultId: undefined,
-									});
-								}}
+								onClick={handleReturnToSearchResults}
 							>
 								<Icon name={IconName.chevronLeft} size="small" type="arrows" />
 								{tText(


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2398

page: http://localhost:8080/opdrachten/7bb060ea-b70e-4200-9fdb-efd9e7eac5e0?tab=SEARCH

before:
![image](https://user-images.githubusercontent.com/1710840/217840242-23868640-9cd7-4c06-885c-58bb7df7aa9c.png)

after:
![image](https://user-images.githubusercontent.com/1710840/217839988-6f3773ea-6317-4ff7-ad58-05bcf373ab20.png)
![image](https://user-images.githubusercontent.com/1710840/217840053-030a19af-160d-4499-a4b4-421b5b5f031b.png)
![image](https://user-images.githubusercontent.com/1710840/217840177-f736d489-859b-4d22-9c3b-f89b77e63f2c.png)

