### PR TITLE
feature/AVO-2721: add onFocus on Edit assignment page and edit collection page

### DIFF
--- a/src/assignment/assignment.types.ts
+++ b/src/assignment/assignment.types.ts
@@ -118,6 +118,7 @@ export interface PupilSearchFilterState extends FilterState {
 export interface EditBlockProps {
 	block: EditableAssignmentBlock;
 	setBlock: (updatedBlock: EditableAssignmentBlock) => void;
+	onFocus?: () => void;
 }
 
 export type EditableAssignmentBlock = Avo.Assignment.Block &

--- a/src/assignment/components/AssignmentDetailsFormEditable.tsx
+++ b/src/assignment/components/AssignmentDetailsFormEditable.tsx
@@ -41,11 +41,12 @@ export interface AssignmentDetailsFormEditableProps {
 	assignment: Partial<AssignmentFields>;
 	setAssignment: Dispatch<SetStateAction<AssignmentFields>>;
 	setValue: UseFormSetValue<AssignmentFields>;
+	onFocus?: () => void;
 }
 
 const AssignmentDetailsFormEditable: FC<
 	AssignmentDetailsFormEditableProps & UserProps & DefaultProps
-> = ({ assignment, setAssignment, setValue, className, style, commonUser }) => {
+> = ({ assignment, setAssignment, setValue, className, style, commonUser, onFocus }) => {
 	const { tText, tHtml } = useTranslation();
 
 	const getId = useCallback(
@@ -268,6 +269,7 @@ const AssignmentDetailsFormEditable: FC<
 												} as AssignmentFields);
 											}}
 											value={assignment.answer_url || undefined}
+											onFocus={onFocus}
 										/>
 										<p className="c-form-help-text">
 											{tText(

--- a/src/assignment/components/AssignmentMetaDataFormEditable.tsx
+++ b/src/assignment/components/AssignmentMetaDataFormEditable.tsx
@@ -22,12 +22,14 @@ type AssignmentMetaDataFormEditableProps = {
 	assignment: Avo.Assignment.Assignment;
 	setAssignment: Dispatch<SetStateAction<Avo.Assignment.Assignment>>;
 	setValue: UseFormSetValue<Avo.Assignment.Assignment>;
+	onFocus?: () => void;
 };
 
 const AssignmentMetaDataFormEditable: FC<AssignmentMetaDataFormEditableProps> = ({
 	assignment,
 	setAssignment,
 	setValue,
+	onFocus,
 }) => {
 	const { tText } = useTranslation();
 	const [isAssignmentStillsModalOpen, setIsAssignmentStillsModalOpen] = useState<boolean>(false);
@@ -89,6 +91,7 @@ const AssignmentMetaDataFormEditable: FC<AssignmentMetaDataFormEditableProps> = 
 												}));
 											}
 										}}
+										onFocus={onFocus}
 									/>
 
 									<FormGroup
@@ -120,6 +123,7 @@ const AssignmentMetaDataFormEditable: FC<AssignmentMetaDataFormEditableProps> = 
 													}));
 												}
 											}}
+											onFocus={onFocus}
 										/>
 									</FormGroup>
 								</Column>

--- a/src/assignment/components/AssignmentTitle.tsx
+++ b/src/assignment/components/AssignmentTitle.tsx
@@ -16,9 +16,10 @@ type AssignmentTitleProps = {
 					previous: Partial<AssignmentFields> | undefined
 			  ) => Partial<AssignmentFields> | undefined)
 	) => void;
+	onFocus?: () => void;
 };
 
-const AssignmentTitle: FC<AssignmentTitleProps> = ({ control, setAssignment }) => {
+const AssignmentTitle: FC<AssignmentTitleProps> = ({ control, setAssignment, onFocus }) => {
 	const { tText } = useTranslation();
 	const [isActive, setIsActive] = useState<boolean>(false);
 
@@ -62,6 +63,7 @@ const AssignmentTitle: FC<AssignmentTitleProps> = ({ control, setAssignment }) =
 										setIsActive(false);
 										// setAssignment && setAssignment((previous) => previous);
 									}}
+									onFocus={onFocus}
 									iconEnd={() =>
 										!isActive && (
 											<Icon name={IconName.edit4} size="small" subtle />

--- a/src/assignment/components/blocks/AssignmentBlockEditText.tsx
+++ b/src/assignment/components/blocks/AssignmentBlockEditText.tsx
@@ -6,7 +6,7 @@ import { TitleDescriptionForm } from '../../../shared/components/TitleDescriptio
 import useTranslation from '../../../shared/hooks/useTranslation';
 import { EditBlockProps } from '../../assignment.types';
 
-export const AssignmentBlockEditText: FC<EditBlockProps> = ({ block, setBlock }) => {
+export const AssignmentBlockEditText: FC<EditBlockProps> = ({ block, setBlock, onFocus }) => {
 	const { tText } = useTranslation();
 
 	return (
@@ -42,6 +42,7 @@ export const AssignmentBlockEditText: FC<EditBlockProps> = ({ block, setBlock })
 						custom_description: value.toHTML(),
 					}),
 			}}
+			onFocus={onFocus}
 		/>
 	);
 };

--- a/src/assignment/hooks/use-edit-blocks.tsx
+++ b/src/assignment/hooks/use-edit-blocks.tsx
@@ -11,7 +11,8 @@ import { AssignmentBlockEditText } from '../components/blocks/AssignmentBlockEdi
 export function useEditBlocks(
 	setBlock: (updatedBlock: Avo.Core.BlockItemBase) => void,
 	buildSearchLink?: (props: Partial<FilterState>) => ReactNode | string,
-	AssignmentBlockItemDescriptionTypes?: AssignmentBlockItemDescriptionType[]
+	AssignmentBlockItemDescriptionTypes?: AssignmentBlockItemDescriptionType[],
+	onFocus?: () => void
 ): (block: Avo.Core.BlockItemBase) => ReactNode | null {
 	return function useEditBlocks(block: Avo.Core.BlockItemBase) {
 		switch (block.type) {
@@ -20,6 +21,7 @@ export function useEditBlocks(
 					<AssignmentBlockEditText
 						setBlock={setBlock}
 						block={block as EditableAssignmentBlock}
+						onFocus={onFocus}
 					/>
 				);
 

--- a/src/assignment/views/AssignmentEdit.tsx
+++ b/src/assignment/views/AssignmentEdit.tsx
@@ -134,6 +134,7 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps & UserProps> = ({
 			canPublish: boolean;
 		}>
 	>({});
+	const [hasUnsavedChanges, setHasUnsavedChanges] = useState<boolean>(false);
 
 	// Computed
 	const assignmentId = match.params.id;
@@ -522,9 +523,16 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps & UserProps> = ({
 		);
 	};
 
+	const cancelSaveBar = () => {
+		reset();
+		setHasUnsavedChanges(false);
+	};
+
 	// Render
 
-	const renderBlockContent = useEditBlocks(setBlock, buildGlobalSearchLink);
+	const renderBlockContent = useEditBlocks(setBlock, buildGlobalSearchLink, undefined, () =>
+		setHasUnsavedChanges(true)
+	);
 
 	const [renderedModals, confirmSliceModal, addBlockModal] = useBlockListModals(
 		assignment?.blocks || [],
@@ -616,7 +624,13 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps & UserProps> = ({
 	);
 
 	const renderTitle = useMemo(
-		() => <AssignmentTitle control={control} setAssignment={setAssignment as any} />,
+		() => (
+			<AssignmentTitle
+				control={control}
+				setAssignment={setAssignment as any}
+				onFocus={() => setHasUnsavedChanges(true)}
+			/>
+		),
 		[tText, control, setAssignment]
 	);
 
@@ -667,6 +681,7 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps & UserProps> = ({
 							assignment={assignment || {}}
 							setAssignment={setAssignment as any}
 							setValue={setValue}
+							onFocus={() => setHasUnsavedChanges(true)}
 						/>
 					</div>
 				);
@@ -680,6 +695,7 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps & UserProps> = ({
 								setAssignment as Dispatch<SetStateAction<Avo.Assignment.Assignment>>
 							}
 							setValue={setValue as any}
+							onFocus={() => setHasUnsavedChanges(true)}
 						/>
 					</div>
 				);
@@ -915,9 +931,9 @@ const AssignmentEdit: FunctionComponent<AssignmentEditProps & UserProps> = ({
 
 			{/* Must always be the second and last element inside the c-sticky-bar__wrapper */}
 			<StickySaveBar
-				isVisible={unsavedChanges}
+				isVisible={unsavedChanges || hasUnsavedChanges}
 				onSave={handleOnSave}
-				onCancel={() => reset()}
+				onCancel={cancelSaveBar}
 			/>
 		</div>
 	);

--- a/src/collection/components/CollectionOrBundleEdit.tsx
+++ b/src/collection/components/CollectionOrBundleEdit.tsx
@@ -233,7 +233,10 @@ const CollectionOrBundleEdit: FunctionComponent<
 		const hasChanges =
 			JSON.stringify(convertRteToString(initialCollection)) !==
 			JSON.stringify(convertRteToString(currentCollection));
-		setUnsavedChanges(hasChanges);
+
+		if (!unsavedChanges) {
+			setUnsavedChanges(hasChanges);
+		}
 	};
 
 	const fetchContributors = useCallback(async (): Promise<void> => {
@@ -757,6 +760,11 @@ const CollectionOrBundleEdit: FunctionComponent<
 		);
 	};
 
+	const cancelSaveBar = () => {
+		changeCollectionState({ type: 'RESET_COLLECTION' });
+		setUnsavedChanges(false);
+	};
+
 	// Listeners
 	const onSaveCollection = async () => {
 		setIsSavingCollection(true);
@@ -1116,6 +1124,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 							type={type}
 							collection={collectionState.currentCollection}
 							changeCollectionState={changeCollectionState}
+							onFocus={() => setUnsavedChanges(true)}
 						/>
 					);
 				case CollectionCreateUpdateTab.PUBLISH:
@@ -1124,6 +1133,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 							type={type}
 							collection={collectionState.currentCollection}
 							changeCollectionState={changeCollectionState}
+							onFocus={() => setUnsavedChanges(true)}
 						/>
 					);
 				case CollectionCreateUpdateTab.ADMIN:
@@ -1132,6 +1142,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 							collection={collectionState.currentCollection}
 							changeCollectionState={changeCollectionState}
 							history={history}
+							onFocus={() => setUnsavedChanges(true)}
 						/>
 					);
 				case CollectionCreateUpdateTab.ACTUALISATION:
@@ -1140,6 +1151,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 							collection={collectionState.currentCollection}
 							changeCollectionState={changeCollectionState}
 							history={history}
+							onFocus={() => setUnsavedChanges(true)}
 						/>
 					);
 				case CollectionCreateUpdateTab.QUALITY_CHECK:
@@ -1148,6 +1160,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 							collection={collectionState.currentCollection}
 							changeCollectionState={changeCollectionState}
 							history={history}
+							onFocus={() => setUnsavedChanges(true)}
 						/>
 					);
 				case CollectionCreateUpdateTab.MARCOM:
@@ -1156,6 +1169,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 							collection={collectionState.currentCollection}
 							changeCollectionState={changeCollectionState}
 							history={history}
+							onFocus={() => setUnsavedChanges(true)}
 						/>
 					);
 				default:
@@ -1402,6 +1416,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 								})
 							}
 							maxLength={110}
+							onFocus={() => setUnsavedChanges(true)}
 						/>
 					}
 					category={type}
@@ -1445,7 +1460,7 @@ const CollectionOrBundleEdit: FunctionComponent<
 					<StickySaveBar
 						isVisible={unsavedChanges}
 						onSave={() => executeAction(CollectionMenuAction.save)}
-						onCancel={() => changeCollectionState({ type: 'RESET_COLLECTION' })}
+						onCancel={cancelSaveBar}
 					/>
 				</div>
 

--- a/src/collection/components/CollectionOrBundleEditActualisation.tsx
+++ b/src/collection/components/CollectionOrBundleEditActualisation.tsx
@@ -28,11 +28,12 @@ interface CollectionOrBundleEditActualisationProps {
 	collection: Avo.Collection.Collection;
 	changeCollectionState: (action: CollectionAction) => void;
 	history: RouteComponentProps['history'];
+	onFocus?: () => void;
 }
 
 const CollectionOrBundleEditActualisation: FunctionComponent<
 	CollectionOrBundleEditActualisationProps & UserProps
-> = ({ collection, changeCollectionState }) => {
+> = ({ collection, changeCollectionState, onFocus }) => {
 	const { tText } = useTranslation();
 
 	const actualisationStatuses = getCollectionManagementStatuses()
@@ -161,6 +162,7 @@ const CollectionOrBundleEditActualisation: FunctionComponent<
 													collectionPropValue: newNotes || null,
 												})
 											}
+											onFocus={onFocus}
 										/>
 									</FormGroup>
 								</Column>

--- a/src/collection/components/CollectionOrBundleEditAdmin.tsx
+++ b/src/collection/components/CollectionOrBundleEditAdmin.tsx
@@ -61,11 +61,12 @@ interface CollectionOrBundleEditAdminProps {
 	collection: Avo.Collection.Collection;
 	changeCollectionState: (action: CollectionAction) => void;
 	history: RouteComponentProps['history'];
+	onFocus?: () => void;
 }
 
 const CollectionOrBundleEditAdmin: FunctionComponent<
 	CollectionOrBundleEditAdminProps & UserProps
-> = ({ collection, changeCollectionState, history, user }) => {
+> = ({ collection, changeCollectionState, history, user, onFocus }) => {
 	const { tText, tHtml } = useTranslation();
 
 	// State
@@ -420,6 +421,7 @@ const CollectionOrBundleEditAdmin: FunctionComponent<
 														collectionPropValue: newBriefing,
 													})
 												}
+												onFocus={onFocus}
 											/>
 										</FormGroup>
 									)}

--- a/src/collection/components/CollectionOrBundleEditContent.tsx
+++ b/src/collection/components/CollectionOrBundleEditContent.tsx
@@ -18,11 +18,12 @@ interface CollectionOrBundleEditContentProps {
 	type: 'collection' | 'bundle';
 	collection: Avo.Collection.Collection;
 	changeCollectionState: (action: CollectionAction) => void;
+	onFocus?: () => void;
 }
 
 const CollectionOrBundleEditContent: FunctionComponent<
 	CollectionOrBundleEditContentProps & UserProps
-> = ({ type, collection, changeCollectionState, user, commonUser }) => {
+> = ({ type, collection, changeCollectionState, user, commonUser, onFocus }) => {
 	const { tText, tHtml } = useTranslation();
 
 	// State
@@ -326,6 +327,7 @@ const CollectionOrBundleEditContent: FunctionComponent<
 							}
 							return null;
 						}}
+						onFocus={onFocus}
 					/>
 				))}
 			</Container>

--- a/src/collection/components/CollectionOrBundleEditMarcom.tsx
+++ b/src/collection/components/CollectionOrBundleEditMarcom.tsx
@@ -42,11 +42,12 @@ interface CollectionOrBundleEditMarcomProps {
 	collection: Avo.Collection.Collection & { marcom_note?: MarcomNoteInfo };
 	changeCollectionState: (action: CollectionAction) => void;
 	history: RouteComponentProps['history'];
+	onFocus?: () => void;
 }
 
 const CollectionOrBundleEditMarcom: FunctionComponent<
 	CollectionOrBundleEditMarcomProps & UserProps
-> = ({ collection, changeCollectionState }) => {
+> = ({ collection, changeCollectionState, onFocus }) => {
 	const { tText, tHtml } = useTranslation();
 
 	const isCollection = collection.type_id === ContentTypeNumber.collection;
@@ -312,6 +313,7 @@ const CollectionOrBundleEditMarcom: FunctionComponent<
 									<TextInput
 										onChange={setMarcomLink}
 										value={marcomLink || undefined}
+										onFocus={onFocus}
 									/>
 								</FormGroup>
 							</FlexItem>
@@ -368,6 +370,7 @@ const CollectionOrBundleEditMarcom: FunctionComponent<
 										},
 									});
 								}}
+								onFocus={onFocus}
 							/>
 						</FormGroup>
 					</Form>

--- a/src/collection/components/CollectionOrBundleEditMetaData.tsx
+++ b/src/collection/components/CollectionOrBundleEditMetaData.tsx
@@ -34,12 +34,14 @@ interface CollectionOrBundleEditMetaDataProps {
 	type: 'collection' | 'bundle';
 	collection: Avo.Collection.Collection;
 	changeCollectionState: (action: CollectionAction) => void;
+	onFocus?: () => void;
 }
 
 const CollectionOrBundleEditMetaData: FunctionComponent<CollectionOrBundleEditMetaDataProps> = ({
 	type,
 	collection,
 	changeCollectionState,
+	onFocus,
 }) => {
 	const { tText } = useTranslation();
 
@@ -87,6 +89,7 @@ const CollectionOrBundleEditMetaData: FunctionComponent<CollectionOrBundleEditMe
 										placeholder={tText(
 											'collection/components/collection-or-bundle-edit-meta-data___short-description-placeholder'
 										)}
+										onFocus={onFocus}
 									/>
 									{!isCollection && (
 										<FormGroup
@@ -175,6 +178,7 @@ const CollectionOrBundleEditMetaData: FunctionComponent<CollectionOrBundleEditMe
 													collectionPropValue: value,
 												})
 											}
+											onFocus={onFocus}
 										/>
 									</FormGroup>
 								</Column>

--- a/src/collection/components/CollectionOrBundleEditQualityCheck.tsx
+++ b/src/collection/components/CollectionOrBundleEditQualityCheck.tsx
@@ -27,11 +27,12 @@ interface CollectionOrBundleEditQualityCheckProps {
 	collection: Avo.Collection.Collection;
 	changeCollectionState: (action: CollectionAction) => void;
 	history: RouteComponentProps['history'];
+	onFocus?: () => void;
 }
 
 const CollectionOrBundleEditQualityCheck: FunctionComponent<
 	CollectionOrBundleEditQualityCheckProps & UserProps
-> = ({ collection, changeCollectionState }) => {
+> = ({ collection, changeCollectionState, onFocus }) => {
 	const { tText } = useTranslation();
 
 	const getApprovedAtDate = (collection: Avo.Collection.Collection): Date | null => {
@@ -213,6 +214,7 @@ const CollectionOrBundleEditQualityCheck: FunctionComponent<
 													collectionPropValue: newNotes || null,
 												})
 											}
+											onFocus={onFocus}
 										/>
 									</FormGroup>
 								</Column>

--- a/src/collection/components/CollectionOrBundleTitle.tsx
+++ b/src/collection/components/CollectionOrBundleTitle.tsx
@@ -9,6 +9,7 @@ type CollectionOrBundleTitleProps = {
 	title: string | undefined;
 	onChange: (title: string) => void;
 	maxLength?: number;
+	onFocus?: () => void;
 };
 
 const CollectionLOrBundleTitle: FC<CollectionOrBundleTitleProps> = ({
@@ -16,6 +17,7 @@ const CollectionLOrBundleTitle: FC<CollectionOrBundleTitleProps> = ({
 	title,
 	onChange,
 	maxLength,
+	onFocus,
 }) => {
 	const { tText } = useTranslation();
 	const [isActive, setIsActive] = useState<boolean>(false);
@@ -46,6 +48,7 @@ const CollectionLOrBundleTitle: FC<CollectionOrBundleTitleProps> = ({
 							iconEnd={() =>
 								!isActive && <Icon name={IconName.edit4} size="small" subtle />
 							}
+							onFocus={onFocus}
 						/>
 					</Flex>
 				</BlockHeading>

--- a/src/collection/components/fragment/FragmentEdit.tsx
+++ b/src/collection/components/fragment/FragmentEdit.tsx
@@ -56,6 +56,7 @@ interface FragmentEditProps {
 	fragment: Avo.Collection.Fragment;
 	allowedToAddLinks: boolean;
 	renderWarning?: () => ReactNode | null;
+	onFocus?: () => void;
 }
 
 const FragmentEdit: FunctionComponent<FragmentEditProps & UserProps> = ({
@@ -70,6 +71,7 @@ const FragmentEdit: FunctionComponent<FragmentEditProps & UserProps> = ({
 	allowedToAddLinks,
 	renderWarning = () => null,
 	user,
+	onFocus,
 }) => {
 	const { tText, tHtml } = useTranslation();
 
@@ -301,6 +303,7 @@ const FragmentEdit: FunctionComponent<FragmentEditProps & UserProps> = ({
 						onChange={setTempTitle}
 						onBlur={() => handleChangedValue('custom_title', tempTitle)}
 						disabled={disableVideoFields}
+						onFocus={onFocus}
 					/>
 				</FormGroup>
 				{!isThisFragmentACollection && (
@@ -333,6 +336,7 @@ const FragmentEdit: FunctionComponent<FragmentEditProps & UserProps> = ({
 									}
 								}}
 								disabled={disableVideoFields}
+								onFocus={onFocus}
 							/>
 						)}
 					</FormGroup>

--- a/src/shared/components/ShortDescriptionField/ShortDescriptionField.tsx
+++ b/src/shared/components/ShortDescriptionField/ShortDescriptionField.tsx
@@ -10,12 +10,14 @@ interface ShortDescriptionFieldProps extends Pick<FormGroupProps, 'error'> {
 	onChange: (value: string) => void;
 	value: string | null;
 	placeholder?: string;
+	onFocus?: () => void;
 }
 
 const ShortDescriptionField: FunctionComponent<ShortDescriptionFieldProps> = ({
 	onChange,
 	value,
 	placeholder,
+	onFocus,
 }) => {
 	const { tText } = useTranslation();
 
@@ -43,6 +45,7 @@ const ShortDescriptionField: FunctionComponent<ShortDescriptionFieldProps> = ({
 				height="medium"
 				placeholder={placeholder}
 				onChange={onChange}
+				onFocus={onFocus}
 			/>
 			<label>{error(false)}</label>
 		</FormGroup>

--- a/src/shared/components/TitleDescriptionForm/TitleDescriptionForm.tsx
+++ b/src/shared/components/TitleDescriptionForm/TitleDescriptionForm.tsx
@@ -18,6 +18,7 @@ export interface TitleDescriptionFormProps extends DefaultProps {
 	id: string | number;
 	title?: TitleDescriptionFormTitleField;
 	description?: TitleDescriptionFormDescriptionField;
+	onFocus?: () => void;
 }
 
 export const TitleDescriptionFormIds = {
@@ -26,7 +27,7 @@ export const TitleDescriptionFormIds = {
 };
 
 export const TitleDescriptionForm: FC<TitleDescriptionFormProps> = (props) => {
-	const { id, style, className } = props;
+	const { id, style, className, onFocus } = props;
 
 	const titleValue = props.title?.value;
 	const descriptionInitialHtml = props.description?.initialHtml;
@@ -61,6 +62,7 @@ export const TitleDescriptionForm: FC<TitleDescriptionFormProps> = (props) => {
 						onChange={setTitle}
 						onBlur={() => props.title?.onChange?.(title as string)}
 						id={getId(TitleDescriptionFormIds.title)}
+						onFocus={onFocus}
 					/>
 				</FormGroup>
 			)}
@@ -76,6 +78,7 @@ export const TitleDescriptionForm: FC<TitleDescriptionFormProps> = (props) => {
 						onChange={setDescription}
 						onBlur={() => props.description?.onChange?.(description as RichEditorState)}
 						id={getId(TitleDescriptionFormIds.description)}
+						onFocus={onFocus}
 					/>
 				</FormGroup>
 			)}


### PR DESCRIPTION
<img width="1160" alt="image" src="https://github.com/viaacode/avo2-client/assets/113892598/5c0df896-aaa2-4eed-85d8-137c1ebbd81a">

<img width="1163" alt="image" src="https://github.com/viaacode/avo2-client/assets/113892598/3ec9ce42-d960-498c-a8be-fd4518d5ad13">


<img width="1156" alt="image" src="https://github.com/viaacode/avo2-client/assets/113892598/d91ebd3e-2641-439d-814a-8c0d1e15495b">


Ticket: https://meemoo.atlassian.net/browse/AVO-2721
**Check avo2-components commit**: https://github.com/viaacode/avo2-components/commit/6f906d522d069d64834fd2ef5fc82f61b1f9c5a6