### PR TITLE
fix(avo-2796): add publish and admin tab to assignment create page, adjust permissions for showing admin tab

### DIFF
--- a/src/assignment/hooks/assignment-teacher-tabs.tsx
+++ b/src/assignment/hooks/assignment-teacher-tabs.tsx
@@ -1,7 +1,9 @@
 import { IconName, TabProps } from '@viaa/avo2-components';
+import { Avo, PermissionName } from '@viaa/avo2-types';
 import * as H from 'history';
 import React, { useCallback, useMemo, useState } from 'react';
 
+import { PermissionService } from '../../authentication/helpers/permission-service';
 import { APP_PATH } from '../../constants';
 import { navigate } from '../../shared/helpers';
 import useTranslation from '../../shared/hooks/useTranslation';
@@ -9,7 +11,8 @@ import { ASSIGNMENT_CREATE_UPDATE_TABS } from '../assignment.const';
 
 export function useAssignmentTeacherTabs(
 	history: H.History<unknown>,
-	assignmentId: string
+	assignmentId: string,
+	user: Avo.User.User | undefined
 ): [
 	TabProps[],
 	ASSIGNMENT_CREATE_UPDATE_TABS | undefined,
@@ -21,6 +24,13 @@ export function useAssignmentTeacherTabs(
 	const [tab, setTab] = useState<ASSIGNMENT_CREATE_UPDATE_TABS>(
 		ASSIGNMENT_CREATE_UPDATE_TABS.CONTENT
 	);
+
+	const showAdminTab: boolean = PermissionService.hasAtLeastOnePerm(user, [
+		PermissionName.EDIT_ASSIGNMENT_LABELS,
+		PermissionName.EDIT_ASSIGNMENT_AUTHOR,
+		PermissionName.EDIT_ASSIGNMENT_EDITORIAL_STATUS,
+	]);
+
 	const tabs: TabProps[] = useMemo(
 		() =>
 			[
@@ -48,11 +58,15 @@ export function useAssignmentTeacherTabs(
 							},
 					  ]
 					: []),
-				{
-					id: ASSIGNMENT_CREATE_UPDATE_TABS.ADMIN,
-					label: tText('assignment/hooks/assignment-teacher-tabs___beheer'),
-					icon: IconName.settings as IconName,
-				},
+				...(showAdminTab
+					? [
+							{
+								id: ASSIGNMENT_CREATE_UPDATE_TABS.ADMIN,
+								label: tText('assignment/hooks/assignment-teacher-tabs___beheer'),
+								icon: IconName.settings as IconName,
+							},
+					  ]
+					: []),
 			].map((item) => ({
 				...item,
 				active: item.id === tab,

--- a/src/assignment/hooks/assignment-teacher-tabs.tsx
+++ b/src/assignment/hooks/assignment-teacher-tabs.tsx
@@ -11,8 +11,8 @@ import { ASSIGNMENT_CREATE_UPDATE_TABS } from '../assignment.const';
 
 export function useAssignmentTeacherTabs(
 	history: H.History<unknown>,
-	assignmentId: string,
-	user: Avo.User.User | undefined
+	user: Avo.User.User | undefined,
+	assignmentId?: string
 ): [
 	TabProps[],
 	ASSIGNMENT_CREATE_UPDATE_TABS | undefined,

--- a/src/assignment/views/AssignmentCreate.tsx
+++ b/src/assignment/views/AssignmentCreate.tsx
@@ -1,7 +1,15 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, Container, Icon, IconName, Spacer, Tabs } from '@viaa/avo2-components';
 import type { Avo } from '@viaa/avo2-types';
-import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+	Dispatch,
+	FunctionComponent,
+	SetStateAction,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from 'react';
 import { useForm } from 'react-hook-form';
 import MetaTags from 'react-meta-tags';
 import { Link } from 'react-router-dom';
@@ -21,8 +29,10 @@ import { ToastService } from '../../shared/services/toast-service';
 import { ASSIGNMENT_CREATE_UPDATE_TABS, ASSIGNMENT_FORM_SCHEMA } from '../assignment.const';
 import { AssignmentService } from '../assignment.service';
 import AssignmentActions from '../components/AssignmentActions';
+import AssignmentAdminFormEditable from '../components/AssignmentAdminFormEditable';
 import AssignmentDetailsFormEditable from '../components/AssignmentDetailsFormEditable';
 import AssignmentHeading from '../components/AssignmentHeading';
+import AssignmentMetaDataFormEditable from '../components/AssignmentMetaDataFormEditable';
 import AssignmentPupilPreview from '../components/AssignmentPupilPreview';
 import AssignmentTitle from '../components/AssignmentTitle';
 import { buildGlobalSearchLink } from '../helpers/build-search-link';
@@ -36,9 +46,10 @@ import {
 	useBlocksList,
 	useEditBlocks,
 } from '../hooks';
+import { AssignmentFields } from '../hooks/assignment-form';
+
 import './AssignmentCreate.scss';
 import './AssignmentPage.scss';
-import { AssignmentFields } from '../hooks/assignment-form';
 
 const AssignmentCreate: FunctionComponent<DefaultSecureRouteProps> = ({
 	user,
@@ -137,7 +148,11 @@ const AssignmentCreate: FunctionComponent<DefaultSecureRouteProps> = ({
 		when: isDirty,
 	});
 	const [loadingInfo, setLoadingInfo] = useState<LoadingInfo>({ state: 'loading' });
-	const [tabs, tab, , onTabClick] = useAssignmentTeacherTabs(history, assignment?.id as string);
+	const [tabs, tab, , onTabClick] = useAssignmentTeacherTabs(
+		history,
+		assignment?.id as string,
+		user
+	);
 	const [isViewAsPupilEnabled, setIsViewAsPupilEnabled] = useState<boolean>();
 
 	// Render
@@ -277,6 +292,30 @@ const AssignmentCreate: FunctionComponent<DefaultSecureRouteProps> = ({
 							setValue={setValue as any}
 						/>
 					</div>
+				);
+
+			case ASSIGNMENT_CREATE_UPDATE_TABS.PUBLISH:
+				return (
+					<div className="c-assignment-details-tab">
+						<AssignmentMetaDataFormEditable
+							assignment={assignment as Avo.Assignment.Assignment}
+							setAssignment={
+								setAssignment as Dispatch<SetStateAction<Avo.Assignment.Assignment>>
+							}
+							setValue={setValue as any}
+						/>
+					</div>
+				);
+
+			case ASSIGNMENT_CREATE_UPDATE_TABS.ADMIN:
+				return (
+					<AssignmentAdminFormEditable
+						assignment={assignment as Avo.Assignment.Assignment}
+						setAssignment={
+							setAssignment as Dispatch<SetStateAction<Avo.Assignment.Assignment>>
+						}
+						setValue={setValue as any}
+					/>
 				);
 
 			default:

--- a/src/assignment/views/AssignmentCreate.tsx
+++ b/src/assignment/views/AssignmentCreate.tsx
@@ -148,11 +148,7 @@ const AssignmentCreate: FunctionComponent<DefaultSecureRouteProps> = ({
 		when: isDirty,
 	});
 	const [loadingInfo, setLoadingInfo] = useState<LoadingInfo>({ state: 'loading' });
-	const [tabs, tab, , onTabClick] = useAssignmentTeacherTabs(
-		history,
-		assignment?.id as string,
-		user
-	);
+	const [tabs, tab, , onTabClick] = useAssignmentTeacherTabs(history, user);
 	const [isViewAsPupilEnabled, setIsViewAsPupilEnabled] = useState<boolean>();
 
 	// Render

--- a/src/assignment/views/AssignmentEdit.tsx
+++ b/src/assignment/views/AssignmentEdit.tsx
@@ -182,8 +182,8 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps> = ({
 
 	const [tabs, tab, setTab, onTabClick] = useAssignmentTeacherTabs(
 		history,
-		match.params.id as string,
-		user
+		user,
+		match.params.id
 	);
 	const [isViewAsPupilEnabled, setIsViewAsPupilEnabled] = useState<boolean>(false);
 	const [isConfirmSaveActionModalOpen, setIsConfirmSaveActionModalOpen] =

--- a/src/assignment/views/AssignmentEdit.tsx
+++ b/src/assignment/views/AssignmentEdit.tsx
@@ -182,7 +182,8 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps> = ({
 
 	const [tabs, tab, setTab, onTabClick] = useAssignmentTeacherTabs(
 		history,
-		match.params.id as string
+		match.params.id as string,
+		user
 	);
 	const [isViewAsPupilEnabled, setIsViewAsPupilEnabled] = useState<boolean>(false);
 	const [isConfirmSaveActionModalOpen, setIsConfirmSaveActionModalOpen] =


### PR DESCRIPTION
[AVO-2804](https://meemoo.atlassian.net/browse/AVO-2804)
[AVO-2809](https://meemoo.atlassian.net/browse/AVO-2809)

[Avo2-client PR](https://github.com/viaacode/avo2-client/pull/1861)
[Avo2-proxy PR](https://github.com/viaacode/avo2-proxy/pull/680)
[Avo2-typings PR](https://github.com/viaacode/avo2-typings/pull/131)

Before:
<img width="644" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/f4ff3989-5261-4afa-af3a-248e8c0bb99c">

After:
<img width="642" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/f1775bf8-2d80-47ea-9782-d3608cbdd986">


[AVO-2804]: https://meemoo.atlassian.net/browse/AVO-2804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AVO-2809]: https://meemoo.atlassian.net/browse/AVO-2809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ