### PR TITLE
fix(AVO-3336): remove the hash from the audio still asset url

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,13 @@ import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 import svgrPlugin from 'vite-plugin-svgr';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 
+const ASSETS_WITHOUT_A_HASH = [
+	// Avoid hashes in the audio still path, since it gets saved in the database
+	// And we don't want it to update the hash everytime the svg file changes
+	// https://meemoo.atlassian.net/browse/AVO-3336
+	'audio-still.svg',
+];
+
 export default defineConfig(() => {
 	return {
 		build: {
@@ -14,6 +21,13 @@ export default defineConfig(() => {
 			sourcemap: true,
 			rollupOptions: {
 				plugins: [sourcemaps()],
+				output: {
+					assetFileNames: function (file) {
+						return ASSETS_WITHOUT_A_HASH.includes(file.name)
+							? `assets/[name].[ext]`
+							: `assets/[name]-[hash].[ext]`;
+					},
+				},
 			},
 		},
 		server: {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3336

requires hasura PR: https://github.com/viaacode/hasura-graphql/pull/130

before:
![image](https://github.com/viaacode/avo2-client/assets/1710840/1234b687-aa36-47e2-9487-7caa559e285d)


after:
![image](https://github.com/viaacode/avo2-client/assets/1710840/bed5abf5-0306-4b9c-a606-49b7da14800b)

