### PR TITLE
fix(avo-2847): fix header owners and contributors containing viewers

### DIFF
--- a/src/shared/components/HeaderOwnerAndContributors/HeaderOwnerAndContributors.tsx
+++ b/src/shared/components/HeaderOwnerAndContributors/HeaderOwnerAndContributors.tsx
@@ -11,6 +11,7 @@ import React, { FC, ReactNode } from 'react';
 
 import { getFullName } from '../../helpers';
 import { tHtml, tText } from '../../helpers/translate';
+import { ContributorInfoRights } from '../ShareWithColleagues/ShareWithColleagues.types';
 
 import './HeaderOwnerAndContributors.scss';
 
@@ -29,7 +30,9 @@ export const HeaderOwnerAndContributors: FC<HeaderOwnerAndContributorsProps> = (
 		(contributors || []) as
 			| Omit<Avo.Assignment.Contributor, 'assignment_id'>[]
 			| Omit<Avo.Collection.Contributor, 'collection_id'>[]
-	).filter((contrib) => !!contrib?.profile_id);
+	).filter(
+		(contrib) => !!contrib.profile_id && !(contrib.rights === ContributorInfoRights.VIEWER)
+	);
 
 	const renderContributors = (): ReactNode => {
 		if (nonPendingContributors?.length) {
@@ -66,7 +69,6 @@ export const HeaderOwnerAndContributors: FC<HeaderOwnerAndContributorsProps> = (
 									return getFullName(contributor.profile, false, false);
 								})
 								.join(', ')}
-							;
 						</p>
 					</TooltipContent>
 				</Tooltip>


### PR DESCRIPTION
[AVO-2847](https://meemoo.atlassian.net/browse/AVO-2847)

Before:
<img width="1378" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/9089d79a-0818-48a9-906e-680bab454866">

After:
<img width="1379" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/f5237cce-546f-45ba-83c2-d62f7980b7c5">


[AVO-2847]: https://meemoo.atlassian.net/browse/AVO-2847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ