### PR TITLE
fix(avo-2433): bump avo2-components to include fix for pagination icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@react-hook/resize-observer": "^1.2.6",
         "@storybook/addon-actions": "^6.5.12",
         "@tanstack/react-query": "^4.14.1",
-        "@viaa/avo2-components": "^3.5.2",
+        "@viaa/avo2-components": "^3.5.3",
         "@viaa/avo2-types": "2.46.7",
         "braft-editor": "^2.3.9",
         "capture-stack-trace": "^1.0.1",
@@ -6649,9 +6649,9 @@
       }
     },
     "node_modules/@viaa/avo2-components": {
-      "version": "3.5.2",
-      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-components/-/avo2-components-3.5.2.tgz",
-      "integrity": "sha512-HNmaMEJ8Wx0FXb5/kTMHuajHbm8ldHhNGIwnV4BhbEf3FIElfFHShHBskpwsItAGMl8yFhcVTgZ1NiOFfBygjQ==",
+      "version": "3.5.3",
+      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-components/-/avo2-components-3.5.3.tgz",
+      "integrity": "sha512-G/EwqDW+a0Yj3mmqrVJryZx4/oozLZk9RBZ37jgf1hT4xQW1KFCVp4c4XX3biIm+JK576jYUxTuIIFJAiVlu5Q==",
       "dependencies": {
         "autosize": "^4.0.2",
         "caniuse-lite": "^1.0.30001340",
@@ -29290,9 +29290,9 @@
       }
     },
     "@viaa/avo2-components": {
-      "version": "3.5.2",
-      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-components/-/avo2-components-3.5.2.tgz",
-      "integrity": "sha512-HNmaMEJ8Wx0FXb5/kTMHuajHbm8ldHhNGIwnV4BhbEf3FIElfFHShHBskpwsItAGMl8yFhcVTgZ1NiOFfBygjQ==",
+      "version": "3.5.3",
+      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-components/-/avo2-components-3.5.3.tgz",
+      "integrity": "sha512-G/EwqDW+a0Yj3mmqrVJryZx4/oozLZk9RBZ37jgf1hT4xQW1KFCVp4c4XX3biIm+JK576jYUxTuIIFJAiVlu5Q==",
       "requires": {
         "autosize": "^4.0.2",
         "caniuse-lite": "^1.0.30001340",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@react-hook/resize-observer": "^1.2.6",
     "@storybook/addon-actions": "^6.5.12",
     "@tanstack/react-query": "^4.14.1",
-    "@viaa/avo2-components": "^3.5.2",
+    "@viaa/avo2-components": "^3.5.3",
     "@viaa/avo2-types": "2.46.7",
     "braft-editor": "^2.3.9",
     "capture-stack-trace": "^1.0.1",


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2433

bumps version of the avo2-components to include pagination icons fix:
https://github.com/viaacode/avo2-components/commit/a16f32b1fd2250a19c3074dcd47f9f21c9ef0d7e

before:
![image](https://user-images.githubusercontent.com/1710840/218108757-3fdf1147-16e5-4ee4-a8df-c7abd798c6c4.png)

after:
![image](https://user-images.githubusercontent.com/1710840/218108668-7011790b-d229-4706-8910-bfb52564e85c.png)
![image](https://user-images.githubusercontent.com/1710840/218108682-7bcb0965-0615-49ad-a00c-df55eb3f5b28.png)
