### PR TITLE
fix(avo-3044): use tHtml so p-tags are not shown

### DIFF
--- a/src/assignment/views/AssignmentOverview.tsx
+++ b/src/assignment/views/AssignmentOverview.tsx
@@ -919,7 +919,7 @@ const AssignmentOverview: FunctionComponent<
 		if (canEditAssignments) {
 			// Teacher
 			if (query.view === AssignmentView.ACTIVE) {
-				return tText(
+				return tHtml(
 					'assignment/views/assignment-overview___beschrijving-hoe-een-opdracht-aan-te-maken'
 				);
 			}


### PR DESCRIPTION
Before:
<img width="1050" alt="image" src="https://github.com/viaacode/avo2-client/assets/113892598/a4eba808-8297-44b5-9d82-4d3ea78851db">


After:
<img width="1087" alt="image" src="https://github.com/viaacode/avo2-client/assets/113892598/95f37eac-5aaa-4472-92e9-fa70464b0078">


Ticket: https://meemoo.atlassian.net/browse/AVO-3044