### PR TITLE
Bugfix/avo 3271 initial search results

### DIFF
--- a/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponseSearchTab.tsx
+++ b/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponseSearchTab.tsx
@@ -97,11 +97,15 @@ const AssignmentResponseSearchTab: FunctionComponent<
 				.map(String)
 				.includes(String(user?.profile?.userGroupIds[0]))
 		) {
-			// Mutate to avoid render loop
-			filterState.filters = {
-				...filterState.filters,
-				educationDegree: ElementaryEducationDegrees,
-			};
+			if (filterState.filters?.educationDegree !== ElementaryEducationDegrees) {
+				handleNewFilterState({
+					...filterState,
+					filters: {
+						...filterState.filters,
+						educationDegree: ElementaryEducationDegrees,
+					},
+				});
+			}
 		}
 	}, [assignment, filterState]);
 

--- a/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponseSearchTab.tsx
+++ b/src/assignment/views/AssignmentResponseEdit/tabs/AssignmentResponseSearchTab.tsx
@@ -98,7 +98,7 @@ const AssignmentResponseSearchTab: FunctionComponent<
 				.includes(String(user?.profile?.userGroupIds[0]))
 		) {
 			if (filterState.filters?.educationDegree !== ElementaryEducationDegrees) {
-				handleNewFilterState({
+				setFilterState({
 					...filterState,
 					filters: {
 						...filterState.filters,

--- a/src/search/components/SearchFiltersAndResults.tsx
+++ b/src/search/components/SearchFiltersAndResults.tsx
@@ -324,19 +324,19 @@ const SearchFiltersAndResults: FunctionComponent<SearchFiltersAndResultsProps> =
 	};
 
 	const deleteAllFilters = () => {
-		const clone = cloneDeep(filterState);
+		const copiedFilterState = cloneDeep(filterState);
 
 		// Only remove filters that are user-editable
-		for (const key in clone) {
-			if (Object.prototype.hasOwnProperty.call(clone, key)) {
+		for (const key in copiedFilterState) {
+			if (Object.prototype.hasOwnProperty.call(copiedFilterState, key)) {
 				if (enabledFilters?.map(String).includes(key)) {
-					delete clone[key as keyof typeof clone];
+					delete copiedFilterState[key as keyof typeof copiedFilterState];
 				}
 			}
 		}
 
 		setSearchTerms('');
-		setFilterState(clone, urlUpdateType);
+		setFilterState(copiedFilterState, urlUpdateType);
 	};
 
 	const handleBookmarkToggle = async (uuid: string, active: boolean) => {

--- a/src/search/components/SearchFiltersAndResults.tsx
+++ b/src/search/components/SearchFiltersAndResults.tsx
@@ -324,8 +324,19 @@ const SearchFiltersAndResults: FunctionComponent<SearchFiltersAndResultsProps> =
 	};
 
 	const deleteAllFilters = () => {
+		const clone = cloneDeep(filterState);
+
+		// Only remove filters that are user-editable
+		for (const key in clone) {
+			if (Object.prototype.hasOwnProperty.call(clone, key)) {
+				if (enabledFilters?.map(String).includes(key)) {
+					delete clone[key as keyof typeof clone];
+				}
+			}
+		}
+
 		setSearchTerms('');
-		setFilterState({}, urlUpdateType);
+		setFilterState(clone, urlUpdateType);
 	};
 
 	const handleBookmarkToggle = async (uuid: string, active: boolean) => {

--- a/src/search/store/actions.ts
+++ b/src/search/store/actions.ts
@@ -7,6 +7,7 @@ import { fetchSearchResults } from '../search.service';
 
 import {
 	SearchActionTypes,
+	type SetSearchResultsControllerAction,
 	type SetSearchResultsErrorAction,
 	type SetSearchResultsLoadingAction,
 	type SetSearchResultsSuccessAction,
@@ -24,7 +25,7 @@ const getSearchResults = (
 		dispatch(setSearchResultsLoading());
 
 		try {
-			const data = await fetchSearchResults(
+			const [request, controller] = fetchSearchResults(
 				orderProperty,
 				orderDirection,
 				from,
@@ -32,6 +33,10 @@ const getSearchResults = (
 				filters,
 				filterOptionSearch
 			);
+
+			dispatch(setSearchResultsControllerAction(controller));
+
+			const data = await request;
 
 			if ((data as any)?.statusCode) {
 				console.error(
@@ -84,6 +89,13 @@ const setSearchResultsError = (): SetSearchResultsErrorAction => ({
 const setSearchResultsLoading = (): SetSearchResultsLoadingAction => ({
 	type: SearchActionTypes.SET_RESULTS_LOADING,
 	loading: true,
+});
+
+const setSearchResultsControllerAction = (
+	controller: AbortController
+): SetSearchResultsControllerAction => ({
+	type: SearchActionTypes.SET_RESULTS_CONTROLLER,
+	controller,
 });
 
 export {

--- a/src/search/store/initial-state.ts
+++ b/src/search/store/initial-state.ts
@@ -4,6 +4,7 @@ const initialState: SearchState = Object.freeze({
 	data: null,
 	loading: false,
 	error: false,
+	controller: null,
 });
 
 export default initialState;

--- a/src/search/store/reducer.ts
+++ b/src/search/store/reducer.ts
@@ -2,6 +2,7 @@ import { createReducer } from './../../shared/helpers';
 import initialState from './initial-state';
 import {
 	SearchActionTypes,
+	type SetSearchResultsControllerAction,
 	type SetSearchResultsErrorAction,
 	type SetSearchResultsLoadingAction,
 	type SetSearchResultsSuccessAction,
@@ -26,6 +27,20 @@ const searchReducer = createReducer(initialState, {
 		loading: false,
 		error: action.error,
 	}),
+	[SearchActionTypes.SET_RESULTS_CONTROLLER]: (
+		state,
+		action: SetSearchResultsControllerAction
+	) => {
+		// Cancel any previous requests
+		if (state.controller && !state.controller.signal.aborted) {
+			state.controller.abort();
+		}
+
+		return {
+			...state,
+			controller: action.controller,
+		};
+	},
 });
 
 export default searchReducer;

--- a/src/search/store/types.ts
+++ b/src/search/store/types.ts
@@ -5,6 +5,7 @@ export enum SearchActionTypes {
 	SET_RESULTS_LOADING = '@@search/SET_RESULTS_LOADING',
 	SET_RESULTS_SUCCESS = '@@search/SET_RESULTS_SUCCESS',
 	SET_RESULTS_ERROR = '@@search/SET_RESULTS_ERROR',
+	SET_RESULTS_CONTROLLER = '@@search/SET_RESULTS_CONTROLLER',
 }
 
 export interface SetSearchResultsSuccessAction extends Action {
@@ -19,8 +20,13 @@ export interface SetSearchResultsErrorAction extends Action {
 	error: boolean;
 }
 
+export interface SetSearchResultsControllerAction extends Action {
+	controller: AbortController;
+}
+
 export interface SearchState {
 	readonly data: Avo.Search.Search | null;
 	readonly loading: boolean;
 	readonly error: boolean;
+	readonly controller: AbortController | null;
 }


### PR DESCRIPTION
feat(AVO-3271): avoid resetting values of disabled filters
fix(AVO-3271): apply filters on initial load
fix(AVO-3271): cancel previous requests and avoid race conditions
fix(AVO-3271): avoid logging event on initial load

Based on https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal#aborting_a_fetch_operation_using_an_explicit_signal