### PR TITLE
fix(avo-2441): show error toast when creating marcom entries fails

### DIFF
--- a/src/shared/services/data-service.ts
+++ b/src/shared/services/data-service.ts
@@ -31,9 +31,9 @@ export const fetchData = <TData, TVariables>(
 
 		const json = await res.json();
 
-		if (json.errors) {
-			const { message } = json.errors[0] || {};
-			throw new Error(message || 'Error');
+		if (json?.errors || res.status >= 400) {
+			const { message } = json?.errors?.[0] || {};
+			throw new Error(message || res.statusText || 'Error');
 		}
 
 		return json.data;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2441

when adding a marcom entry to this specific bundle, something fails in the backend, but the frontend ignored this and showed a success toast.

https://onderwijs-qas.hetarchief.be/bundels/c6e7a794-0c32-43c3-acc0-eeed4d34ab2b/bewerk/marcom

A failed message should be shown instead.


before:
![image](https://user-images.githubusercontent.com/1710840/225561956-9aecc655-6316-4eb4-a4cf-ad996efb3dc3.png)

after:
![image](https://user-images.githubusercontent.com/1710840/225562108-cb6ba7f9-0dcb-45a4-ae09-313d2f5010cc.png)
