### PR TITLE
fix(avo-2323): Fix faulty character count on bundle long description …

### DIFF
--- a/src/collection/collection.helpers.tsx
+++ b/src/collection/collection.helpers.tsx
@@ -71,7 +71,7 @@ const GET_VALIDATION_RULES_FOR_SAVE: () => ValidationRule<
 				: tText('collection/collection___de-lange-beschrijving-van-deze-bundel-is-te-lang'),
 		isValid: (collection: Partial<Avo.Collection.Collection>) =>
 			!(collection as any).description_long ||
-			(collection as any).description_long.length <= MAX_LONG_DESCRIPTION_LENGTH,
+			stripHtml((collection as any).description_long).length <= MAX_LONG_DESCRIPTION_LENGTH,
 	},
 ];
 


### PR DESCRIPTION
[AVO-2323](https://meemoo.atlassian.net/browse/AVO-2323)

Fix:
Fix faulty character count on bundle long description on save by stripping html in validation check before save.

[AVO-2323]: https://meemoo.atlassian.net/browse/AVO-2323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ