### PR TITLE
fix(avo-2858): fix profile picture on searchresult

### DIFF
--- a/src/search/components/SearchResultItem.tsx
+++ b/src/search/components/SearchResultItem.tsx
@@ -1,6 +1,6 @@
 import { Avatar, IconName, TagOption, Thumbnail } from '@viaa/avo2-components';
 import type { Avo } from '@viaa/avo2-types';
-import { compact, trimStart } from 'lodash-es';
+import { compact, isNil, trimStart } from 'lodash-es';
 import React, { FunctionComponent } from 'react';
 
 import { toEnglishContentType } from '../../collection/collection.types';
@@ -105,7 +105,7 @@ const SearchResultItem: FunctionComponent<SearchResultItemProps> = ({
 					image={result.owner?.avatar_path || undefined}
 					name={name}
 					initials={initials.toLocaleUpperCase()}
-					size="small"
+					size={isNil(result.owner?.avatar_path) ? 'small' : undefined}
 					dark
 				/>
 			);


### PR DESCRIPTION
[AVO-2858](https://meemoo.atlassian.net/browse/AVO-2858)

Before:
<img width="1024" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/212bc7fc-3efb-4466-8075-e7f75cceebf6">

After:
<img width="1109" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/4207f31f-9fcf-4c51-a300-5af2da16f74d">


[AVO-2858]: https://meemoo.atlassian.net/browse/AVO-2858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ