### PR TITLE
fix(avo-2824): move warning messages inside is shared with others check

### DIFF
--- a/src/assignment/modals/DeleteAssignmentModal.tsx
+++ b/src/assignment/modals/DeleteAssignmentModal.tsx
@@ -8,6 +8,7 @@ interface DeleteAssignmentModalProps {
 	isOpen: boolean;
 	onClose?: () => void;
 	deleteObjectCallback: () => void;
+
 	isContributor: boolean;
 	isSharedWithOthers: boolean;
 	contributorCount: number;
@@ -49,26 +50,26 @@ const DeleteAssignmentModal: FunctionComponent<DeleteAssignmentModalProps> = ({
 					)
 				);
 			}
+
+			if (containsBuildBlocks) {
+				messages.push(
+					tHtml(
+						'assignment/views/assignment-overview___deze-opdracht-bevat-mogelijk-collecties-die-eveneens-verwijderd-zullen-worden'
+					)
+				);
+			}
+
+			if (hasResponses) {
+				messages.push(
+					tHtml(
+						'assignment/views/assignment-overview___leerlingen-bekeken-deze-opdracht-reeds'
+					)
+				);
+			}
 		} else if (isContributor) {
 			messages.push(
 				tHtml(
 					'assignment/modals/delete-assignment-modal___ben-je-zeker-dat-je-jezelf-van-deze-opdracht-wil-wissen'
-				)
-			);
-		}
-
-		if (containsBuildBlocks) {
-			messages.push(
-				tHtml(
-					'assignment/views/assignment-overview___deze-opdracht-bevat-mogelijk-collecties-die-eveneens-verwijderd-zullen-worden'
-				)
-			);
-		}
-
-		if (hasResponses) {
-			messages.push(
-				tHtml(
-					'assignment/views/assignment-overview___leerlingen-bekeken-deze-opdracht-reeds'
 				)
 			);
 		}


### PR DESCRIPTION
[AVO-2824](https://meemoo.atlassian.net/browse/AVO-2824)

Before:
<img width="964" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/2d2d79cf-c93a-4922-9e42-4c4b1d214264">

After:
<img width="1235" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/b8cd1eb1-65b9-4133-a611-ea622c308ed9">


[AVO-2824]: https://meemoo.atlassian.net/browse/AVO-2824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ