### PR TITLE
fix(avo-2672): remove briefings form group and add permission to edit assignment quality labels

### DIFF
--- a/src/assignment/components/AssignmentAdminFormEditable.tsx
+++ b/src/assignment/components/AssignmentAdminFormEditable.tsx
@@ -7,7 +7,6 @@ import {
 	Spacer,
 	TagInfo,
 	TagsInput,
-	TextArea,
 	TextInput,
 } from '@viaa/avo2-components';
 import { Avo, PermissionName } from '@viaa/avo2-types';
@@ -130,32 +129,6 @@ const AssignmentAdminFormEditable: FC<AssignmentAdminFormEditableProps & UserPro
 									<TextInput
 										disabled
 										value={formatTimestamp(assignment.updated_at) || '-'}
-									/>
-								</FormGroup>
-
-								<FormGroup
-									label={tText(
-										'assignment/components/assignment-admin-form-editable___briefings'
-									)}
-								>
-									<TextArea
-										height="auto"
-										value={assignment.briefing_id || undefined}
-										onChange={(value: string) => {
-											{
-												(setValue as any)('briefing_id', value, {
-													shouldDirty: true,
-													shouldTouch: true,
-												});
-												setAssignment((prev) => ({
-													...prev,
-													briefing_id: value,
-													blocks:
-														(prev as Avo.Assignment.Assignment)
-															?.blocks || [],
-												}));
-											}
-										}}
 									/>
 								</FormGroup>
 


### PR DESCRIPTION
[AVO-2672](https://meemoo.atlassian.net/browse/AVO-2672)

Added missing permission in Hasura

Before: 
![image](https://github.com/viaacode/avo2-client/assets/113341869/df1428c3-81b0-45a8-8bcf-7d873d0b7756)

After:
![image](https://github.com/viaacode/avo2-client/assets/113341869/c35d8af7-a195-40cf-b4d6-2e156368a9b0)


[AVO-2672]: https://meemoo.atlassian.net/browse/AVO-2672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ