### PR TITLE
fix(avo-3002): fix padding in paragraphs in c-content divs

### DIFF
--- a/src/styles/components/_content-page.scss
+++ b/src/styles/components/_content-page.scss
@@ -122,7 +122,8 @@
 	white-space: initial;
 
 	p {
-		padding: 1.5rem 0;
+		margin: 0;
+		padding: 0.4rem 0;
 	}
 
 	a {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3002

this bug seems to be caused by the fix of https://meemoo.atlassian.net/browse/AVO-2926

so this pr tries to tweak the solution for AVO-2926 to solve both AVO-2926 and AVO-3002

replaced this PR:  https://github.com/viaacode/react-admin-core-module/pull/218

![image](https://github.com/viaacode/avo2-client/assets/1710840/b2a73935-16f2-4a3c-8a81-75a496919b43)
