### PR TITLE
fix(AVO-2881): only childless edu levels/degrees in complete profile

### DIFF
--- a/src/shared/components/LomFieldsInput/LomFieldsInput.tsx
+++ b/src/shared/components/LomFieldsInput/LomFieldsInput.tsx
@@ -137,7 +137,7 @@ const LomFieldsInput: FC<LomFieldsInputProps> = ({
 					<TagsInput
 						id="educationId"
 						isLoading={isEducationLevelsLoading}
-						options={allEducationLevels?.map(lomToTagInfo)}
+						options={getEducationLevelOptions(allEducationLevels)}
 						value={
 							getEducationLevelOptions([
 								...lomFields.educationDegree,


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2881

before:
![image](https://github.com/viaacode/avo2-client/assets/1710840/b8a2d2b9-ee07-401b-a8aa-551d34536ae7)


after:
![image](https://github.com/viaacode/avo2-client/assets/1710840/0b5b37cc-1313-4b18-81b6-09f6bb818a22)

