### PR TITLE
fix(avo-2807): only load collection for pupil if quick link exists

### DIFF
--- a/src/collection/views/CollectionDetail.tsx
+++ b/src/collection/views/CollectionDetail.tsx
@@ -110,6 +110,9 @@ type CollectionDetailPermissions = Partial<{
 	canDeleteCollections: boolean;
 	canCreateCollections: boolean;
 	canViewAnyPublishedItems: boolean;
+	canViewAnyPublishedCollections: boolean;
+	canViewAnyUnpublishedCollections: boolean;
+	canViewQuickLanes: boolean;
 	canCreateQuickLane: boolean;
 	canAutoplayCollection: boolean;
 	canCreateAssignments: boolean;
@@ -335,7 +338,14 @@ const CollectionDetail: FunctionComponent<
 					{ name: PermissionName.DELETE_ANY_COLLECTIONS },
 				],
 				canViewAnyPublishedItems: [{ name: PermissionName.VIEW_ANY_PUBLISHED_ITEMS }],
+				canViewAnyPublishedCollections: [
+					{ name: PermissionName.VIEW_ANY_PUBLISHED_COLLECTIONS },
+				],
+				canViewAnyUnpublishedCollections: [
+					{ name: PermissionName.VIEW_ANY_UNPUBLISHED_COLLECTIONS },
+				],
 				canCreateQuickLane: [{ name: PermissionName.CREATE_QUICK_LANE }],
+				canViewQuickLanes: [{ name: PermissionName.VIEW_QUICK_LANE_DETAIL }],
 				canAutoplayCollection: [{ name: PermissionName.AUTOPLAY_COLLECTION }],
 				canCreateAssignments: [{ name: PermissionName.CREATE_ASSIGNMENTS }],
 				canCreateBundles: [{ name: PermissionName.CREATE_BUNDLES }],
@@ -381,6 +391,25 @@ const CollectionDetail: FunctionComponent<
 				setCollectionInfo({
 					showNoAccessPopup: false,
 					showLoginPopup: true,
+					permissions: permissionObj,
+					collection: null,
+				});
+				setLoadingInfo({
+					state: 'loaded',
+				});
+				return;
+			}
+
+			if (
+				!permissionObj.canViewAnyUnpublishedCollections &&
+				!permissionObj.canViewAnyPublishedCollections &&
+				(!permissionObj.canViewQuickLanes ||
+					(permissionObj.canViewQuickLanes &&
+						!window.location.href.includes(ROUTE_PARTS.quickLane)))
+			) {
+				setCollectionInfo({
+					showNoAccessPopup: true,
+					showLoginPopup: false,
 					permissions: permissionObj,
 					collection: null,
 				});

--- a/src/item/views/ItemDetail.tsx
+++ b/src/item/views/ItemDetail.tsx
@@ -216,7 +216,7 @@ const ItemDetail: FunctionComponent<ItemDetailProps & DefaultSecureRouteProps<{ 
 				if (String(user.profile?.userGroupIds[0]) === SpecialUserGroup.Pupil) {
 					setLoadingInfo({
 						state: 'error',
-						message: tText(
+						message: tHtml(
 							'item/views/item___je-hebt-geen-rechten-om-dit-item-te-bekijken-leerling'
 						),
 						icon: IconName.lock,
@@ -224,7 +224,7 @@ const ItemDetail: FunctionComponent<ItemDetailProps & DefaultSecureRouteProps<{ 
 				} else {
 					setLoadingInfo({
 						state: 'error',
-						message: tText(
+						message: tHtml(
 							'item/views/item___je-hebt-geen-rechten-om-dit-item-te-bekijken'
 						),
 						icon: IconName.lock,
@@ -237,7 +237,7 @@ const ItemDetail: FunctionComponent<ItemDetailProps & DefaultSecureRouteProps<{ 
 			if (!itemObj) {
 				setLoadingInfo({
 					state: 'error',
-					message: tText('item/views/item___dit-item-werd-niet-gevonden'),
+					message: tHtml('item/views/item___dit-item-werd-niet-gevonden'),
 					icon: IconName.search,
 				});
 				return;
@@ -303,7 +303,7 @@ const ItemDetail: FunctionComponent<ItemDetailProps & DefaultSecureRouteProps<{ 
 			);
 			setLoadingInfo({
 				state: 'error',
-				message: tText('item/views/item-detail___het-ophalen-van-het-item-is-mislukt'),
+				message: tHtml('item/views/item-detail___het-ophalen-van-het-item-is-mislukt'),
 			});
 		}
 	}, [itemId, setItem, tText, history, user]);


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2807

proxy PR: https://github.com/viaacode/avo2-proxy/pull/678


after:

collection link:
![image](https://github.com/viaacode/avo2-proxy/assets/1710840/247ee6c9-09b5-4c17-9550-e3554fe66448)



quick link:
![image](https://github.com/viaacode/avo2-proxy/assets/1710840/ff3cfbe5-de74-4445-9a55-884d1b0aceb6)



public assignment:
![image](https://github.com/viaacode/avo2-proxy/assets/1710840/e9f84640-78be-46f3-a416-97b6bfa86bbb)



private assignment:
![image](https://github.com/viaacode/avo2-proxy/assets/1710840/0853ffd1-7aa3-444b-874a-d269bd576b4e)
