### PR TITLE
fix(avo-2724): show bijschrift under videoplayer

### DIFF
--- a/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.scss
+++ b/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.scss
@@ -11,6 +11,8 @@ $c-spinner-fullscreen-holder-bg: rgba(#000, 0.5);
 $c-video-player-progress-inner-bg: $color-teal-bright;
 
 .c-video-player {
+	display: flex;
+	flex-direction: column;
 	position: relative;
 	border-radius: 0.4rem;
 	overflow: hidden;


### PR DESCRIPTION
Before:

<img width="1091" alt="image" src="https://github.com/viaacode/avo2-client/assets/113892598/c2a7a835-472c-4aa7-9c7c-f97a68259336">



After:

<img width="1088" alt="image" src="https://github.com/viaacode/avo2-client/assets/113892598/c3f3f059-c0a4-4177-a5c7-fc16ab8da085">



Ticket: https://meemoo.atlassian.net/browse/AVO-2724