### PR TITLE
feat(AVO-3309): add logging events for un-,subscribe to newsletters

### DIFF
--- a/src/settings/components/CompleteProfileStep.tsx
+++ b/src/settings/components/CompleteProfileStep.tsx
@@ -35,8 +35,10 @@ import withUser, { type UserProps } from '../../shared/hocs/withUser';
 import useTranslation from '../../shared/hooks/useTranslation';
 import {
 	CampaignMonitorService,
+	NewsletterPreferenceKey,
 	type NewsletterPreferences,
 } from '../../shared/services/campaign-monitor-service';
+import { trackEvents } from '../../shared/services/event-logging-service';
 import { ToastService } from '../../shared/services/toast-service';
 import store from '../../store';
 import { SettingsService } from '../settings.service';
@@ -144,6 +146,20 @@ const CompleteProfileStep: FunctionComponent<
 			}
 			try {
 				await CampaignMonitorService.updateNewsletterPreferences(preferences);
+				if (subscribeToNewsletter) {
+					trackEvents(
+						{
+							action: 'add',
+							object: commonUser.profileId,
+							object_type: 'profile',
+							resource: {
+								id: NewsletterPreferenceKey.newsletter,
+								type: 'campaign-monitor-list',
+							},
+						},
+						commonUser
+					);
+				}
 			} catch (err) {
 				console.error(
 					new CustomError('Failed to updateNewsletterPreferences', err, {

--- a/src/settings/components/Email/Email.tsx
+++ b/src/settings/components/Email/Email.tsx
@@ -84,6 +84,13 @@ const Email: FunctionComponent<UserProps> = ({ commonUser }) => {
 				preferenceCenterKey as string | undefined
 			);
 
+			// No await for logging events
+			CampaignMonitorService.triggerEventsForNewsletterPreferences(
+				initialNewsletterPreferences,
+				currentNewsletterPreferences,
+				commonUser
+			);
+
 			setInitialNewsletterPreferences({
 				...initialNewsletterPreferences,
 				...currentNewsletterPreferences,

--- a/src/settings/components/Email/Email.tsx
+++ b/src/settings/components/Email/Email.tsx
@@ -88,7 +88,8 @@ const Email: FunctionComponent<UserProps> = ({ commonUser }) => {
 			CampaignMonitorService.triggerEventsForNewsletterPreferences(
 				initialNewsletterPreferences,
 				currentNewsletterPreferences,
-				commonUser
+				commonUser,
+				preferenceCenterKey
 			);
 
 			setInitialNewsletterPreferences({

--- a/src/shared/services/campaign-monitor-service.ts
+++ b/src/shared/services/campaign-monitor-service.ts
@@ -1,16 +1,22 @@
 import { fetchWithLogoutJson } from '@meemoo/admin-core-ui';
+import { type Avo } from '@viaa/avo2-types';
+import { compact } from 'lodash-es';
 import { stringifyUrl } from 'query-string';
 
 import { CustomError, getEnv } from '../helpers';
 
+import { type MinimalClientEvent, trackEvents } from './event-logging-service';
+
 export type EmailTemplateType = 'item' | 'collection' | 'bundle';
 
-// TODO replace withAvo.Newsletter.Preferences when typings v2.49.5 is released together with proxy v1.26.0 (rondje 3)
-export interface NewsletterPreferences {
-	newsletter: boolean;
-	workshop: boolean;
-	ambassador: boolean;
+export enum NewsletterPreferenceKey {
+	newsletter = 'newsletter',
+	workshop = 'workshop',
+	ambassador = 'ambassador',
 }
+
+// TODO replace withAvo.Newsletter.Preferences when typings v2.49.5 is released together with proxy v1.26.0 (rondje 3)
+export type NewsletterPreferences = Record<NewsletterPreferenceKey, boolean>;
 
 export class CampaignMonitorService {
 	public static async fetchNewsletterPreferences(
@@ -44,6 +50,53 @@ export class CampaignMonitorService {
 				preferences,
 			});
 		}
+	}
+
+	/**
+	 * Add an event for each subscribe or unsubscribe from a campaign monitor list to the events logging database
+	 * @param oldNewsletterPreferences
+	 * @param newNewsletterPreferences
+	 * @param commonUser
+	 */
+	public static async triggerEventsForNewsletterPreferences(
+		oldNewsletterPreferences: Partial<NewsletterPreferences>,
+		newNewsletterPreferences: Partial<NewsletterPreferences>,
+		commonUser: Avo.User.CommonUser | undefined
+	) {
+		if (!commonUser) {
+			return;
+		}
+		const events: MinimalClientEvent[] = compact(
+			Object.values(NewsletterPreferenceKey).map((key): MinimalClientEvent | null => {
+				if (oldNewsletterPreferences[key] !== newNewsletterPreferences[key]) {
+					if (newNewsletterPreferences[key] === true) {
+						// subscribed
+						return {
+							action: 'add',
+							object: commonUser.profileId,
+							object_type: 'profile',
+							resource: {
+								id: key,
+								type: 'campaign-monitor-list',
+							},
+						};
+					} else if (newNewsletterPreferences[key] === false) {
+						// unsubscribed
+						return {
+							action: 'remove',
+							object: commonUser.profileId,
+							object_type: 'profile',
+							resource: {
+								id: key,
+								type: 'campaign-monitor-list',
+							},
+						};
+					}
+				}
+				return null;
+			})
+		);
+		await trackEvents(events, commonUser);
 	}
 
 	public static async shareThroughEmail(

--- a/src/shared/services/campaign-monitor-service.ts
+++ b/src/shared/services/campaign-monitor-service.ts
@@ -57,11 +57,13 @@ export class CampaignMonitorService {
 	 * @param oldNewsletterPreferences
 	 * @param newNewsletterPreferences
 	 * @param commonUser
+	 * @param preferenceCenterKey
 	 */
 	public static async triggerEventsForNewsletterPreferences(
 		oldNewsletterPreferences: Partial<NewsletterPreferences>,
 		newNewsletterPreferences: Partial<NewsletterPreferences>,
-		commonUser: Avo.User.CommonUser | undefined
+		commonUser: Avo.User.CommonUser | undefined,
+		preferenceCenterKey: string
 	) {
 		if (!commonUser) {
 			return;
@@ -78,6 +80,7 @@ export class CampaignMonitorService {
 							resource: {
 								id: key,
 								type: 'campaign-monitor-list',
+								preferenceCenterKey,
 							},
 						};
 					} else if (newNewsletterPreferences[key] === false) {
@@ -89,6 +92,7 @@ export class CampaignMonitorService {
 							resource: {
 								id: key,
 								type: 'campaign-monitor-list',
+								preferenceCenterKey,
 							},
 						};
 					}

--- a/src/shared/services/event-logging-service.ts
+++ b/src/shared/services/event-logging-service.ts
@@ -3,7 +3,7 @@ import { type Avo } from '@viaa/avo2-types';
 
 import { getEnv } from '../helpers';
 
-interface MinimalClientEvent {
+export interface MinimalClientEvent {
 	action: Avo.EventLogging.Action;
 	object: string; // entity being modified
 	object_type: Avo.EventLogging.ObjectType;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3309

keeps track of subscribe and unsubscribe actions during the registration fase and in the accounts menu

registration process
![image](https://github.com/viaacode/avo2-client/assets/1710840/8e36a6cc-acec-4c28-a26e-fb8fdc84f59b)
![image](https://github.com/viaacode/avo2-client/assets/1710840/172fad94-d5c7-4aea-9904-34e2eef62d86)

account email preferences:
![image](https://github.com/viaacode/avo2-client/assets/1710840/49bca4cc-677b-4e38-a1ee-c7969ab12dbf)
![image](https://github.com/viaacode/avo2-client/assets/1710840/2e4ee10b-f2fc-447a-a05d-36363c655997)
