### PR TITLE
fix(avo-2608): Add spacing between contributors and previous word

### DIFF
--- a/src/shared/components/HeaderOwnerAndContributors/HeaderOwnerAndContributors.tsx
+++ b/src/shared/components/HeaderOwnerAndContributors/HeaderOwnerAndContributors.tsx
@@ -36,7 +36,7 @@ export const HeaderOwnerAndContributors: FC<HeaderOwnerAndContributorsProps> = (
 				<Tooltip position="right">
 					<TooltipTrigger>
 						<p>
-							en
+							{' en '}
 							<span className="c-contributors">
 								{tHtml(
 									'shared/components/header-owner-and-contributors/header-owner-and-contributors___count-anderen',
@@ -80,12 +80,13 @@ export const HeaderOwnerAndContributors: FC<HeaderOwnerAndContributorsProps> = (
 							<>
 								{tHtml(
 									'shared/components/header-owner-and-contributors/header-owner-and-contributors___ik'
-								)}{' '}
+								)}
 								{renderContributors()}
 							</>
 						) : (
 							<>
-								{getFullName(owner, false, false)} {renderContributors()}
+								{getFullName(owner, false, false)}
+								{renderContributors()}
 							</>
 						)}
 					</p>


### PR DESCRIPTION
[AVO-2608](https://meemoo.atlassian.net/browse/AVO-2608)

Before:
<img width="267" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/531fd349-e8e6-492d-a153-745c3a166d09">

After:
<img width="334" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/b48ba00d-342f-4eec-b62c-96ac73f01d22">


[AVO-2608]: https://meemoo.atlassian.net/browse/AVO-2608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ