### PR TITLE
fix(avo-2242): Add can publish permission to permissions object in or…

### DIFF
--- a/src/collection/components/CollectionOrBundleEdit.tsx
+++ b/src/collection/components/CollectionOrBundleEdit.tsx
@@ -400,6 +400,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 				canDelete: rawPermissions[1],
 				canCreate: rawPermissions[2],
 				canViewItems: rawPermissions[3],
+				canPublish: rawPermissions[4],
 			};
 
 			if (!permissionObj.canEdit) {


### PR DESCRIPTION
Add extra can publish permission to permissions object on Collection  and bundle edit in order to check it and show the publish button accordingly.

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/113341869/218697169-b960ad5e-3283-48b9-a0f8-45004171cae9.png">