### PR TITLE
fix(AVO-3015): show audio still for audio items, show copyright in admin

### DIFF
--- a/src/admin/content-page/components/blocks/MediaGridWrapper/MediaGridWrapper.tsx
+++ b/src/admin/content-page/components/blocks/MediaGridWrapper/MediaGridWrapper.tsx
@@ -27,6 +27,7 @@ import withUser, { UserProps } from '../../../../../shared/hocs/withUser';
 import useTranslation from '../../../../../shared/hooks/useTranslation';
 import { BookmarksViewsPlaysService } from '../../../../../shared/services/bookmarks-views-plays-service';
 import { ToastService } from '../../../../../shared/services/toast-service';
+import { ADMIN_PATH } from '../../../../admin.const';
 import { ContentPageService } from '../../../services/content-page.service';
 
 import { BlockMediaGrid, MediaListItem } from './BlockMediaGrid';
@@ -154,6 +155,7 @@ const MediaGridWrapper: FunctionComponent<MediaGridWrapperProps & UserProps> = (
 				}
 			}
 		} catch (err) {
+			console.error(err);
 			setLoadingInfo({
 				state: 'error',
 				message: tHtml(
@@ -318,6 +320,9 @@ const MediaGridWrapper: FunctionComponent<MediaGridWrapperProps & UserProps> = (
 			itemOrCollectionOrAssignment?.view_counts_aggregate?.aggregate?.sum?.count || 0;
 
 		const element: MediaGridBlockComponentState = (elements || [])[index] || ({} as any);
+		const showCopyrightNotice =
+			!!itemOrCollectionOrAssignment.copyrightOrganisation &&
+			(!commonUser || location.pathname.startsWith(ADMIN_PATH.DASHBOARD));
 
 		return {
 			category:
@@ -352,7 +357,7 @@ const MediaGridWrapper: FunctionComponent<MediaGridWrapperProps & UserProps> = (
 				label: itemLabel,
 				meta: getThumbnailMetadata(itemOrCollectionOrAssignment),
 				src: element.copyrightImage || getThumbnailFromItem(itemOrCollectionOrAssignment),
-				topRight: !!itemOrCollectionOrAssignment.copyrightOrganisation && !commonUser && (
+				topRight: showCopyrightNotice && (
 					<Button
 						type="inline-link"
 						onClick={(evt) =>

--- a/src/admin/content-page/components/blocks/MediaGridWrapper/MediaGridWrapper.tsx
+++ b/src/admin/content-page/components/blocks/MediaGridWrapper/MediaGridWrapper.tsx
@@ -10,6 +10,9 @@ import {
 import { type Avo } from '@viaa/avo2-types';
 import { compact, isEmpty, isNil } from 'lodash-es';
 import React, { FunctionComponent, ReactNode, useCallback, useEffect, useState } from 'react';
+import { withRouter } from 'react-router';
+import { RouteComponentProps } from 'react-router-dom';
+import { compose } from 'redux';
 
 import placeholderImage from '../../../../../assets/images/assignment-placeholder.png';
 import {
@@ -46,7 +49,9 @@ interface MediaGridWrapperProps extends MediaGridBlockState {
 	ctaButtonAltTitle?: string;
 }
 
-const MediaGridWrapper: FunctionComponent<MediaGridWrapperProps & UserProps> = ({
+const MediaGridWrapper: FunctionComponent<
+	MediaGridWrapperProps & UserProps & RouteComponentProps
+> = ({
 	title,
 	buttonLabel,
 	buttonAltTitle,
@@ -71,6 +76,7 @@ const MediaGridWrapper: FunctionComponent<MediaGridWrapperProps & UserProps> = (
 	results,
 	renderLink,
 	commonUser,
+	location,
 }: any) => {
 	// TODO remove any when typings for admin-core-ui is fixed
 	const { tText, tHtml } = useTranslation();
@@ -514,4 +520,7 @@ const MediaGridWrapper: FunctionComponent<MediaGridWrapperProps & UserProps> = (
 	);
 };
 
-export default withUser(MediaGridWrapper) as FunctionComponent<MediaGridWrapperProps>;
+export default compose(
+	withRouter,
+	withUser
+)(MediaGridWrapper) as FunctionComponent<MediaGridWrapperProps>;

--- a/src/admin/shared/hoc/with-admin-core-config.const.tsx
+++ b/src/admin/shared/hoc/with-admin-core-config.const.tsx
@@ -13,7 +13,7 @@ import { Link, useHistory } from 'react-router-dom';
 
 import { APP_PATH, RouteId } from '../../../constants';
 import { FlowPlayerWrapper } from '../../../shared/components';
-import { ROUTE_PARTS } from '../../../shared/constants';
+import { DEFAULT_AUDIO_STILL, ROUTE_PARTS } from '../../../shared/constants';
 import { getEnv } from '../../../shared/helpers';
 import { tHtml, tText } from '../../../shared/helpers/translate';
 import { EducationOrganisationService } from '../../../shared/services/education-organizations-service';
@@ -147,6 +147,7 @@ export function getAdminCoreConfig(): AdminConfig {
 			loader: {
 				component: () => <Spinner size="large" />,
 			},
+			defaultAudioStill: DEFAULT_AUDIO_STILL,
 			buttonTypes: () => [
 				{
 					label: tText('admin/content-block/content-block___primair'),


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3015

requires proxy and admin-core PRs:
* https://github.com/viaacode/avo2-proxy/pull/713
* https://github.com/viaacode/react-admin-core-module/pull/222

before:
![image](https://github.com/viaacode/avo2-client/assets/1710840/6581c662-10f6-4ffd-811a-68d37b09215f)
![image](https://github.com/viaacode/avo2-client/assets/1710840/75a12a95-6505-4c76-8542-4957d99f4b5c)


after:
![image](https://github.com/viaacode/avo2-client/assets/1710840/c842558c-b34d-48e2-be97-685db727df04)
![image](https://github.com/viaacode/avo2-client/assets/1710840/d594f599-7d33-44d5-9d48-406152578dc5)
