### PR TITLE
fix(avo-2971): fix timecrop bug + previewImagePath bug

### DIFF
--- a/src/shared/components/TimeCropControls/TimeCropControls.tsx
+++ b/src/shared/components/TimeCropControls/TimeCropControls.tsx
@@ -45,6 +45,13 @@ const TimeCropControls: FC<TimeCropControlsPops> = ({
 		onChange(fragmentStartTime, fragmentEndTime);
 	}, [fragmentStartTime, fragmentEndTime]);
 
+	useEffect(() => {
+		setFragmentStartTime(startTime);
+		setFragmentStartString(formatDurationHoursMinutesSeconds(startTime));
+		setFragmentEndTime(endTime);
+		setFragmentEndString(formatDurationHoursMinutesSeconds(endTime));
+	}, [startTime, endTime]);
+
 	const onUpdateMultiRangeValues = (values: number[]) => {
 		setFragmentStartTime(values[0]);
 		setFragmentEndTime(values[1]);

--- a/src/shared/services/video-stills-service.ts
+++ b/src/shared/services/video-stills-service.ts
@@ -34,8 +34,17 @@ export class VideoStillService {
 	 * @return url to frame from video
 	 */
 	public static async getVideoStill(externalId: string, startTime: number): Promise<string> {
-		const stills = await VideoStillService.getVideoStills([{ externalId, startTime }]);
-		return stills[0].previewImagePath;
+		try {
+			const stills = await VideoStillService.getVideoStills([{ externalId, startTime }]);
+			if (stills[0] && stills[0].previewImagePath) {
+				return stills[0].previewImagePath;
+			}
+			return '';
+		} catch (err) {
+			throw new CustomError('Failed to get video still previewImagePath', err, {
+				externalId,
+			});
+		}
 	}
 
 	public static async getThumbnailsForSubject(


### PR DESCRIPTION
First:
<img width="1242" alt="image" src="https://github.com/viaacode/avo2-client/assets/113892598/b90b90e0-98da-48a0-80d4-98e3f502f11b">

Then:
<img width="1255" alt="image" src="https://github.com/viaacode/avo2-client/assets/113892598/88673154-5b99-4630-9bb8-8e07eb79b02f">


Also had issue:
<img width="1698" alt="image" src="https://github.com/viaacode/avo2-client/assets/113892598/429586c1-c517-4068-8435-93b4230c24a4">



Ticket: https://meemoo.atlassian.net/browse/AVO-2971