### PR TITLE
fix(avo-2441): delete collection also from bundles

### DIFF
--- a/src/bundle/views/BundleDetail.tsx
+++ b/src/bundle/views/BundleDetail.tsx
@@ -338,7 +338,7 @@ const BundleDetail: FunctionComponent<
 	const onDeleteBundle = async () => {
 		try {
 			setIsDeleteModalOpen(false);
-			await CollectionService.deleteCollection(bundleId);
+			await CollectionService.deleteCollectionOrBundle(bundleId);
 
 			trackEvents(
 				{

--- a/src/collection/collection.service.ts
+++ b/src/collection/collection.service.ts
@@ -9,14 +9,14 @@ import { getProfileId } from '../authentication/helpers/get-profile-id';
 import { PermissionService } from '../authentication/helpers/permission-service';
 import {
 	App_Collection_Marcom_Log_Insert_Input,
-	DeleteCollectionBookmarksDocument,
-	DeleteCollectionBookmarksMutation,
-	DeleteCollectionBookmarksMutationVariables,
 	DeleteCollectionFragmentByIdDocument,
 	DeleteCollectionFragmentByIdMutation,
 	DeleteCollectionLabelsDocument,
 	DeleteCollectionLabelsMutation,
 	DeleteCollectionLabelsMutationVariables,
+	DeleteCollectionOrBundleByUuidDocument,
+	DeleteCollectionOrBundleByUuidMutation,
+	DeleteCollectionOrBundleByUuidMutationVariables,
 	DeleteMarcomEntriesByParentCollectionIdDocument,
 	DeleteMarcomEntriesByParentCollectionIdMutation,
 	DeleteMarcomEntriesByParentCollectionIdMutationVariables,
@@ -78,9 +78,6 @@ import {
 	InsertMarcomNoteMutationVariables,
 	Lookup_Enum_Collection_Management_Qc_Label_Enum,
 	Lookup_Enum_Relation_Types_Enum,
-	SoftDeleteCollectionByIdDocument,
-	SoftDeleteCollectionByIdMutation,
-	SoftDeleteCollectionByIdMutationVariables,
 	UpdateCollectionByIdDocument,
 	UpdateCollectionByIdMutation,
 	UpdateCollectionByIdMutationVariables,
@@ -642,30 +639,27 @@ export class CollectionService {
 	};
 
 	/**
-	 * Delete collection by id.
+	 * Delete collection or bundle by its uuid and also deletes bookmarks,
+	 * and corresponding fragments from bundels in case of collection delete
 	 *
-	 * @param collectionId Unique identifier of the collection.
+	 * @param collectionOrBundleUuid Unique identifier of the collection.
 	 */
-	static deleteCollection = async (collectionId: string): Promise<void> => {
+	static deleteCollectionOrBundle = async (collectionOrBundleUuid: string): Promise<void> => {
 		try {
 			// delete collection by id
+			const variables: DeleteCollectionOrBundleByUuidMutationVariables = {
+				collectionOrBundleUuid: collectionOrBundleUuid,
+				collectionOrBundleUuidAsText: collectionOrBundleUuid,
+			};
 			await Promise.all([
-				dataService.query<SoftDeleteCollectionByIdMutation>({
-					query: SoftDeleteCollectionByIdDocument,
-					variables: {
-						id: collectionId,
-					} as SoftDeleteCollectionByIdMutationVariables,
-				}),
-				dataService.query<DeleteCollectionBookmarksMutation>({
-					query: DeleteCollectionBookmarksDocument,
-					variables: {
-						id: collectionId,
-					} as DeleteCollectionBookmarksMutationVariables,
+				dataService.query<DeleteCollectionOrBundleByUuidMutation>({
+					query: DeleteCollectionOrBundleByUuidDocument,
+					variables,
 				}),
 			]);
 		} catch (err) {
 			throw new CustomError(`Failed to delete collection or bundle'}`, err, {
-				collectionId,
+				collectionId: collectionOrBundleUuid,
 			});
 		}
 	};

--- a/src/collection/components/CollectionOrBundleEdit.tsx
+++ b/src/collection/components/CollectionOrBundleEdit.tsx
@@ -777,7 +777,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 				);
 				return;
 			}
-			await CollectionService.deleteCollection(collectionState.currentCollection.id);
+			await CollectionService.deleteCollectionOrBundle(collectionState.currentCollection.id);
 
 			trackEvents(
 				{

--- a/src/collection/components/CollectionOrBundleOverview.tsx
+++ b/src/collection/components/CollectionOrBundleOverview.tsx
@@ -36,7 +36,7 @@ import QuickLaneModal from '../../shared/components/QuickLaneModal/QuickLaneModa
 import { getMoreOptionsLabel } from '../../shared/constants';
 import {
 	Lookup_Enum_Assignment_Content_Labels_Enum,
-	useSoftDeleteCollectionByIdMutation,
+	useDeleteCollectionOrBundleByUuidMutation,
 } from '../../shared/generated/graphql-db-types';
 import {
 	buildLink,
@@ -96,7 +96,8 @@ const CollectionOrBundleOverview: FunctionComponent<CollectionOrBundleOverviewPr
 	const [page, setPage] = useState<number>(0);
 
 	// Mutations
-	const { mutateAsync: triggerCollectionDelete } = useSoftDeleteCollectionByIdMutation();
+	const { mutateAsync: triggerCollectionOrBundleDelete } =
+		useDeleteCollectionOrBundleByUuidMutation();
 
 	// Listeners
 	const onClickDelete = (collectionUuid: string) => {
@@ -257,9 +258,10 @@ const CollectionOrBundleOverview: FunctionComponent<CollectionOrBundleOverviewPr
 				);
 				return;
 			}
-			await triggerCollectionDelete(
+			await triggerCollectionOrBundleDelete(
 				{
-					id: selectedCollectionUuid,
+					collectionOrBundleUuid: selectedCollectionUuid,
+					collectionOrBundleUuidAsText: selectedCollectionUuid,
 				},
 				{
 					onSuccess: async () => {

--- a/src/collection/queries/delete-collection-or-bundle-by-uuid.graphql
+++ b/src/collection/queries/delete-collection-or-bundle-by-uuid.graphql
@@ -1,0 +1,19 @@
+mutation deleteCollectionOrBundleByUuid(
+	$collectionOrBundleUuid: uuid!
+	$collectionOrBundleUuidAsText: String!
+) {
+	update_app_collections(
+		where: { id: { _eq: $collectionOrBundleUuid } }
+		_set: { is_deleted: true }
+	) {
+		affected_rows
+	}
+	delete_app_collection_fragments(
+		where: { type: { _eq: "COLLECTION" }, external_id: { _eq: $collectionOrBundleUuidAsText } }
+	) {
+		affected_rows
+	}
+	delete_app_collection_bookmarks(where: { collection_uuid: { _eq: $collectionOrBundleUuid } }) {
+		affected_rows
+	}
+}

--- a/src/collection/queries/soft-delete-collection-by-id.graphql
+++ b/src/collection/queries/soft-delete-collection-by-id.graphql
@@ -1,5 +1,0 @@
-mutation softDeleteCollectionById($id: uuid!) {
-	update_app_collections(where: { id: { _eq: $id } }, _set: { is_deleted: true }) {
-		affected_rows
-	}
-}

--- a/src/collection/views/CollectionDetail.tsx
+++ b/src/collection/views/CollectionDetail.tsx
@@ -621,7 +621,7 @@ const CollectionDetail: FunctionComponent<
 
 	const onDeleteCollection = async (): Promise<void> => {
 		try {
-			await CollectionService.deleteCollection(collectionId);
+			await CollectionService.deleteCollectionOrBundle(collectionId);
 
 			trackEvents(
 				{

--- a/src/shared/generated/graphql-db-types.ts
+++ b/src/shared/generated/graphql-db-types.ts
@@ -43426,6 +43426,14 @@ export type DeleteCollectionLabelsMutationVariables = Exact<{
 
 export type DeleteCollectionLabelsMutation = { __typename?: 'mutation_root', delete_app_collection_labels?: { __typename?: 'app_collection_labels_mutation_response', affected_rows: number } | null };
 
+export type DeleteCollectionOrBundleByUuidMutationVariables = Exact<{
+  collectionOrBundleUuid: Scalars['uuid'];
+  collectionOrBundleUuidAsText: Scalars['String'];
+}>;
+
+
+export type DeleteCollectionOrBundleByUuidMutation = { __typename?: 'mutation_root', update_app_collections?: { __typename?: 'app_collections_mutation_response', affected_rows: number } | null, delete_app_collection_fragments?: { __typename?: 'app_collection_fragments_mutation_response', affected_rows: number } | null, delete_app_collection_bookmarks?: { __typename?: 'app_collection_bookmarks_mutation_response', affected_rows: number } | null };
+
 export type DeleteMarcomEntriesByParentCollectionIdMutationVariables = Exact<{
   parentCollectionId?: InputMaybe<Scalars['uuid']>;
   channelName?: InputMaybe<Scalars['String']>;
@@ -43611,13 +43619,6 @@ export type InsertMarcomNoteMutationVariables = Exact<{
 
 
 export type InsertMarcomNoteMutation = { __typename?: 'mutation_root', insert_app_collection_marcom_notes?: { __typename?: 'app_collection_marcom_notes_mutation_response', returning: Array<{ __typename?: 'app_collection_marcom_notes', id: number }> } | null };
-
-export type SoftDeleteCollectionByIdMutationVariables = Exact<{
-  id: Scalars['uuid'];
-}>;
-
-
-export type SoftDeleteCollectionByIdMutation = { __typename?: 'mutation_root', update_app_collections?: { __typename?: 'app_collections_mutation_response', affected_rows: number } | null };
 
 export type UpdateCollectionByIdMutationVariables = Exact<{
   id: Scalars['uuid'];
@@ -43853,13 +43854,6 @@ export type DeleteCollectionBookmarksForUserMutationVariables = Exact<{
 
 
 export type DeleteCollectionBookmarksForUserMutation = { __typename?: 'mutation_root', delete_app_collection_bookmarks?: { __typename?: 'app_collection_bookmarks_mutation_response', affected_rows: number } | null };
-
-export type DeleteCollectionBookmarksMutationVariables = Exact<{
-  id: Scalars['uuid'];
-}>;
-
-
-export type DeleteCollectionBookmarksMutation = { __typename?: 'mutation_root', delete_app_collection_bookmarks?: { __typename?: 'app_collection_bookmarks_mutation_response', affected_rows: number } | null };
 
 export type DeleteItemBookmarkMutationVariables = Exact<{
   itemUuid: Scalars['uuid'];
@@ -46511,6 +46505,35 @@ export const useDeleteCollectionLabelsMutation = <
       (variables?: DeleteCollectionLabelsMutationVariables) => fetchData<DeleteCollectionLabelsMutation, DeleteCollectionLabelsMutationVariables>(DeleteCollectionLabelsDocument, variables)(),
       options
     );
+export const DeleteCollectionOrBundleByUuidDocument = `
+    mutation deleteCollectionOrBundleByUuid($collectionOrBundleUuid: uuid!, $collectionOrBundleUuidAsText: String!) {
+  update_app_collections(
+    where: {id: {_eq: $collectionOrBundleUuid}}
+    _set: {is_deleted: true}
+  ) {
+    affected_rows
+  }
+  delete_app_collection_fragments(
+    where: {type: {_eq: "COLLECTION"}, external_id: {_eq: $collectionOrBundleUuidAsText}}
+  ) {
+    affected_rows
+  }
+  delete_app_collection_bookmarks(
+    where: {collection_uuid: {_eq: $collectionOrBundleUuid}}
+  ) {
+    affected_rows
+  }
+}
+    `;
+export const useDeleteCollectionOrBundleByUuidMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<DeleteCollectionOrBundleByUuidMutation, TError, DeleteCollectionOrBundleByUuidMutationVariables, TContext>) =>
+    useMutation<DeleteCollectionOrBundleByUuidMutation, TError, DeleteCollectionOrBundleByUuidMutationVariables, TContext>(
+      ['deleteCollectionOrBundleByUuid'],
+      (variables?: DeleteCollectionOrBundleByUuidMutationVariables) => fetchData<DeleteCollectionOrBundleByUuidMutation, DeleteCollectionOrBundleByUuidMutationVariables>(DeleteCollectionOrBundleByUuidDocument, variables)(),
+      options
+    );
 export const DeleteMarcomEntriesByParentCollectionIdDocument = `
     mutation deleteMarcomEntriesByParentCollectionId($parentCollectionId: uuid, $channelName: String, $channelType: String, $publishDateGte: timestamptz, $publishDateLte: timestamptz) {
   delete_app_collection_marcom_log(
@@ -47113,22 +47136,6 @@ export const useInsertMarcomNoteMutation = <
     useMutation<InsertMarcomNoteMutation, TError, InsertMarcomNoteMutationVariables, TContext>(
       ['insertMarcomNote'],
       (variables?: InsertMarcomNoteMutationVariables) => fetchData<InsertMarcomNoteMutation, InsertMarcomNoteMutationVariables>(InsertMarcomNoteDocument, variables)(),
-      options
-    );
-export const SoftDeleteCollectionByIdDocument = `
-    mutation softDeleteCollectionById($id: uuid!) {
-  update_app_collections(where: {id: {_eq: $id}}, _set: {is_deleted: true}) {
-    affected_rows
-  }
-}
-    `;
-export const useSoftDeleteCollectionByIdMutation = <
-      TError = unknown,
-      TContext = unknown
-    >(options?: UseMutationOptions<SoftDeleteCollectionByIdMutation, TError, SoftDeleteCollectionByIdMutationVariables, TContext>) =>
-    useMutation<SoftDeleteCollectionByIdMutation, TError, SoftDeleteCollectionByIdMutationVariables, TContext>(
-      ['softDeleteCollectionById'],
-      (variables?: SoftDeleteCollectionByIdMutationVariables) => fetchData<SoftDeleteCollectionByIdMutation, SoftDeleteCollectionByIdMutationVariables>(SoftDeleteCollectionByIdDocument, variables)(),
       options
     );
 export const UpdateCollectionByIdDocument = `
@@ -47895,22 +47902,6 @@ export const useDeleteCollectionBookmarksForUserMutation = <
     useMutation<DeleteCollectionBookmarksForUserMutation, TError, DeleteCollectionBookmarksForUserMutationVariables, TContext>(
       ['deleteCollectionBookmarksForUser'],
       (variables?: DeleteCollectionBookmarksForUserMutationVariables) => fetchData<DeleteCollectionBookmarksForUserMutation, DeleteCollectionBookmarksForUserMutationVariables>(DeleteCollectionBookmarksForUserDocument, variables)(),
-      options
-    );
-export const DeleteCollectionBookmarksDocument = `
-    mutation deleteCollectionBookmarks($id: uuid!) {
-  delete_app_collection_bookmarks(where: {collection_uuid: {_eq: $id}}) {
-    affected_rows
-  }
-}
-    `;
-export const useDeleteCollectionBookmarksMutation = <
-      TError = unknown,
-      TContext = unknown
-    >(options?: UseMutationOptions<DeleteCollectionBookmarksMutation, TError, DeleteCollectionBookmarksMutationVariables, TContext>) =>
-    useMutation<DeleteCollectionBookmarksMutation, TError, DeleteCollectionBookmarksMutationVariables, TContext>(
-      ['deleteCollectionBookmarks'],
-      (variables?: DeleteCollectionBookmarksMutationVariables) => fetchData<DeleteCollectionBookmarksMutation, DeleteCollectionBookmarksMutationVariables>(DeleteCollectionBookmarksDocument, variables)(),
       options
     );
 export const DeleteItemBookmarkDocument = `

--- a/src/shared/services/bookmarks-views-plays-service/queries/delete-collection-bookmarks.graphql
+++ b/src/shared/services/bookmarks-views-plays-service/queries/delete-collection-bookmarks.graphql
@@ -1,5 +1,0 @@
-mutation deleteCollectionBookmarks($id: uuid!) {
-	delete_app_collection_bookmarks(where: { collection_uuid: { _eq: $id } }) {
-		affected_rows
-	}
-}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2441

requires proxy PR: https://github.com/viaacode/avo2-proxy/pull/597

When you add a collection to a bundle:
![image](https://user-images.githubusercontent.com/1710840/225579725-e72addbd-ba0e-4d13-bf25-763bc00b5c80.png)

and then you delete the collection.

before: the collection is not correctly removed from the bundle:
![image](https://user-images.githubusercontent.com/1710840/225579794-e4a4b5ed-26c5-4d24-a71f-4d47fadeb4d4.png)


after: the collection is correctly removed from the bundle:
![image](https://user-images.githubusercontent.com/1710840/225579982-c13b0b30-36c9-4f53-991c-415cf234592f.png)

