### PR TITLE
fix(avo-2923): switch url order for InteractiveTour

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -196,14 +196,14 @@ export const APP_PATH: { [routeId in RouteId]: RouteInfo } = {
 		showInContentPicker: true,
 		showForInteractiveTour: true,
 	},
-	ASSIGNMENT_CREATE: {
-		route: `/${ROUTE_PARTS.workspace}/${ROUTE_PARTS.assignments}/${ROUTE_PARTS.create}`,
-		showInContentPicker: true,
-		showForInteractiveTour: true,
-	},
 	ASSIGNMENT_DETAIL: {
 		route: `/${ROUTE_PARTS.workspace}/${ROUTE_PARTS.assignments}/:id`,
 		showInContentPicker: false,
+		showForInteractiveTour: true,
+	},
+	ASSIGNMENT_CREATE: {
+		route: `/${ROUTE_PARTS.workspace}/${ROUTE_PARTS.assignments}/${ROUTE_PARTS.create}`,
+		showInContentPicker: true,
 		showForInteractiveTour: true,
 	},
 	ASSIGNMENT_EDIT: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -196,6 +196,9 @@ export const APP_PATH: { [routeId in RouteId]: RouteInfo } = {
 		showInContentPicker: true,
 		showForInteractiveTour: true,
 	},
+	// This entry must come before the ASSIGNMENT_CREATE route,
+	// otherwise the interactive tour button doesn't correctly identify the route
+	// https://meemoo.atlassian.net/browse/AVO-2923
 	ASSIGNMENT_DETAIL: {
 		route: `/${ROUTE_PARTS.workspace}/${ROUTE_PARTS.assignments}/:id`,
 		showInContentPicker: false,


### PR DESCRIPTION
<img width="1214" alt="image" src="https://github.com/viaacode/avo2-client/assets/113892598/49505782-44e6-437d-9ea2-b7afc9552649">


![image](https://github.com/viaacode/avo2-client/assets/113892598/4e8d4bd7-0f58-44a5-8304-8c4310480e1c)


In useGetInteractiveTourForPage.ts the route pairs list is reversed, so ASSIGNMENT_CREATE was seen as ASSIGNMENT_DETAIL. Fix: by switching the order ASSIGNMENT_CREATE is found first and a tour is available.

Ticket: https://meemoo.atlassian.net/browse/AVO-2923