### PR TITLE
fix(avo-2787): up the z-index of assignment edit action bars

### DIFF
--- a/src/assignment/components/AssignmentHeading.scss
+++ b/src/assignment/components/AssignmentHeading.scss
@@ -6,7 +6,7 @@
 		display: grid;
 		grid-template-columns: auto auto auto auto;
 		padding-left: $g-spacer-unit * 2;
-		z-index: 1; // Ensure rich text does not overlap
+		z-index: $g-c-global-navbar-z; // Ensure rich text does not overlap
 
 		@media screen and (min-width: $g-bp2) {
 			gap: $g-spacer-unit;


### PR DESCRIPTION
[AVO-2787](https://meemoo.atlassian.net/browse/AVO-2787)

Before:
<img width="638" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/e5641423-9fb0-4750-b121-d8af75123a81">

After:
<img width="749" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/8fad826c-2672-4a60-b624-6590f863ab7f">


[AVO-2787]: https://meemoo.atlassian.net/browse/AVO-2787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ