### PR TITLE
fix(package.json): move apple m1 package to optional dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
 	extends: [
 		'eslint:recommended',
 		'plugin:react/recommended',
+		'plugin:react-hooks/recommended',
 		'plugin:@typescript-eslint/recommended',
 		'plugin:import/recommended',
 		'plugin:import/typescript',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@flowplayer/player": "3.3.0",
         "@hookform/resolvers": "2.9.11",
-        "@meemoo/admin-core-ui": "3.1.31",
-        "@meemoo/react-components": "3.0.22",
+        "@meemoo/admin-core-ui": "3.1.32",
+        "@meemoo/react-components": "3.0.23",
         "@popperjs/core": "2.11.6",
         "@studiohyperdrive/pagination": "1.0.0",
         "@tanstack/react-query": "4.35.3",
@@ -125,6 +125,7 @@
         "eslint-plugin-import": "2.28.1",
         "eslint-plugin-prettier": "5.0.0",
         "eslint-plugin-react": "7.33.2",
+        "eslint-plugin-react-hooks": "4.6.0",
         "glob": "7.2.3",
         "graphql": "16.8.1",
         "husky": "8.0.3",
@@ -3341,7 +3342,8 @@
     },
     "node_modules/@icons/material": {
       "version": "0.2.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
       "peer": true,
       "peerDependencies": {
         "react": "*"
@@ -4109,12 +4111,12 @@
       }
     },
     "node_modules/@meemoo/admin-core-ui": {
-      "version": "3.1.31",
-      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@meemoo/admin-core-ui/-/admin-core-ui-3.1.31.tgz",
-      "integrity": "sha512-ivD8a0DCBV6R7uYBSU1Q5ONtIuTe2nBYhRajZxMFq0HQa9XjaIO2MItJUDIBGB7qXsMYEVmHMyb+CIXBOBcR7Q==",
+      "version": "3.1.32",
+      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@meemoo/admin-core-ui/-/admin-core-ui-3.1.32.tgz",
+      "integrity": "sha512-95aJTpqbAt9GcluV+AN6LmAFk08gNvlMVKTEsnRwVdIikbWRirr3beEML8biR2mPNRuDhpm7eaWc71E/h0XK/w==",
       "peerDependencies": {
         "@hookform/resolvers": "2.9.11",
-        "@meemoo/react-components": "3.0.22",
+        "@meemoo/react-components": "3.0.23",
         "@studiohyperdrive/pagination": "1.0.0",
         "@tanstack/react-query": "4.35.3",
         "@viaa/avo2-components": "4.0.24",
@@ -4156,7 +4158,9 @@
       }
     },
     "node_modules/@meemoo/react-components": {
-      "version": "3.0.22",
+      "version": "3.0.23",
+      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@meemoo/react-components/-/react-components-3.0.23.tgz",
+      "integrity": "sha512-enWwsutZT+Kpx9X2VLwM7gmDIwIl0y4aEaDQPRPYAnZUeeksN0sCr5pLa/fxePB5DwgGAqxQH4IqqJG3F9oTwA==",
       "dependencies": {
         "braft-editor": "^2.3.9",
         "braft-extensions": "0.1.1",
@@ -6195,7 +6199,8 @@
     },
     "node_modules/braft-convert": {
       "version": "2.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/braft-convert/-/braft-convert-2.3.0.tgz",
+      "integrity": "sha512-5km+dLHk8iYDv2iEYDrDQ2ld/ZoUx66QLql0qdm5PqZEcNXc8dBHGLORfzeu3iMw1jLeAiHxtdY5+ypuIhczVg==",
       "dependencies": {
         "draft-convert": "^2.0.0",
         "draft-js": "^0.10.3"
@@ -6206,7 +6211,8 @@
     },
     "node_modules/braft-editor": {
       "version": "2.3.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/braft-editor/-/braft-editor-2.3.9.tgz",
+      "integrity": "sha512-mqdPk/zI2dhFK8tW/A4Qj/AkkARLh5L/niNw+iif5wFqb6zh15rMlrShgz1nWO/QXyAKr8XtDgxiBbR0zWwtRg==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "braft-convert": "^2.3.0",
@@ -6225,7 +6231,8 @@
     },
     "node_modules/braft-extensions": {
       "version": "0.1.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/braft-extensions/-/braft-extensions-0.1.1.tgz",
+      "integrity": "sha512-lmqGA6TIMqejQfeQ5NvqNsD+pbyqJjWPh6CMcRL2hKd+3yo5Oc9dv6uTWx+f8ICnxXJEs6LZHYOA58zcP2cnJQ==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "braft-convert": "^2.1.10",
@@ -6240,7 +6247,8 @@
     },
     "node_modules/braft-finder": {
       "version": "0.0.19",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/braft-finder/-/braft-finder-0.0.19.tgz",
+      "integrity": "sha512-0kzI6/KbomJJhYX1hpjn4edCKhblyUyWdUrsgBmOrwy0vrj+pPkm69+Uf8Uj6KGAULM6LF0ooC++p7fqUGgFHw==",
       "peerDependencies": {
         "react": "^16.4.1",
         "react-dom": "^16.4.1"
@@ -6248,7 +6256,8 @@
     },
     "node_modules/braft-utils": {
       "version": "3.0.12",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/braft-utils/-/braft-utils-3.0.12.tgz",
+      "integrity": "sha512-O2cKysURNC4HSEMKgNmQ2RluwcrxvYrztlEmyPN5SzktiNX3vaLFQoo0Ez3PlIhvjaGrIBSIT2Oyh2N6mn6TFg==",
       "peerDependencies": {
         "braft-convert": "^2.1.4",
         "draft-js": "^0.10.5",
@@ -6906,7 +6915,9 @@
     },
     "node_modules/core-js": {
       "version": "1.2.7",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js."
     },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
@@ -7662,7 +7673,8 @@
     },
     "node_modules/draft-convert": {
       "version": "2.1.13",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/draft-convert/-/draft-convert-2.1.13.tgz",
+      "integrity": "sha512-/h/n4JCfyO8aWby7wKBkccHdsuVbbDyHWXi/B3Zf2pN++lN1lDOIVt5ulXCcbH2Y5YJEFzMJw/YGfN+R0axxxg==",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "immutable": "~3.7.4",
@@ -7676,7 +7688,8 @@
     },
     "node_modules/draft-js": {
       "version": "0.10.5",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.10.5.tgz",
+      "integrity": "sha512-LE6jSCV9nkPhfVX2ggcRLA4FKs6zWq9ceuO/88BpXdNCS7mjRTgs0NsV6piUCJX9YxMsB9An33wnkMmU2sD2Zg==",
       "dependencies": {
         "fbjs": "^0.8.15",
         "immutable": "~3.7.4",
@@ -7689,14 +7702,16 @@
     },
     "node_modules/draft-js-multidecorators": {
       "version": "1.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/draft-js-multidecorators/-/draft-js-multidecorators-1.0.0.tgz",
+      "integrity": "sha512-7qdy+YQol5iq38AoEerhgSJWhCzxvZLn1x5ODfUlGfWlg0SrZ9AXJbaxHVIjdSIZNrbVIm+WANujNxMqCmDSZQ==",
       "dependencies": {
         "immutable": "*"
       }
     },
     "node_modules/draft-js-prism": {
       "version": "1.0.6",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/draft-js-prism/-/draft-js-prism-1.0.6.tgz",
+      "integrity": "sha512-9iNPPr6/vaC9K60DtVes1JGDZ9uD0vZ7/8i6de5cZEzbftOj/ijIGplEV0dTFT/q8U+bY1uR1ikQevjRh2pEpQ==",
       "peer": true,
       "dependencies": {
         "extend": "^3.0.0",
@@ -7708,7 +7723,8 @@
     },
     "node_modules/draft-js/node_modules/fbjs": {
       "version": "0.8.18",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
+      "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
       "dependencies": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -7721,6 +7737,8 @@
     },
     "node_modules/draft-js/node_modules/ua-parser-js": {
       "version": "0.7.37",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.37.tgz",
+      "integrity": "sha512-xV8kqRKM+jhMvcHWUKthV9fNebIzrNy//2O9ZwWcfiBFR5f25XVZPLlEajk/sf3Ra15V92isyQqnIEXRDaZWEA==",
       "funding": [
         {
           "type": "opencollective",
@@ -7735,14 +7753,14 @@
           "url": "https://github.com/sponsors/faisalman"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/draftjs-utils": {
       "version": "0.9.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/draftjs-utils/-/draftjs-utils-0.9.4.tgz",
+      "integrity": "sha512-KYjABSbGpJrwrwmxVj5UhfV37MF/p0QRxKIyL+/+QOaJ8J9z1FBKxkblThbpR0nJi9lxPQWGg+gh+v0dAsSCCg==",
       "peerDependencies": {
         "draft-js": "^0.10.x",
         "immutable": "3.x.x || 4.x.x"
@@ -8289,6 +8307,18 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "2.1.0",
       "dev": true,
@@ -8621,7 +8651,8 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "peer": true
     },
     "node_modules/external-editor": {
@@ -9413,7 +9444,8 @@
     },
     "node_modules/html-table-to-json": {
       "version": "0.4.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/html-table-to-json/-/html-table-to-json-0.4.1.tgz",
+      "integrity": "sha512-QpAIDUIZQgJWwQPwSD04kLwZM8XqenXL3+H2EdkcJnHlf+7lj+MWrHTdJ2+rGK9m9lFGWTE+wrZSm0EwXf49AA==",
       "peer": true,
       "dependencies": {
         "@types/cheerio": "^0.22.9",
@@ -10293,7 +10325,8 @@
     },
     "node_modules/isomorphic-fetch": {
       "version": "2.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
       "dependencies": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -10301,14 +10334,16 @@
     },
     "node_modules/isomorphic-fetch/node_modules/is-stream": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/isomorphic-fetch/node_modules/node-fetch": {
       "version": "1.7.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "dependencies": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -13159,7 +13194,8 @@
     },
     "node_modules/material-colors": {
       "version": "1.2.6",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
       "peer": true
     },
     "node_modules/mdn-data": {
@@ -14242,7 +14278,8 @@
     },
     "node_modules/prismjs": {
       "version": "1.29.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -14419,7 +14456,8 @@
     },
     "node_modules/react-color": {
       "version": "2.19.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
+      "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
       "peer": true,
       "dependencies": {
         "@icons/material": "^0.2.4",
@@ -14910,7 +14948,8 @@
     },
     "node_modules/reactcss": {
       "version": "1.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
       "peer": true,
       "dependencies": {
         "lodash": "^4.0.1"
@@ -16445,7 +16484,8 @@
     },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "peer": true
     },
     "node_modules/title-case": {
@@ -17306,7 +17346,8 @@
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,6 @@
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
         "@commitlint/cli": "17.7.1",
         "@commitlint/config-conventional": "17.7.0",
-        "@esbuild/darwin-arm64": "^0.20.1",
         "@graphql-codegen/add": "3.2.3",
         "@graphql-codegen/cli": "2.16.5",
         "@graphql-codegen/introspection": "2.2.3",
@@ -146,6 +145,9 @@
         "vite-plugin-svgr": "3.2.0",
         "vite-svg-loader": "4.0.0",
         "vite-tsconfig-paths": "4.2.1"
+      },
+      "optionalDependencies": {
+        "@esbuild/darwin-arm64": "^0.20.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1906,7 +1908,7 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "optional": true,
       "os": [
         "darwin"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -149,6 +149,7 @@
       },
       "optionalDependencies": {
         "@esbuild/darwin-arm64": "^0.20.1",
+        "@esbuild/linux-x64": "^0.20.1",
         "@esbuild/win32-x64": "^0.20.1"
       }
     },
@@ -2143,13 +2144,12 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.1.tgz",
+      "integrity": "sha512-5gRPk7pKuaIB+tmH+yKd2aQTRpqlf1E4f/mC+tawIm/CGJemZcHZpp2ic8oD83nKgUPMEd0fNanrnFljiruuyA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8056,6 +8056,22 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">=12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,8 @@
         "vite-tsconfig-paths": "4.2.1"
       },
       "optionalDependencies": {
-        "@esbuild/darwin-arm64": "^0.20.1"
+        "@esbuild/darwin-arm64": "^0.20.1",
+        "@esbuild/win32-x64": "^0.20.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1901,6 +1902,54 @@
       "version": "0.3.1",
       "license": "MIT"
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.20.1",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.1.tgz",
@@ -1911,6 +1960,293 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.1.tgz",
+      "integrity": "sha512-0MBh53o6XtI6ctDnRMeQ+xoCN8kD2qI1rY1KgF/xdWQwoFeKou7puvDfV8/Wv4Ctx2rRpET/gGdz3YlNtNACSA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -7702,6 +8038,22 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "dependencies": {
     "@flowplayer/player": "3.3.0",
     "@hookform/resolvers": "2.9.11",
-    "@meemoo/admin-core-ui": "3.1.31",
-    "@meemoo/react-components": "3.0.22",
+    "@meemoo/admin-core-ui": "3.1.32",
+    "@meemoo/react-components": "3.0.23",
     "@popperjs/core": "2.11.6",
     "@studiohyperdrive/pagination": "1.0.0",
     "@tanstack/react-query": "4.35.3",
@@ -154,6 +154,7 @@
     "eslint-plugin-import": "2.28.1",
     "eslint-plugin-prettier": "5.0.0",
     "eslint-plugin-react": "7.33.2",
+    "eslint-plugin-react-hooks": "4.6.0",
     "glob": "7.2.3",
     "graphql": "16.8.1",
     "husky": "8.0.3",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,8 @@
   },
   "optionalDependencies": {
     "@esbuild/darwin-arm64": "^0.20.1",
-    "@esbuild/win32-x64": "^0.20.1"
+    "@esbuild/win32-x64": "^0.20.1",
+    "@esbuild/linux-x64": "^0.20.1"
   },
   "overrides": {
     "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
     "@commitlint/cli": "17.7.1",
     "@commitlint/config-conventional": "17.7.0",
-    "@esbuild/darwin-arm64": "^0.20.1",
     "@graphql-codegen/add": "3.2.3",
     "@graphql-codegen/cli": "2.16.5",
     "@graphql-codegen/introspection": "2.2.3",
@@ -175,6 +174,9 @@
     "vite-plugin-svgr": "3.2.0",
     "vite-svg-loader": "4.0.0",
     "vite-tsconfig-paths": "4.2.1"
+  },
+  "optionalDependencies": {
+    "@esbuild/darwin-arm64": "^0.20.1"
   },
   "overrides": {
     "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,8 @@
     "vite-tsconfig-paths": "4.2.1"
   },
   "optionalDependencies": {
-    "@esbuild/darwin-arm64": "^0.20.1"
+    "@esbuild/darwin-arm64": "^0.20.1",
+    "@esbuild/win32-x64": "^0.20.1"
   },
   "overrides": {
     "react": "18.2.0",

--- a/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.tsx
+++ b/src/shared/components/FlowPlayerWrapper/FlowPlayerWrapper.tsx
@@ -271,6 +271,7 @@ const FlowPlayerWrapper: FunctionComponent<
 				{src && (props.autoplay || clickedThumbnail || !item) ? (
 					<FlowPlayer
 						src={getBrowserSafeUrl(src)}
+						type={(item?.type?.label as 'video' | 'audio' | undefined) || 'video'}
 						poster={poster}
 						title={props.title}
 						metadata={

--- a/src/workspace/workspace.routes.tsx
+++ b/src/workspace/workspace.routes.tsx
@@ -19,7 +19,10 @@ export const renderWorkspaceRoutes = (): ReactNode[] => [
 			match: {
 				params: { id },
 			},
-		}) => <Redirect to={`/${ROUTE_PARTS.assignments}/${id}`} />}
+			location,
+		}) => {
+			return <Redirect to={`/${ROUTE_PARTS.assignments}/${id}${location.search}`} />;
+		}}
 		exact
 		path={`${APP_PATH.WORKSPACE.route}${APP_PATH.ASSIGNMENT_DETAIL.route}`}
 		key={`${APP_PATH.WORKSPACE.route}${APP_PATH.ASSIGNMENT_DETAIL.route}`}


### PR DESCRIPTION
on windows this package gives an error:
```
"C:\Program Files\nodejs\npm.cmd" install
npm ERR! code EBADPLATFORM
npm ERR! notsup Unsupported platform for @esbuild/darwin-arm64@0.20.1: wanted {"os":"darwin","cpu":"arm64"} (current: {"os":"win32","cpu":"x64"})
npm ERR! notsup Valid os:   darwin
npm ERR! notsup Actual os:  win32
npm ERR! notsup Valid cpu:  arm64
npm ERR! notsup Actual cpu: x64

npm ERR! A complete log of this run can be found in: C:\Users\bert\AppData\Local\npm-cache\_logs\2024-02-28T08_37_50_539Z-debug-0.log

Process finished with exit code 1
```

Maybe this PR can be a solution for all devices/OS's

More info:
https://docs.npmjs.com/cli/v10/configuring-npm/package-json#optionaldependencies