### PR TITLE
AVO-3725: avoid rerendering the embed app when the user is already logged in

### DIFF
--- a/src/embed/hooks/useGetLoginStateForEmbed.ts
+++ b/src/embed/hooks/useGetLoginStateForEmbed.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { type Avo } from '@viaa/avo2-types';
 
+import { LoginMessage } from '../../authentication/authentication.types';
 import { setLoginSuccess } from '../../authentication/store/actions';
 import { EmbedCodeService } from '../../embed-code/embed-code-service';
 import { QUERY_KEYS } from '../../shared/constants/query-keys';
@@ -16,7 +17,7 @@ export const useGetLoginStateForEmbed = () => {
 			try {
 				const loginState = (store.getState() as unknown as AppState)?.loginState.data;
 
-				if (loginState?.message === 'LOGGED_IN') {
+				if (loginState?.message === LoginMessage.LOGGED_IN) {
 					return loginState;
 				}
 

--- a/src/embed/hooks/useGetLoginStateForEmbed.ts
+++ b/src/embed/hooks/useGetLoginStateForEmbed.ts
@@ -6,7 +6,7 @@ import { EmbedCodeService } from '../../embed-code/embed-code-service';
 import { QUERY_KEYS } from '../../shared/constants/query-keys';
 import { CustomError } from '../../shared/helpers/custom-error';
 import { getEnv } from '../../shared/helpers/env';
-import store from '../../store';
+import store, { type AppState } from '../../store';
 import { LTI_JWT_TOKEN_HEADER } from '../embed.types';
 
 export const useGetLoginStateForEmbed = () => {
@@ -14,6 +14,12 @@ export const useGetLoginStateForEmbed = () => {
 		[QUERY_KEYS.GET_LOGIN_STATE_EMBED],
 		async () => {
 			try {
+				const loginState = (store.getState() as unknown as AppState)?.loginState.data;
+
+				if (loginState?.message === 'LOGGED_IN') {
+					return loginState;
+				}
+
 				const response = await fetch(`${getEnv('PROXY_URL')}/auth/check-login`, {
 					method: 'GET',
 					credentials: 'include',


### PR DESCRIPTION
Every time the user was focussing the iframe, the app was checking the login state, triggering a re-render because the loginstate changed although nothing changed.