### PR TITLE
fix(avo2145): Add max date containing the end of the current academic…

### DIFF
--- a/src/assignment/components/AssignmentDetailsFormEditable.tsx
+++ b/src/assignment/components/AssignmentDetailsFormEditable.tsx
@@ -22,6 +22,7 @@ import {
 	Assignment_v2_With_Labels,
 	AssignmentFormState,
 } from '../assignment.types';
+import { endOfAcademicYear } from '../helpers/academic-year';
 import { isDeadlineBeforeAvailableAt } from '../helpers/is-deadline-before-available-at';
 import { mergeWithOtherLabels } from '../helpers/merge-with-other-labels';
 
@@ -166,6 +167,7 @@ const AssignmentDetailsFormEditable: FC<
 						value={availableAt}
 						showTimeInput
 						minDate={new Date()}
+						maxDate={endOfAcademicYear()}
 						onChange={(value: Date | null) => {
 							setValue('available_at', value?.toISOString(), {
 								shouldDirty: true,
@@ -188,6 +190,7 @@ const AssignmentDetailsFormEditable: FC<
 						value={deadline}
 						showTimeInput
 						minDate={new Date()}
+						maxDate={endOfAcademicYear()}
 						onChange={(value) => {
 							setValue('deadline_at', value?.toISOString(), {
 								shouldDirty: true,


### PR DESCRIPTION
[Page](http://localhost:8080/werkruimte/opdrachten/5e716c08-88b9-4132-9640-dd80560f6fb7/bewerk)

[Ticket](https://meemoo.atlassian.net/browse/AVO-2145)

Fix: Add max date containing the end of the current academic year to datepickers & add extra line to translation of text below datepickers.

<img width="562" alt="image" src="https://user-images.githubusercontent.com/113341869/232735441-4cf87c8b-c34d-44d1-ac16-c9cf13035502.png">
