### PR TITLE
fix(avo-2247): Adjust if statement in order for items without a descr…

### DIFF
--- a/src/shared/components/BlockList/blocks/CollectionFragmentTypeItem.tsx
+++ b/src/shared/components/BlockList/blocks/CollectionFragmentTypeItem.tsx
@@ -96,7 +96,7 @@ const CollectionFragmentTypeItem: FC<CollectionFragmentTypeItemProps> = ({
 					<CollapsibleColumn>
 						{meta && <BlockItemMetadata {...meta} block={block} />}
 
-						{custom ? customDescription : originalDescription}
+						{custom ? customDescription : custom === false ? originalDescription : null}
 					</CollapsibleColumn>
 
 					{custom && canOpenOriginal && (


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2247

Adjust if statement in order for items without a description to not trigger a text with timestamp render

page: http://localhost:8080/werkruimte/opdrachten/5e716c08-88b9-4132-9640-dd80560f6fb7/bewerk

before : 
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/113341869/218746868-212ca8e8-f2ff-4170-ba44-b2d6038e8d4f.png">

after : 
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/113341869/218746965-367b08e0-3dbb-4a48-ab34-e43b17d1ded7.png">
