### PR TITLE
feat(AVO-3010): improve performance of the content picker for profiles

### DIFF
--- a/src/admin/shared/components/ContentPicker/ContentPicker.tsx
+++ b/src/admin/shared/components/ContentPicker/ContentPicker.tsx
@@ -206,7 +206,7 @@ const ContentPickerComponent: FunctionComponent<ContentPickerProps & UserProps> 
 			newValue = propValue as string | null;
 		} else if (prop === 'selectedItem') {
 			newValue = (propValue as PickerItem)?.value || null;
-			newLabel = (propValue as PickerItem).label;
+			newLabel = (propValue as PickerItem)?.label;
 		} else if (selectedType.picker === 'TEXT_INPUT') {
 			newValue = input;
 		} else if (selectedType.picker === 'SELECT' && selectedItem) {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3010

requires proxy pr: https://github.com/viaacode/avo2-proxy/pull/697

* use custom queries that only fetch the name, email and id of the user and don't use the heave users_summary_view
* switch to backend routes for these queries

![image](https://github.com/viaacode/avo2-proxy/assets/1710840/dd09141a-d67c-4393-b372-98549d9a6eae)
