### PR TITLE
fix(AVO-3113): return empty instead of untranslated string

### DIFF
--- a/src/admin/shared/components/ContentPicker/helpers/parse-picker.ts
+++ b/src/admin/shared/components/ContentPicker/helpers/parse-picker.ts
@@ -34,7 +34,7 @@ export const parseSearchQuery = (input: string): string => {
 			)
 		);
 
-		return 'Ongeldige zoekfilter';
+		return '';
 	}
 };
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3113

Mirror of https://github.com/viaacode/react-admin-core-module/pull/226