### PR TITLE
fix(avo-2855): fix pupil assignment title alignment

### DIFF
--- a/src/assignment/views/AssignmentResponseEdit/AssignmentResponseEdit.tsx
+++ b/src/assignment/views/AssignmentResponseEdit/AssignmentResponseEdit.tsx
@@ -282,7 +282,7 @@ const AssignmentResponseEdit: FunctionComponent<AssignmentResponseEditProps & Us
 
 	const renderedTitle = useMemo(
 		() => (
-			<Flex center className={classnames({ 'u-spacer-top-l': showBackButton })}>
+			<Flex className={classnames({ 'u-spacer-top-l': showBackButton })}>
 				<Icon name={IconName.clipboard} size="large" />
 
 				<BlockHeading className="u-spacer-left" type="h2">


### PR DESCRIPTION
[AVO-2855](https://meemoo.atlassian.net/browse/AVO-2855)

Before:
<img width="1350" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/d6e07bdf-ff3b-4aa8-9f06-f9a3fb44f3c0">

After:
<img width="953" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/cf70ea64-278b-4d18-b016-5c175e01e1c9">


[AVO-2855]: https://meemoo.atlassian.net/browse/AVO-2855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cif