### PR TITLE
fix(avo-2851): fix assignment detail video fragments title not clickable

### DIFF
--- a/src/assignment/views/AssignmentDetail.tsx
+++ b/src/assignment/views/AssignmentDetail.tsx
@@ -719,12 +719,10 @@ const AssignmentDetail: FC<AssignmentDetailProps & DefaultSecureRouteProps<{ id:
 			<BlockList
 				blocks={(blocks || []) as Avo.Core.BlockItemBase[]}
 				config={{
-					TEXT: {
-						title: {
-							canClickHeading: false,
-						},
-					},
 					ITEM: {
+						title: {
+							canClickHeading: true,
+						},
 						flowPlayer: {
 							canPlay: true,
 						},


### PR DESCRIPTION
[AVO-2851](https://meemoo.atlassian.net/browse/AVO-2851)

Before:
<img width="1450" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/fd561940-5bf3-4cbb-b9cb-91010122ffd4">

After:
<img width="1336" alt="image" src="https://github.com/viaacode/avo2-client/assets/113341869/fe9247a7-4c3f-496c-84fa-8211d6f493b7">


[AVO-2851]: https://meemoo.atlassian.net/browse/AVO-2851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ