### PR TITLE
fix(avo-2771): ensure tabs and scrollbar don't go through options menu

### DIFF
--- a/src/assignment/components/AssignmentHeading.scss
+++ b/src/assignment/components/AssignmentHeading.scss
@@ -103,6 +103,8 @@
 	&__bottom {
 		overflow-x: auto;
 		overflow-y: hidden;
+		z-index: 0;
+		position: relative;
 
 		// Don't overwrite .o-container on wide screens
 		@media screen and (max-width: ($g-bp2 - 1px)) {

--- a/src/styles/components/_index.scss
+++ b/src/styles/components/_index.scss
@@ -33,7 +33,6 @@
 @import "./settings-table";
 @import "./stats";
 @import "./table-view";
-@import "./tabs";
 @import "./timestamp";
 @import "./title-overlay";
 @import "./toolbar";

--- a/src/styles/components/tabs.scss
+++ b/src/styles/components/tabs.scss
@@ -1,9 +1,0 @@
-.c-tabs {
-	max-width: 100%;
-	overflow-x: auto;
-	overflow-y: hidden;
-
-	@media screen and (max-width: $g-bp2) {
-		padding-bottom: 0.6rem;
-	}
-}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2771

before:
![image](https://github.com/viaacode/avo2-client/assets/1710840/defe8334-2e0a-4db3-a9f0-35bcdadc802f)


after:
![image](https://github.com/viaacode/avo2-client/assets/1710840/29c139e9-d61a-4d54-9e7d-1b0dd6f62a36)
