### PR TITLE
fix(avo-2450): show hide zendesk widget using css only

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ wrapHistory(history, {
 const App: FunctionComponent<RouteComponentProps & UserProps> = (props) => {
 	const { tHtml } = useTranslation();
 	const isAdminRoute = new RegExp(`^/${ROUTE_PARTS.admin}`, 'g').test(props.location.pathname);
+	const isPupilUser = String(props?.user?.profile?.userGroupIds?.[0]) === SpecialUserGroup.Pupil;
 
 	const [loadingInfo, setLoadingInfo] = useState<LoadingInfo>({ state: 'loading' });
 
@@ -67,12 +68,12 @@ const App: FunctionComponent<RouteComponentProps & UserProps> = (props) => {
 
 	useEffect(() => {
 		// Hide zendesk when a pupil is logged in
-		if (String(props?.user?.profile?.userGroupIds?.[0]) === SpecialUserGroup.Pupil) {
+		if (isPupilUser || isAdminRoute) {
 			document.body.classList.add('hide-zendesk-widget');
 		} else {
 			document.body.classList.remove('hide-zendesk-widget');
 		}
-	}, [props.user]);
+	}, [isPupilUser, isAdminRoute]);
 
 	useEffect(() => {
 		if (loadingInfo.state === 'loaded') {
@@ -113,10 +114,10 @@ const App: FunctionComponent<RouteComponentProps & UserProps> = (props) => {
 						{!isLoginRoute && <Navigation {...props} />}
 						{renderRoutes()}
 						{!isLoginRoute && <Footer {...props} />}
-						<ZendeskWrapper />
 						<ACMIDMNudgeModal />
 					</>
 				)}
+				<ZendeskWrapper />
 			</div>
 		);
 	};

--- a/src/admin/Admin.tsx
+++ b/src/admin/Admin.tsx
@@ -48,12 +48,6 @@ const Admin: FunctionComponent<{ user: Avo.User.User }> = ({ user }) => {
 				actionButtons: ['home', 'helpdesk'],
 			});
 		}
-
-		// Remove zendesk when loading beheer after visiting the client side of the app
-		const zendeskWidget = document.querySelector('iframe#launcher');
-		if (zendeskWidget) {
-			zendeskWidget.remove();
-		}
 	}, [user, setLoadingInfo, tText]);
 
 	useEffect(() => {
@@ -61,13 +55,6 @@ const Admin: FunctionComponent<{ user: Avo.User.User }> = ({ user }) => {
 			setLoadingInfo({ state: 'loaded' });
 		}
 	}, [userPermissions, navigationItems, setLoadingInfo]);
-
-	useEffect(() => {
-		const widget = document.querySelector('iframe#launcher');
-		if (widget) {
-			widget.remove();
-		}
-	}, []);
 
 	const renderAdminPage = () => {
 		if (!navigationItems || !userPermissions) {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2450

pupil should not see the widget:
![image](https://user-images.githubusercontent.com/1710840/225932811-58263a29-f1f9-4b1f-b174-e516dad0c43e.png)

other users should see the widget:
![image](https://user-images.githubusercontent.com/1710840/225932955-959ef685-7c64-4519-9471-bbb9c71ae732.png)

except on the admin dashboard screens:
![image](https://user-images.githubusercontent.com/1710840/225933085-7218a477-d9c2-4abd-bc30-34be5cb561ab.png)

