### PR TITLE
fix(AVO-3132): split copy link from title link for coll, bun. & assign.

### DIFF
--- a/src/admin/assignments/views/AssignmentsOverviewAdmin.tsx
+++ b/src/admin/assignments/views/AssignmentsOverviewAdmin.tsx
@@ -3,7 +3,7 @@ import { type Avo } from '@viaa/avo2-types';
 import { compact, first, get, isNil, partition, without } from 'lodash-es';
 import React, {
 	FunctionComponent,
-	ReactText,
+	ReactNode,
 	useCallback,
 	useEffect,
 	useMemo,
@@ -31,6 +31,7 @@ import { Lookup_Enum_Relation_Types_Enum } from '../../../shared/generated/graph
 import { buildLink, CustomError, formatDate } from '../../../shared/helpers';
 import { isContentBeingEdited } from '../../../shared/helpers/is-content-being-edited';
 import { groupLomLinks } from '../../../shared/helpers/lom';
+import { renderCollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/helpers/render-collection-or-bundle-or-assignment-title-and-copy-tag';
 import { lomsToTagList } from '../../../shared/helpers/strings-to-taglist';
 import { truncateTableValue } from '../../../shared/helpers/truncate';
 import withUser, { UserProps } from '../../../shared/hocs/withUser';
@@ -483,28 +484,15 @@ const AssignmentOverviewAdmin: FunctionComponent<RouteComponentProps & UserProps
 		columnId: AssignmentOverviewTableColumns
 	) => {
 		const { id, created_at, updated_at, deadline_at } = assignment;
+		const editLink = buildLink(APP_PATH.ASSIGNMENT_EDIT_TAB.route, {
+			id,
+			tabId: ASSIGNMENT_CREATE_UPDATE_TABS.CONTENT,
+		});
 
 		switch (columnId) {
-			case 'title':
-				return (
-					<Link to={buildLink(APP_PATH.ASSIGNMENT_DETAIL.route, { id })}>
-						<span>{truncateTableValue(assignment.title)}</span>
-						{!!assignment.relations?.[0].object && (
-							<a
-								href={buildLink(APP_PATH.ASSIGNMENT_DETAIL.route, {
-									id: assignment.relations?.[0].object,
-								})}
-							>
-								<TagList
-									tags={[
-										{ id: assignment.relations?.[0].object, label: 'Kopie' },
-									]}
-									swatches={false}
-								/>
-							</a>
-						)}
-					</Link>
-				);
+			case 'title': {
+				return renderCollectionOrBundleOrAssignmentTitleAndCopyTag(assignment, editLink);
+			}
 
 			case 'author':
 				return truncateTableValue((assignment as any)?.owner?.full_name);
@@ -674,12 +662,7 @@ const AssignmentOverviewAdmin: FunctionComponent<RouteComponentProps & UserProps
 								disabled={true}
 							/>
 						) : (
-							<Link
-								to={buildLink(APP_PATH.ASSIGNMENT_EDIT_TAB.route, {
-									id: assignment.id,
-									tabId: ASSIGNMENT_CREATE_UPDATE_TABS.CONTENT,
-								})}
-							>
+							<Link to={editLink}>
 								<Button
 									type="secondary"
 									icon={IconName.edit}
@@ -772,7 +755,7 @@ const AssignmentOverviewAdmin: FunctionComponent<RouteComponentProps & UserProps
 					isLoading={isLoading}
 					showCheckboxes
 					selectedItemIds={selectedAssignmentIds}
-					onSelectionChanged={setSelectedAssignmentIds as (ids: ReactText[]) => void}
+					onSelectionChanged={setSelectedAssignmentIds as (ids: ReactNode[]) => void}
 					onSelectAll={setAllAssignmentsAsSelected}
 					onSelectBulkAction={handleBulkAction as any}
 					bulkActions={GET_ASSIGNMENT_BULK_ACTIONS(user as Avo.User.User)}

--- a/src/admin/assignments/views/AssignmentsOverviewAdmin.tsx
+++ b/src/admin/assignments/views/AssignmentsOverviewAdmin.tsx
@@ -25,13 +25,13 @@ import {
 	LoadingErrorLoadedComponent,
 	LoadingInfo,
 } from '../../../shared/components';
+import { CollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/components/CollectionOrBundleOrAssignmentTitleAndCopyTag/CollectionOrBundleOrAssignmentTitleAndCopyTag';
 import ConfirmModal from '../../../shared/components/ConfirmModal/ConfirmModal';
 import { EDIT_STATUS_REFETCH_TIME } from '../../../shared/constants';
 import { Lookup_Enum_Relation_Types_Enum } from '../../../shared/generated/graphql-db-types';
 import { buildLink, CustomError, formatDate } from '../../../shared/helpers';
 import { isContentBeingEdited } from '../../../shared/helpers/is-content-being-edited';
 import { groupLomLinks } from '../../../shared/helpers/lom';
-import { renderCollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/helpers/render-collection-or-bundle-or-assignment-title-and-copy-tag';
 import { lomsToTagList } from '../../../shared/helpers/strings-to-taglist';
 import { truncateTableValue } from '../../../shared/helpers/truncate';
 import withUser, { UserProps } from '../../../shared/hocs/withUser';
@@ -491,7 +491,12 @@ const AssignmentOverviewAdmin: FunctionComponent<RouteComponentProps & UserProps
 
 		switch (columnId) {
 			case 'title': {
-				return renderCollectionOrBundleOrAssignmentTitleAndCopyTag(assignment, editLink);
+				return (
+					<CollectionOrBundleOrAssignmentTitleAndCopyTag
+						collOrBundleOrAssignment={assignment}
+						editLink={editLink}
+					/>
+				);
 			}
 
 			case 'author':

--- a/src/admin/collectionsOrBundles/views/CollectionOrBundleActualisationOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionOrBundleActualisationOverview.tsx
@@ -20,8 +20,8 @@ import {
 	LoadingErrorLoadedComponent,
 	LoadingInfo,
 } from '../../../shared/components';
+import { CollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/components/CollectionOrBundleOrAssignmentTitleAndCopyTag/CollectionOrBundleOrAssignmentTitleAndCopyTag';
 import { buildLink, CustomError } from '../../../shared/helpers';
-import { renderCollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/helpers/render-collection-or-bundle-or-assignment-title-and-copy-tag';
 import { useCompaniesWithUsers } from '../../../shared/hooks/useCompanies';
 import { useLomEducationLevels } from '../../../shared/hooks/useLomEducationLevels';
 import { useLomSubjects } from '../../../shared/hooks/useLomSubjects';
@@ -274,9 +274,11 @@ const CollectionOrBundleActualisationOverview: FunctionComponent<
 
 		switch (columnId) {
 			case 'title': {
-				return renderCollectionOrBundleOrAssignmentTitleAndCopyTag(
-					collectionOrBundle,
-					editLink
+				return (
+					<CollectionOrBundleOrAssignmentTitleAndCopyTag
+						collOrBundleOrAssignment={collectionOrBundle}
+						editLink={editLink}
+					/>
 				);
 			}
 

--- a/src/admin/collectionsOrBundles/views/CollectionOrBundleActualisationOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionOrBundleActualisationOverview.tsx
@@ -1,9 +1,8 @@
-import { Button, ButtonToolbar, IconName, TagList } from '@viaa/avo2-components';
+import { Button, ButtonToolbar, IconName } from '@viaa/avo2-components';
 import { type Avo } from '@viaa/avo2-types';
-import { get, truncate } from 'lodash-es';
 import React, {
 	FunctionComponent,
-	ReactText,
+	ReactNode,
 	useCallback,
 	useEffect,
 	useMemo,
@@ -22,6 +21,7 @@ import {
 	LoadingInfo,
 } from '../../../shared/components';
 import { buildLink, CustomError } from '../../../shared/helpers';
+import { renderCollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/helpers/render-collection-or-bundle-or-assignment-title-and-copy-tag';
 import { useCompaniesWithUsers } from '../../../shared/hooks/useCompanies';
 import { useLomEducationLevels } from '../../../shared/hooks/useLomEducationLevels';
 import { useLomSubjects } from '../../../shared/hooks/useLomSubjects';
@@ -74,27 +74,24 @@ const CollectionOrBundleActualisationOverview: FunctionComponent<
 
 	// computed
 
-	const userGroupOptions = useMemo(
-		() => [
+	const userGroupOptions = useMemo(() => {
+		return [
 			{
 				id: NULL_FILTER,
 				label: tText('admin/collections-or-bundles/views/collection-or-bundle___geen-rol'),
-				checked: get(tableState, 'author.user_groups', [] as string[]).includes(
-					NULL_FILTER
-				),
+				checked: ((tableState?.author_user_group || []) as string[]).includes(NULL_FILTER),
 			},
 			...userGroups.map(
 				(option): CheckboxOption => ({
 					id: String(option.id),
 					label: option.label as string,
-					checked: get(tableState, 'author.user_groups', [] as string[]).includes(
+					checked: (tableState?.author_user_group || ([] as string[])).includes(
 						String(option.id)
 					),
 				})
 			),
-		],
-		[tableState, userGroups, tText]
-	);
+		];
+	}, [tableState, userGroups, tText]);
 
 	const collectionLabelOptions = useMemo(
 		() => [
@@ -103,13 +100,13 @@ const CollectionOrBundleActualisationOverview: FunctionComponent<
 				label: tText(
 					'admin/collections-or-bundles/views/collections-or-bundles-overview___geen-label'
 				),
-				checked: get(tableState, 'collection_labels', [] as string[]).includes(NULL_FILTER),
+				checked: ((tableState?.collection_labels || []) as string[]).includes(NULL_FILTER),
 			},
 			...collectionLabels.map(
 				(option): CheckboxOption => ({
 					id: String(option.value),
 					label: option.description,
-					checked: get(tableState, 'collection_labels', [] as string[]).includes(
+					checked: ((tableState?.collection_labels || []) as string[]).includes(
 						String(option.value)
 					),
 				})
@@ -125,13 +122,13 @@ const CollectionOrBundleActualisationOverview: FunctionComponent<
 				label: tText(
 					'admin/collections-or-bundles/views/collection-or-bundle-actualisation-overview___geen-organisatie'
 				),
-				checked: get(tableState, 'organisation', [] as string[]).includes(NULL_FILTER),
+				checked: ((tableState?.organisation || []) as string[]).includes(NULL_FILTER),
 			},
 			...organisations.map(
 				(option): CheckboxOption => ({
 					id: String(option.or_id),
 					label: option.name,
-					checked: get(tableState, 'organisation', [] as string[]).includes(
+					checked: ((tableState?.organisation || []) as string[]).includes(
 						String(option.or_id)
 					),
 				})
@@ -267,34 +264,19 @@ const CollectionOrBundleActualisationOverview: FunctionComponent<
 	};
 
 	const renderTableCell = (
-		rowData: Partial<Avo.Collection.Collection>,
+		collectionOrBundle: Partial<Avo.Collection.Collection>,
 		columnId: CollectionOrBundleActualisationOverviewTableCols
 	) => {
 		const editLink = buildLink(
 			isCollection ? APP_PATH.COLLECTION_EDIT_TAB.route : APP_PATH.BUNDLE_EDIT_TAB.route,
-			{ id: rowData.id, tabId: CollectionCreateUpdateTab.ACTUALISATION }
+			{ id: collectionOrBundle.id, tabId: CollectionCreateUpdateTab.ACTUALISATION }
 		);
 
 		switch (columnId) {
 			case 'title': {
-				const title = truncate(rowData[columnId] || '-', { length: 50 });
-
-				return (
-					<Link to={editLink}>
-						<span>{title}</span>
-						{!!rowData.relations?.[0].object && (
-							<a
-								href={buildLink(APP_PATH.COLLECTION_DETAIL.route, {
-									id: rowData.relations?.[0].object,
-								})}
-							>
-								<TagList
-									tags={[{ id: rowData.relations?.[0].object, label: 'Kopie' }]}
-									swatches={false}
-								/>
-							</a>
-						)}
-					</Link>
+				return renderCollectionOrBundleOrAssignmentTitleAndCopyTag(
+					collectionOrBundle,
+					editLink
 				);
 			}
 
@@ -329,7 +311,11 @@ const CollectionOrBundleActualisationOverview: FunctionComponent<
 				);
 
 			default:
-				return renderCollectionOverviewColumns(rowData, columnId, collectionLabels);
+				return renderCollectionOverviewColumns(
+					collectionOrBundle,
+					columnId,
+					collectionLabels
+				);
 		}
 	};
 
@@ -377,7 +363,7 @@ const CollectionOrBundleActualisationOverview: FunctionComponent<
 					renderNoResults={renderNoResults}
 					rowKey="id"
 					selectedItemIds={selectedCollectionIds}
-					onSelectionChanged={setSelectedCollectionIds as (ids: ReactText[]) => void}
+					onSelectionChanged={setSelectedCollectionIds as (ids: ReactNode[]) => void}
 					onSelectAll={setAllCollectionsAsSelected}
 					isLoading={isLoading}
 				/>

--- a/src/admin/collectionsOrBundles/views/CollectionOrBundleMarcomOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionOrBundleMarcomOverview.tsx
@@ -1,9 +1,8 @@
-import { Button, ButtonToolbar, IconName, TagList } from '@viaa/avo2-components';
+import { Button, ButtonToolbar, IconName } from '@viaa/avo2-components';
 import { type Avo } from '@viaa/avo2-types';
-import { get, truncate } from 'lodash-es';
 import React, {
 	FunctionComponent,
-	ReactText,
+	ReactNode,
 	useCallback,
 	useEffect,
 	useMemo,
@@ -26,6 +25,7 @@ import {
 	LoadingInfo,
 } from '../../../shared/components';
 import { buildLink, CustomError } from '../../../shared/helpers';
+import { renderCollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/helpers/render-collection-or-bundle-or-assignment-title-and-copy-tag';
 import { useCompaniesWithUsers } from '../../../shared/hooks/useCompanies';
 import { useLomEducationLevels } from '../../../shared/hooks/useLomEducationLevels';
 import { useLomSubjects } from '../../../shared/hooks/useLomSubjects';
@@ -75,27 +75,25 @@ const CollectionOrBundleMarcomOverview: FunctionComponent<
 	const [organisations] = useCompaniesWithUsers();
 
 	// computed
-	const userGroupOptions = useMemo(
-		() => [
+
+	const userGroupOptions = useMemo(() => {
+		return [
 			{
 				id: NULL_FILTER,
 				label: tText('admin/collections-or-bundles/views/collection-or-bundle___geen-rol'),
-				checked: get(tableState, 'author.user_groups', [] as string[]).includes(
-					NULL_FILTER
-				),
+				checked: ((tableState?.author_user_group || []) as string[]).includes(NULL_FILTER),
 			},
 			...userGroups.map(
 				(option): CheckboxOption => ({
 					id: String(option.id),
 					label: option.label as string,
-					checked: get(tableState, 'author.user_groups', [] as string[]).includes(
+					checked: (tableState?.author_user_group || ([] as string[])).includes(
 						String(option.id)
 					),
 				})
 			),
-		],
-		[tableState, userGroups, tText]
-	);
+		];
+	}, [tableState, userGroups, tText]);
 
 	const collectionLabelOptions = useMemo(
 		() => [
@@ -104,19 +102,41 @@ const CollectionOrBundleMarcomOverview: FunctionComponent<
 				label: tText(
 					'admin/collections-or-bundles/views/collections-or-bundles-overview___geen-label'
 				),
-				checked: get(tableState, 'collection_labels', [] as string[]).includes(NULL_FILTER),
+				checked: ((tableState?.collection_labels || []) as string[]).includes(NULL_FILTER),
 			},
 			...collectionLabels.map(
 				(option): CheckboxOption => ({
 					id: String(option.value),
 					label: option.description,
-					checked: get(tableState, 'collection_labels', [] as string[]).includes(
+					checked: ((tableState?.collection_labels || []) as string[]).includes(
 						String(option.value)
 					),
 				})
 			),
 		],
 		[collectionLabels, tText, tableState]
+	);
+
+	const organisationOptions = useMemo(
+		() => [
+			{
+				id: NULL_FILTER,
+				label: tText(
+					'admin/collections-or-bundles/views/collection-or-bundle-actualisation-overview___geen-organisatie'
+				),
+				checked: ((tableState?.organisation || []) as string[]).includes(NULL_FILTER),
+			},
+			...organisations.map(
+				(option): CheckboxOption => ({
+					id: String(option.or_id),
+					label: option.name,
+					checked: ((tableState?.organisation || []) as string[]).includes(
+						String(option.or_id)
+					),
+				})
+			),
+		],
+		[organisations, tText, tableState]
 	);
 
 	const channelNameOptions = useMemo(() => {
@@ -139,7 +159,7 @@ const CollectionOrBundleMarcomOverview: FunctionComponent<
 			},
 			...options,
 		];
-	}, [GET_MARCOM_CHANNEL_TYPE_OPTIONS, tableState]);
+	}, [tText, tableState?.marcom_last_communication_channel_name]);
 
 	const channelTypeOptions = useMemo(
 		() => [
@@ -151,29 +171,7 @@ const CollectionOrBundleMarcomOverview: FunctionComponent<
 				),
 			})),
 		],
-		[GET_MARCOM_CHANNEL_TYPE_OPTIONS, tableState]
-	);
-
-	const organisationOptions = useMemo(
-		() => [
-			{
-				id: NULL_FILTER,
-				label: tText(
-					'admin/collections-or-bundles/views/collection-or-bundle-marcom-overview___geen-organisatie'
-				),
-				checked: get(tableState, 'organisation', [] as string[]).includes(NULL_FILTER),
-			},
-			...organisations.map(
-				(option): CheckboxOption => ({
-					id: String(option.or_id),
-					label: option.name,
-					checked: get(tableState, 'organisation', [] as string[]).includes(
-						String(option.or_id)
-					),
-				})
-			),
-		],
-		[organisations, tText, tableState]
+		[tableState]
 	);
 
 	const tableColumns = useMemo(
@@ -305,32 +303,18 @@ const CollectionOrBundleMarcomOverview: FunctionComponent<
 	};
 
 	const renderTableCell = (
-		rowData: Partial<Avo.Collection.Collection>,
+		collectionOrBundle: Partial<Avo.Collection.Collection>,
 		columnId: CollectionOrBundleMarcomOverviewTableCols
 	) => {
 		const editLink = buildLink(
 			isCollection ? APP_PATH.COLLECTION_EDIT_TAB.route : APP_PATH.BUNDLE_EDIT_TAB.route,
-			{ id: rowData.id, tabId: CollectionCreateUpdateTab.MARCOM }
+			{ id: collectionOrBundle.id, tabId: CollectionCreateUpdateTab.MARCOM }
 		);
 		switch (columnId) {
 			case 'title': {
-				const title = truncate((rowData as any)[columnId] || '-', { length: 50 });
-				return (
-					<Link to={editLink}>
-						<span>{title}</span>
-						{!!rowData.relations?.[0].object && (
-							<a
-								href={buildLink(APP_PATH.COLLECTION_DETAIL.route, {
-									id: rowData.relations?.[0].object,
-								})}
-							>
-								<TagList
-									tags={[{ id: rowData.relations?.[0].object, label: 'Kopie' }]}
-									swatches={false}
-								/>
-							</a>
-						)}
-					</Link>
+				return renderCollectionOrBundleOrAssignmentTitleAndCopyTag(
+					collectionOrBundle,
+					editLink
 				);
 			}
 
@@ -365,7 +349,11 @@ const CollectionOrBundleMarcomOverview: FunctionComponent<
 				);
 
 			default:
-				return renderCollectionOverviewColumns(rowData, columnId, collectionLabels);
+				return renderCollectionOverviewColumns(
+					collectionOrBundle,
+					columnId,
+					collectionLabels
+				);
 		}
 	};
 
@@ -413,7 +401,7 @@ const CollectionOrBundleMarcomOverview: FunctionComponent<
 					renderNoResults={renderNoResults}
 					rowKey="id"
 					selectedItemIds={selectedCollectionIds}
-					onSelectionChanged={setSelectedCollectionIds as (ids: ReactText[]) => void}
+					onSelectionChanged={setSelectedCollectionIds as (ids: ReactNode[]) => void}
 					onSelectAll={setAllCollectionsAsSelected}
 					isLoading={isLoading}
 				/>

--- a/src/admin/collectionsOrBundles/views/CollectionOrBundleMarcomOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionOrBundleMarcomOverview.tsx
@@ -24,8 +24,8 @@ import {
 	LoadingErrorLoadedComponent,
 	LoadingInfo,
 } from '../../../shared/components';
+import { CollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/components/CollectionOrBundleOrAssignmentTitleAndCopyTag/CollectionOrBundleOrAssignmentTitleAndCopyTag';
 import { buildLink, CustomError } from '../../../shared/helpers';
-import { renderCollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/helpers/render-collection-or-bundle-or-assignment-title-and-copy-tag';
 import { useCompaniesWithUsers } from '../../../shared/hooks/useCompanies';
 import { useLomEducationLevels } from '../../../shared/hooks/useLomEducationLevels';
 import { useLomSubjects } from '../../../shared/hooks/useLomSubjects';
@@ -312,9 +312,11 @@ const CollectionOrBundleMarcomOverview: FunctionComponent<
 		);
 		switch (columnId) {
 			case 'title': {
-				return renderCollectionOrBundleOrAssignmentTitleAndCopyTag(
-					collectionOrBundle,
-					editLink
+				return (
+					<CollectionOrBundleOrAssignmentTitleAndCopyTag
+						collOrBundleOrAssignment={collectionOrBundle}
+						editLink={editLink}
+					/>
 				);
 			}
 

--- a/src/admin/collectionsOrBundles/views/CollectionOrBundleQualityCheckOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionOrBundleQualityCheckOverview.tsx
@@ -20,8 +20,8 @@ import {
 	LoadingErrorLoadedComponent,
 	LoadingInfo,
 } from '../../../shared/components';
+import { CollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/components/CollectionOrBundleOrAssignmentTitleAndCopyTag/CollectionOrBundleOrAssignmentTitleAndCopyTag';
 import { buildLink, CustomError } from '../../../shared/helpers';
-import { renderCollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/helpers/render-collection-or-bundle-or-assignment-title-and-copy-tag';
 import { useCompaniesWithUsers } from '../../../shared/hooks/useCompanies';
 import { useLomEducationLevels } from '../../../shared/hooks/useLomEducationLevels';
 import { useLomSubjects } from '../../../shared/hooks/useLomSubjects';
@@ -279,9 +279,11 @@ const CollectionOrBundleQualityCheckOverview: FunctionComponent<
 		);
 		switch (columnId) {
 			case 'title': {
-				return renderCollectionOrBundleOrAssignmentTitleAndCopyTag(
-					collectionOrBundle,
-					editLink
+				return (
+					<CollectionOrBundleOrAssignmentTitleAndCopyTag
+						collOrBundleOrAssignment={collectionOrBundle}
+						editLink={editLink}
+					/>
 				);
 			}
 

--- a/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
@@ -24,10 +24,10 @@ import {
 	LoadingErrorLoadedComponent,
 	LoadingInfo,
 } from '../../../shared/components';
+import { CollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/components/CollectionOrBundleOrAssignmentTitleAndCopyTag/CollectionOrBundleOrAssignmentTitleAndCopyTag';
 import { EDIT_STATUS_REFETCH_TIME } from '../../../shared/constants';
 import { buildLink, CustomError, getFullName } from '../../../shared/helpers';
 import { isContentBeingEdited } from '../../../shared/helpers/is-content-being-edited';
-import { renderCollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/helpers/render-collection-or-bundle-or-assignment-title-and-copy-tag';
 import { useCompaniesWithUsers } from '../../../shared/hooks/useCompanies';
 import { useLomEducationLevels } from '../../../shared/hooks/useLomEducationLevels';
 import { useLomSubjects } from '../../../shared/hooks/useLomSubjects';
@@ -529,9 +529,11 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 
 		switch (columnId) {
 			case 'title': {
-				return renderCollectionOrBundleOrAssignmentTitleAndCopyTag(
-					collectionOrBundle,
-					editLink
+				return (
+					<CollectionOrBundleOrAssignmentTitleAndCopyTag
+						collOrBundleOrAssignment={collectionOrBundle}
+						editLink={editLink}
+					/>
 				);
 			}
 

--- a/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
+++ b/src/admin/collectionsOrBundles/views/CollectionsOrBundlesOverview.tsx
@@ -1,9 +1,9 @@
-import { Button, ButtonToolbar, IconName, TagInfo, TagList } from '@viaa/avo2-components';
+import { Button, ButtonToolbar, IconName, TagInfo } from '@viaa/avo2-components';
 import { type Avo } from '@viaa/avo2-types';
-import { compact, get, partition, truncate } from 'lodash-es';
+import { compact, partition } from 'lodash-es';
 import React, {
 	FunctionComponent,
-	ReactText,
+	ReactNode,
 	useCallback,
 	useEffect,
 	useMemo,
@@ -27,6 +27,7 @@ import {
 import { EDIT_STATUS_REFETCH_TIME } from '../../../shared/constants';
 import { buildLink, CustomError, getFullName } from '../../../shared/helpers';
 import { isContentBeingEdited } from '../../../shared/helpers/is-content-being-edited';
+import { renderCollectionOrBundleOrAssignmentTitleAndCopyTag } from '../../../shared/helpers/render-collection-or-bundle-or-assignment-title-and-copy-tag';
 import { useCompaniesWithUsers } from '../../../shared/hooks/useCompanies';
 import { useLomEducationLevels } from '../../../shared/hooks/useLomEducationLevels';
 import { useLomSubjects } from '../../../shared/hooks/useLomSubjects';
@@ -103,29 +104,26 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 	);
 
 	// computed
-	const userGroupOptions = useMemo(
-		() => [
+
+	const userGroupOptions = useMemo(() => {
+		return [
 			{
 				id: NULL_FILTER,
-				label: tText(
-					'admin/collections-or-bundles/views/collections-or-bundles___geen-rol'
-				),
-				checked: get(tableState, 'author.user_groups', [] as string[]).includes(
-					NULL_FILTER
-				),
+				label: tText('admin/collections-or-bundles/views/collection-or-bundle___geen-rol'),
+				checked: ((tableState?.author_user_group || []) as string[]).includes(NULL_FILTER),
 			},
 			...userGroups.map(
 				(option): CheckboxOption => ({
 					id: String(option.id),
 					label: option.label as string,
-					checked: get(tableState, 'author.user_groups', [] as string[]).includes(
+					checked: (tableState?.author_user_group || ([] as string[])).includes(
 						String(option.id)
 					),
 				})
 			),
-		],
-		[tableState, userGroups, tText]
-	);
+		];
+	}, [tableState, userGroups, tText]);
+
 	const collectionLabelOptions = useMemo(
 		() => [
 			{
@@ -133,13 +131,13 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 				label: tText(
 					'admin/collections-or-bundles/views/collections-or-bundles-overview___geen-label'
 				),
-				checked: get(tableState, 'collection_labels', [] as string[]).includes(NULL_FILTER),
+				checked: ((tableState?.collection_labels || []) as string[]).includes(NULL_FILTER),
 			},
 			...collectionLabels.map(
 				(option): CheckboxOption => ({
 					id: String(option.value),
 					label: option.description,
-					checked: get(tableState, 'collection_labels', [] as string[]).includes(
+					checked: ((tableState?.collection_labels || []) as string[]).includes(
 						String(option.value)
 					),
 				})
@@ -153,15 +151,15 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 			{
 				id: NULL_FILTER,
 				label: tText(
-					'admin/collections-or-bundles/views/collections-or-bundles-overview___geen-organisatie'
+					'admin/collections-or-bundles/views/collection-or-bundle-actualisation-overview___geen-organisatie'
 				),
-				checked: get(tableState, 'organisation', [] as string[]).includes(NULL_FILTER),
+				checked: ((tableState?.organisation || []) as string[]).includes(NULL_FILTER),
 			},
 			...organisations.map(
 				(option): CheckboxOption => ({
 					id: String(option.or_id),
 					label: option.name,
-					checked: get(tableState, 'organisation', [] as string[]).includes(
+					checked: ((tableState?.organisation || []) as string[]).includes(
 						String(option.or_id)
 					),
 				})
@@ -518,38 +516,22 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 	};
 
 	const renderTableCell = (
-		collection: Partial<Avo.Collection.Collection>,
+		collectionOrBundle: Partial<Avo.Collection.Collection>,
 		columnId: CollectionsOrBundlesOverviewTableCols
 	) => {
+		const editLink = buildLink(
+			isCollection ? APP_PATH.COLLECTION_EDIT_TAB.route : APP_PATH.BUNDLE_EDIT_TAB.route,
+			{
+				id: collectionOrBundle.id,
+				tabId: ASSIGNMENT_CREATE_UPDATE_TABS.CONTENT,
+			}
+		);
+
 		switch (columnId) {
 			case 'title': {
-				return (
-					<Link
-						to={buildLink(
-							isCollection
-								? APP_PATH.COLLECTION_DETAIL.route
-								: APP_PATH.BUNDLE_DETAIL.route,
-							{ id: collection.id }
-						)}
-					>
-						<span>
-							{truncate((collection as any)[columnId] || '-', { length: 50 })}
-						</span>
-						{!!collection.relations?.[0].object && (
-							<a
-								href={buildLink(APP_PATH.COLLECTION_DETAIL.route, {
-									id: collection.relations?.[0].object,
-								})}
-							>
-								<TagList
-									tags={[
-										{ id: collection.relations?.[0].object, label: 'Kopie' },
-									]}
-									swatches={false}
-								/>
-							</a>
-						)}
-					</Link>
+				return renderCollectionOrBundleOrAssignmentTitleAndCopyTag(
+					collectionOrBundle,
+					editLink
 				);
 			}
 
@@ -558,7 +540,7 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 					return null;
 				}
 				const isCollectionBeingEdited = isContentBeingEdited(
-					editStatuses?.[collection.id as string],
+					editStatuses?.[collectionOrBundle.id as string],
 					user.profile?.id
 				);
 				const viewButtonTitle = isCollection
@@ -587,7 +569,7 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 									? APP_PATH.COLLECTION_DETAIL.route
 									: APP_PATH.BUNDLE_DETAIL.route,
 								{
-									id: collection.id,
+									id: collectionOrBundle.id,
 								}
 							)}
 						>
@@ -608,17 +590,7 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 								disabled={true}
 							/>
 						) : (
-							<Link
-								to={buildLink(
-									isCollection
-										? APP_PATH.COLLECTION_EDIT_TAB.route
-										: APP_PATH.BUNDLE_EDIT_TAB.route,
-									{
-										id: collection.id,
-										tabId: ASSIGNMENT_CREATE_UPDATE_TABS.CONTENT,
-									}
-								)}
-							>
+							<Link to={editLink}>
 								<Button
 									type="secondary"
 									icon={IconName.edit}
@@ -632,7 +604,11 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 			}
 
 			default:
-				return renderCollectionOverviewColumns(collection, columnId, collectionLabels);
+				return renderCollectionOverviewColumns(
+					collectionOrBundle,
+					columnId,
+					collectionLabels
+				);
 		}
 	};
 
@@ -683,7 +659,7 @@ const CollectionsOrBundlesOverview: FunctionComponent<CollectionsOrBundlesOvervi
 					bulkActions={GET_COLLECTION_BULK_ACTIONS()}
 					onSelectBulkAction={handleBulkAction as any}
 					selectedItemIds={selectedCollectionIds}
-					onSelectionChanged={setSelectedCollectionIds as (ids: ReactText[]) => void}
+					onSelectionChanged={setSelectedCollectionIds as (ids: ReactNode[]) => void}
 					onSelectAll={setAllCollectionsAsSelected}
 					isLoading={isLoading}
 				/>

--- a/src/shared/components/CollectionOrBundleOrAssignmentTitleAndCopyTag/CollectionOrBundleOrAssignmentTitleAndCopyTag.tsx
+++ b/src/shared/components/CollectionOrBundleOrAssignmentTitleAndCopyTag/CollectionOrBundleOrAssignmentTitleAndCopyTag.tsx
@@ -1,19 +1,22 @@
 import { TagList } from '@viaa/avo2-components';
 import type { Avo } from '@viaa/avo2-types';
 import { truncate } from 'lodash-es';
-import React from 'react';
+import React, { FC } from 'react';
 import { Link } from 'react-router-dom';
 
-import { APP_PATH } from '../../constants';
+import { APP_PATH } from '../../../constants';
+import { buildLink } from '../../helpers';
 
-import { buildLink } from './link';
-
-export function renderCollectionOrBundleOrAssignmentTitleAndCopyTag(
+interface CollectionOrBundleOrAssignmentTitleAndCopyTagProps {
 	collOrBundleOrAssignment:
 		| Partial<Avo.Collection.Collection>
-		| Partial<Avo.Assignment.Assignment>,
-	editLink: string
-) {
+		| Partial<Avo.Assignment.Assignment>;
+	editLink: string;
+}
+
+export const CollectionOrBundleOrAssignmentTitleAndCopyTag: FC<
+	CollectionOrBundleOrAssignmentTitleAndCopyTagProps
+> = ({ collOrBundleOrAssignment, editLink }) => {
 	const title = truncate((collOrBundleOrAssignment as any).title || '-', { length: 50 });
 	return (
 		<>
@@ -36,4 +39,4 @@ export function renderCollectionOrBundleOrAssignmentTitleAndCopyTag(
 			)}
 		</>
 	);
-}
+};

--- a/src/shared/helpers/render-collection-or-bundle-or-assignment-title-and-copy-tag.tsx
+++ b/src/shared/helpers/render-collection-or-bundle-or-assignment-title-and-copy-tag.tsx
@@ -1,0 +1,39 @@
+import { TagList } from '@viaa/avo2-components';
+import type { Avo } from '@viaa/avo2-types';
+import { truncate } from 'lodash-es';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { APP_PATH } from '../../constants';
+
+import { buildLink } from './link';
+
+export function renderCollectionOrBundleOrAssignmentTitleAndCopyTag(
+	collOrBundleOrAssignment:
+		| Partial<Avo.Collection.Collection>
+		| Partial<Avo.Assignment.Assignment>,
+	editLink: string
+) {
+	const title = truncate((collOrBundleOrAssignment as any).title || '-', { length: 50 });
+	return (
+		<>
+			<Link to={editLink}>
+				<span>{title}</span>
+			</Link>{' '}
+			{!!collOrBundleOrAssignment.relations?.[0].object && (
+				<Link
+					to={buildLink(APP_PATH.COLLECTION_DETAIL.route, {
+						id: collOrBundleOrAssignment.relations?.[0].object,
+					})}
+				>
+					<TagList
+						tags={[
+							{ id: collOrBundleOrAssignment.relations?.[0].object, label: 'Kopie' },
+						]}
+						swatches={false}
+					/>
+				</Link>
+			)}
+		</>
+	);
+}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3132

* make one render function for rendering titles and kopie label
* unnest the link for the title from the link of the copy label
* use function on pages
    * assignment overview
    * collection/bundle overview
    * collection/bundle actualisation overview
    * collection/bundle quality overview
    * collection/bundle communication overview
* replace usage of lodash get function with elvis operator ?.
* replace ReactText with ReactNode
* fix error in author user group filter property: tableState.author.user_groups => tableState.author_user_group

![image](https://github.com/viaacode/avo2-client/assets/1710840/da70ee40-0180-44a3-9de7-9b49d45f4c03)
