### PR TITLE
fix(avo-2620): Move render header function in orde to display filter in every situation

### DIFF
--- a/src/collection/components/CollectionOrBundleOverview.tsx
+++ b/src/collection/components/CollectionOrBundleOverview.tsx
@@ -735,12 +735,16 @@ const CollectionOrBundleOverview: FunctionComponent<CollectionOrBundleOverviewPr
 				sortable: true,
 				dataType: TableColumnDataType.dateTime,
 			},
-			{
-				id: 'share_type',
-				label: tText('collection/collection___gedeeld'),
-				sortable: true,
-				dataType: TableColumnDataType.string,
-			},
+			...(isCollection
+				? [
+						{
+							id: 'share_type',
+							label: tText('collection/collection___gedeeld'),
+							sortable: true,
+							dataType: TableColumnDataType.string,
+						},
+				  ]
+				: []),
 			...(showPublicState
 				? [
 						{
@@ -967,7 +971,7 @@ const CollectionOrBundleOverview: FunctionComponent<CollectionOrBundleOverviewPr
 
 	const renderCollections = () => (
 		<>
-			{renderHeader()}
+			{isCollection && renderHeader()}
 			{collections && collections.length ? renderTable(collections) : renderEmptyFallback()}
 			{!isNil(selectedCollectionUuid) && renderDeleteModal()}
 			{renderQuickLaneModal()}

--- a/src/collection/components/CollectionOrBundleOverview.tsx
+++ b/src/collection/components/CollectionOrBundleOverview.tsx
@@ -831,7 +831,6 @@ const CollectionOrBundleOverview: FunctionComponent<CollectionOrBundleOverviewPr
 
 	const renderTable = (collections: Collection[]) => (
 		<>
-			{renderHeader()}
 			<Table
 				columns={getColumns()}
 				data={collections}
@@ -968,6 +967,7 @@ const CollectionOrBundleOverview: FunctionComponent<CollectionOrBundleOverviewPr
 
 	const renderCollections = () => (
 		<>
+			{renderHeader()}
 			{collections && collections.length ? renderTable(collections) : renderEmptyFallback()}
 			{!isNil(selectedCollectionUuid) && renderDeleteModal()}
 			{renderQuickLaneModal()}


### PR DESCRIPTION
AVO-[2620](https://meemoo.atlassian.net/browse/AVO-2620)

Before: 
![image](https://github.com/viaacode/avo2-client/assets/113341869/c216a45b-d92f-4872-ae6d-c46654aabbe9)

After:
![image](https://github.com/viaacode/avo2-client/assets/113341869/00d36da2-8456-459c-92f7-356814827354)
