### PR TITLE
fix(avo-2776): hide toast message if statuscode indicates no access

### DIFF
--- a/src/assignment/views/AssignmentEdit.tsx
+++ b/src/assignment/views/AssignmentEdit.tsx
@@ -340,25 +340,27 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps> = ({
 		try {
 			await AssignmentService.updateAssignmentEditor(assignmentId);
 		} catch (err) {
-			if ((err as CustomError)?.innerException?.additionalInfo.statusCode === 409) {
-				ToastService.danger(
-					tText(
-						'assignment/views/assignment-edit___iemand-is-deze-opdracht-reeds-aan-het-bewerken'
-					)
-				);
-			} else {
-				await releaseAssignmentEditStatus();
-				ToastService.danger(
-					tText(
-						'assignment/views/assignment-edit___verbinding-met-bewerk-server-verloren'
-					)
-				);
-			}
-
 			redirectToClientPage(
 				buildLink(APP_PATH.ASSIGNMENT_DETAIL.route, { id: assignmentId }),
 				history
 			);
+
+			if ((err as CustomError)?.innerException?.additionalInfo.statusCode === 409) {
+				ToastService.danger(
+					tHtml(
+						'assignment/views/assignment-edit___iemand-is-deze-opdracht-reeds-aan-het-bewerken'
+					)
+				);
+			} else if ((err as CustomError).innerException?.additionalInfo.statusCode === 401) {
+				return; // User has no rights to edit the assignment
+			} else {
+				await releaseAssignmentEditStatus();
+				ToastService.danger(
+					tHtml(
+						'assignment/views/assignment-edit___verbinding-met-bewerk-server-verloren'
+					)
+				);
+			}
 		}
 	};
 
@@ -368,7 +370,7 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps> = ({
 		} catch (err) {
 			if ((err as CustomError)?.innerException?.additionalInfo.statusCode !== 409) {
 				ToastService.danger(
-					tText(
+					tHtml(
 						'assignment/views/assignment-edit___er-liep-iets-fout-met-het-updaten-van-de-opdracht-bewerk-status'
 					)
 				);
@@ -393,7 +395,7 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps> = ({
 			);
 
 			ToastService.success(
-				tText(
+				tHtml(
 					'assignment/views/assignment-edit___je-was-meer-dan-15-minuten-inactief-je-aanpassingen-zijn-opgeslagen'
 				),
 				{
@@ -402,7 +404,7 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps> = ({
 			);
 		} catch (err) {
 			ToastService.danger(
-				tText(
+				tHtml(
 					'assignment/views/assignment-edit___je-was-meer-dan-15-minuten-inactief-het-opslaan-van-je-aanpassingen-is-mislukt'
 				),
 				{

--- a/src/collection/components/CollectionOrBundleEdit.tsx
+++ b/src/collection/components/CollectionOrBundleEdit.tsx
@@ -1056,13 +1056,15 @@ const CollectionOrBundleEdit: FunctionComponent<
 			if ((err as CustomError).innerException?.additionalInfo.statusCode === 409) {
 				await releaseCollectionEditStatus();
 				ToastService.danger(
-					tText(
+					tHtml(
 						'collection/components/collection-or-bundle-edit___iemand-is-deze-collectie-reeds-aan-het-bewerken'
 					)
 				);
+			} else if ((err as CustomError).innerException?.additionalInfo.statusCode === 401) {
+				return; // User has no rights to edit the collection
 			} else {
 				ToastService.danger(
-					tText(
+					tHtml(
 						'collection/components/collection-or-bundle-edit___verbinding-met-bewerk-server-verloren'
 					)
 				);
@@ -1076,7 +1078,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 		} catch (err) {
 			if ((err as CustomError)?.innerException?.additionalInfo.statusCode !== 409) {
 				ToastService.danger(
-					tText(
+					tHtml(
 						'collection/components/collection-or-bundle-edit___er-liep-iets-fout-met-het-updaten-van-de-collectie-bewerk-status'
 					)
 				);
@@ -1094,7 +1096,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 			await updateCollection();
 
 			ToastService.success(
-				tText(
+				tHtml(
 					'collection/components/collection-or-bundle-edit___je-was-meer-dan-15-minuten-inactief-je-aanpassingen-zijn-opgeslagen'
 				),
 				{
@@ -1103,7 +1105,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 			);
 		} catch (err) {
 			ToastService.danger(
-				tText(
+				tHtml(
 					'collection/components/collection-or-bundle-edit___je-was-meer-dan-15-minuten-inactief-het-opslaan-van-je-aanpassingen-is-mislukt'
 				),
 				{

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -20,9 +20,12 @@ export const ASSIGNMENT_OVERVIEW_BACK_BUTTON_FILTERS =
 export function getMoreOptionsLabel(): string {
 	return tText('shared/constants/index___meer-opties');
 }
+
 // Refetch interval of 15 seconds
 export const EDIT_STATUS_REFETCH_TIME = 15_000;
 // Initial time of 1 minute until warning modal pops up
-export const IDLE_TIME_UNTIL_WARNING = 60_000;
-// Max idle time of 14 minutes after warning modal pops up
-export const MAX_EDIT_IDLE_TIME = 840_000;
+export const IDLE_TIME_UNTIL_WARNING = 15_000;
+// export const IDLE_TIME_UNTIL_WARNING = 60_000;
+// Max idle time of 14 minutes after warning modal pops up (15 minutes total)
+export const MAX_EDIT_IDLE_TIME = 15_000;
+// export const MAX_EDIT_IDLE_TIME = 840_000;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2776

before:
![image](https://github.com/viaacode/avo2-client/assets/1710840/7f5a01d0-387a-4591-8eb6-f365980003bd)


after:
![image](https://github.com/viaacode/avo2-client/assets/1710840/a330a2ce-1310-4704-8c72-ebfec9c3107f)
